### PR TITLE
Simplify loop in hash_key().

### DIFF
--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -240,12 +240,11 @@ pub fn hash_key(compiler: &Compiler, args: &[String], preprocessor_output: &[u8]
     //TODO: drop the compiler filename from the hash
     m.update(compiler.executable.as_bytes());
     m.update(CACHE_VERSION);
-    let last = args.len() - 1;
     for (i, arg) in args.iter().enumerate() {
-        m.update(arg.as_bytes());
-        if i < last {
+        if i != 0 {
             m.update(&b" "[..]);
         }
+        m.update(arg.as_bytes());
     }
     //TODO: should propogate these over from the client.
     // https://github.com/glandium/sccache/issues/5


### PR DESCRIPTION
This also avoids an underflow if args is empty.