### PR TITLE
[RFC] Add support for custom s3 endpoint url

### DIFF
--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -50,7 +50,7 @@ pub struct S3Cache {
 
 impl S3Cache {
     /// Create a new `S3Cache` storing data in `bucket`.
-    pub fn new(bucket: &str) -> io::Result<S3Cache> {
+    pub fn new(bucket: &str, endpoint: &str) -> io::Result<S3Cache> {
         let home = try!(env::home_dir().ok_or(Error::new(ErrorKind::Other, "Couldn't find home directory")));
         let profile_providers = vec![
             ProfileProvider::with_configuration(home.join(".aws").join("credentials"), "default"),
@@ -61,7 +61,7 @@ impl S3Cache {
             ];
         let provider = AutoRefreshingProviderSync::with_mutex(ChainProvider::with_profile_providers(profile_providers)).ok().map(Arc::new);
         //TODO: configurable SSL
-        let bucket = Arc::new(Bucket::new(bucket, Ssl::No));
+        let bucket = Arc::new(Bucket::new(bucket, endpoint, Ssl::No));
         Ok(S3Cache {
             bucket: bucket,
             provider: provider,

--- a/src/simples3/s3.rs
+++ b/src/simples3/s3.rs
@@ -26,17 +26,13 @@ pub enum Ssl {
     No,
 }
 
-fn base_url(bucket_name: &str, ssl: Ssl, region: Option<&str>) -> String {
-    format!("{}://{}.s3{}.amazonaws.com/",
+fn base_url(endpoint: &str, ssl: Ssl) -> String {
+    format!("{}://{}/",
             match ssl {
                 Ssl::Yes => "https",
                 Ssl::No => "http",
             },
-            bucket_name,
-            match region {
-                Some(ref r) => format!("-{}", r),
-                None => String::new(),
-            })
+            endpoint)
 }
 
 fn hmac<D: Digest>(d: D, key: &[u8], data: &[u8]) -> Vec<u8> {
@@ -71,8 +67,8 @@ pub enum S3Error {
 }
 
 impl Bucket {
-    pub fn new(name: &str, ssl: Ssl) -> Bucket {
-        let base_url = base_url(&name, ssl, None);
+    pub fn new(name: &str, endpoint: &str, ssl: Ssl) -> Bucket {
+        let base_url = base_url(&endpoint, ssl);
         Bucket {
             name: name.to_owned(),
             base_url: base_url,


### PR DESCRIPTION
Specify a new endpoint with `SCCACHE_ENDPOINT`
such as Minio https://github.com/minio/minio.

If not defaults to 's3.amazonaws.com'. Current
code for some reason was not working with custom
regions. Introduced a new ENV called `SCCACHE_REGION`
to handle cross region s3 URLs.