### PR TITLE
Support sccache being copied/hardlinked to a different name

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -46,7 +46,7 @@ pub enum Command {
 
 /// Get the `App` used for argument parsing.
 fn get_app<'a, 'b>() -> App<'a, 'b> {
-    App::new("sccache")
+    App::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
         .setting(AppSettings::TrailingVarArg)
         .args_from_usage(


### PR DESCRIPTION
Resolves #44.

There's a bunch of unwrap() in there, but they should be "safe", as in, as far as reading the doc goes, they shouldn't ever be panicking in the code paths they are used under. (For example, exe.file_name().unwrap() shouldn't panic considering env::current_exe succeeded (actually, it could panic if the executable was removed since the process started, but panicking in that case doesn't sound too bad)).