### PR TITLE
Add a Redis cache variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
  "lru-disk-cache 0.1.0",
  "mio-named-pipes 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redis 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -663,6 +664,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1239,7 @@ dependencies = [
 "checksum pulldown-cmark 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8361e81576d2e02643b04950e487ec172b687180da65c731c03cf336784e6c07"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
+"checksum redis 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02a92e223490cc63d9230c4cdf132a48ce154ab1e063558e3841e219c2ea3f91"
 "checksum regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)" = "56b7ee9f764ecf412c6e2fff779bca4b22980517ae335a21aeaf4e32625a5df2"
 "checksum regex-syntax 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "31040aad7470ad9d8c46302dcffba337bb4289ca5da2e3cd6e37b64109a85199"
 "checksum retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29460f6011a25fc70b22010e796bd98330baccaa0005cba6f90b858a510dec0d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/mozilla/sccache/"
 app_dirs = "1.1.1"
 bincode = { git = 'https://github.com/TyOverby/bincode' }
 byteorder = "1.0"
-chrono = "0.2.25"
+chrono = { version = "0.2.25", optional = true }
 clap = "2.3.0"
 env_logger = "0.3.3"
 error-chain = { version = "0.7.2", default-features = false }
@@ -19,21 +19,21 @@ fern = "0.3.5"
 filetime = "0.1"
 futures = "0.1.11"
 futures-cpupool = "0.1"
-hyper = { git = "https://github.com/hyperium/hyper" }
-hyper-tls = { git = "https://github.com/hyperium/hyper-tls" }
+hyper = { git = "https://github.com/hyperium/hyper", optional = true }
+hyper-tls = { git = "https://github.com/hyperium/hyper-tls", optional = true }
 libc = "0.2.10"
 local-encoding = "0.2.0"
 log = "0.3.6"
 lru-disk-cache = { path = "lru-disk-cache" }
 number_prefix = "0.2.5"
-redis = { version = "0.8.0" }
+redis = { version = "0.8.0", optional = true }
 regex = "0.1.65"
 retry = "0.4.0"
-rust-crypto = "0.2.36"
+rust-crypto = { version = "0.2.36", optional = true }
 rustc-serialize = "0.3"
 serde = "0.9"
 serde_derive = "0.9"
-serde_json = "0.9.0"
+serde_json = { version = "0.9.0", optional = true }
 sha1 = "0.2.0"
 tempdir = "0.3.4"
 time = "0.1.35"
@@ -59,6 +59,9 @@ mio-named-pipes = "0.1"
 
 [features]
 default = []
+all = ["redis", "s3"]
+s3 = ["chrono", "hyper", "hyper-tls", "rust-crypto", "serde_json", "simple-s3"]
+simple-s3 = []
 # Enable features that require unstable features of Nightly Rust.
 unstable = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ local-encoding = "0.2.0"
 log = "0.3.6"
 lru-disk-cache = { path = "lru-disk-cache" }
 number_prefix = "0.2.5"
+redis = { version = "0.8.0" }
 regex = "0.1.65"
 retry = "0.4.0"
 rust-crypto = "0.2.36"

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Requirements
 
 sccache is a [Rust](https://www.rust-lang.org/) program. Building it requires `cargo` (and thus `rustc`). sccache currently requires **Rust 1.16**.
 
-We recommend you install Rust via [Rustup](https://rustup.rs/). The generated binaries can be built so that they are very portable, see [scripts/build-release.sh](scripts/build-release.sh).
+We recommend you install Rust via [Rustup](https://rustup.rs/). The generated binaries can be built so that they are very portable, see [scripts/build-release.sh](scripts/build-release.sh). By default `sccache` supports a local disk cache. To build `sccache` with support for `S3` and/or `Redis` cache backends, add `--features=all` or select a specific feature by passing `s3` and/or `redis`. Refer the [Cargo Documentation](http://doc.crates.io/manifest.html#the-features-section) for details.
 
 ## Build
 
-> $ cargo build [--release]
+> $ cargo build [--features=all|redis|s3] [--release]
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ sccache defaults to using local disk storage. You can set the `SCCACHE_DIR` envi
 
 If you want to use S3 storage for the sccache cache, you need to set the `SCCACHE_BUCKET` environment variable to the name of the S3 bucket to use.
 
-The environment variables are only taken into account when the server starts, so only on the first run.
+Set `SCCACHE_REDIS` to a [Redis](https://redis.io/) url in format `redis://[:<passwd>@]<hostname>[:port][/<db>]` to store the cache in a Redis instance.
+
+*Important:* The environment variables are only taken into account when the server starts, so only on the first run.
 
 Debugging
 ---------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,15 @@ environment:
   # Stable 64-bit MSVC
     - channel: stable
       target: x86_64-pc-windows-msvc
+      FEATURES: --features=all
   # Beta 64-bit MSVC
     - channel: beta
       target: x86_64-pc-windows-msvc
+      FEATURES: --features=all
   # Nightly 64-bit MSVC
     - channel: nightly
       target: x86_64-pc-windows-msvc
-      FEATURES: --features=unstable
+      FEATURES: --features="all unstable"
       CARGO_TEST_EXTRA: --all
 
 ### GNU Toolchains ###

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -17,14 +17,15 @@ case $system in
     MINGW*|MSYS_NT*)
 	system=Windows
         rm -rf target/release
-        rustup run nightly cargo build --release --target=x86_64-pc-windows-msvc --features=unstable && rustup run nightly cargo test --release
+        rustup run nightly cargo build --release --target=x86_64-pc-windows-msvc --features="all unstable" && rustup run nightly cargo test --release
         cp target/release/sccache.exe "$stagedir"
         compress=bz2
         ;;
     Linux)
         # Build using rust-musl-builder
         rm -rf target/x86_64-unknown-linux-musl/release
-        docker run --rm -it -v "$(pwd)":/home/rust/src -v ~/.cargo/git:/home/rust/.cargo/git -v ~/.cargo/registry:/home/rust/.cargo/registry luser/rust-musl-builder sh -c "cargo build --release && cargo test --release"
+        docker run --rm -it -v "$(pwd)":/home/rust/src -v ~/.cargo/git:/home/rust/.cargo/git -v
+        ~/.cargo/registry:/home/rust/.cargo/registry luser/rust-musl-builder sh -c "cargo build --release --features=all && cargo test --features=all --release"
         cp target/x86_64-unknown-linux-musl/release/sccache "$stagedir"
         strip "$stagedir/sccache"
         compress=xz

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod cache;
 pub mod disk;
+pub mod redis;
 pub mod s3;
 
 pub use cache::cache::*;

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -14,7 +14,9 @@
 
 pub mod cache;
 pub mod disk;
+#[cfg(feature = "redis")]
 pub mod redis;
+#[cfg(feature = "s3")]
 pub mod s3;
 
 pub use cache::cache::*;

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -1,0 +1,133 @@
+// Copyright 2016 Mozilla Foundation
+// Copyright 2016 Felix Obenhuber <felix@obenhuber.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cache::{
+    Cache,
+    CacheRead,
+    CacheWrite,
+    Storage,
+};
+use errors::*;
+use futures::Future;
+use futures_cpupool::CpuPool;
+use redis::{
+    cmd,
+    Client,
+    Commands,
+    Connection,
+    InfoDict,
+};
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::time::{
+    Duration,
+    Instant,
+};
+
+/// A cache that stores entries in a Redis.
+#[derive(Clone)]
+pub struct RedisCache {
+    url: String,
+    client: Client,
+    pool: CpuPool,
+}
+
+impl RedisCache {
+    /// Create a new `RedisCache`.
+    pub fn new(url: &str, pool: &CpuPool) -> Result<RedisCache> {
+        Ok(RedisCache {
+            url: url.to_owned(),
+            client: Client::open(url)?,
+            pool: pool.clone(),
+        })
+    }
+
+    /// Returns a connection with configured read and write timeouts.
+    fn connect(&self) -> Result<Connection> {
+        self.client.get_connection()
+            .map_err(|e| e.into())
+            .and_then(|c| {
+                c.set_read_timeout(Some(Duration::from_millis(10_000)))?;
+                c.set_write_timeout(Some(Duration::from_millis(10_000)))?;
+                Ok(c)
+            })
+    }
+}
+
+impl Storage for RedisCache {
+    /// Open a connection and query for a key.
+    fn get(&self, key: &str) -> SFuture<Cache> {
+        let key = key.to_owned();
+        let me = self.clone();
+        self.pool.spawn_fn(move || {
+            let c = me.connect()?;
+            let d = c.get::<&str, Vec<u8>>(&key)?;
+            if d.is_empty() {
+                Ok(Cache::Miss)
+            } else {
+                CacheRead::from(Cursor::new(d))
+                    .map(Cache::Hit)
+            }
+        }).boxed()
+    }
+
+    /// Initiate a cache write. There is nothing special needed
+    /// for the Redis cache.
+    fn start_put(&self, _key: &str) -> Result<CacheWrite> {
+        Ok(CacheWrite::new())
+    }
+
+    /// Open a connecxtion and store a object in the cache.
+    fn finish_put(&self, key: &str, entry: CacheWrite) -> SFuture<Duration> {
+        let key = key.to_owned();
+        let me = self.clone();
+        self.pool.spawn_fn(move || {
+            let start = Instant::now();
+            let c = me.connect()?;
+            let d = entry.finish()?;
+            c.set::<&str, Vec<u8>, ()>(&key, d)?;
+            Ok(start.elapsed())
+        }).boxed()
+    }
+
+    /// Returns the cache location.
+    fn location(&self) -> String {
+        format!("Redis: {}", self.url)
+    }
+
+    /// Returns the current cache size. This value is aquired via
+    /// the Redis INFO command (used_memory).
+    fn current_size(&self) -> Option<usize> {
+        self.connect().ok()
+            .and_then(|c| cmd("INFO").query(&c).ok())
+            .and_then(|i: InfoDict| i.get("used_memory"))
+    }
+
+    /// Returns the maximum cache size. This value is read via
+    /// the Redis CONFIG command (maxmemory). If the server has no
+    /// configured limit, the result is None.
+    fn max_size(&self) -> Option<usize> {
+        self.connect().ok()
+            .and_then(|c| cmd("CONFIG").arg("GET").arg("maxmemory").query(&c).ok())
+            .and_then(|h: HashMap<String, usize>| h.get("maxmemory").map(|s| *s))
+            .and_then(|s| {
+                if s != 0 {
+                    Some(s)
+                } else {
+                    None
+                }
+            })
+    }
+}

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -51,6 +51,11 @@ pub fn get_app<'a, 'b>() -> App<'a, 'b> {
     App::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
         .setting(AppSettings::TrailingVarArg)
+        .after_help(concat!(
+                "Enabled features:\n",
+                "    S3:    ", cfg!(feature = "s3"), "\n",
+                "    Redis: ", cfg!(feature = "redis"), "\n")
+                )
         .args_from_usage(
             "-s --show-stats 'show cache statistics'
              -z, --zero-stats 'zero statistics counters'

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,6 +22,7 @@ use futures::future;
 use hyper;
 use lru_disk_cache;
 use serde_json;
+use redis;
 
 error_chain! {
     foreign_links {
@@ -30,6 +31,7 @@ error_chain! {
         Lru(lru_disk_cache::Error);
         Json(serde_json::Error);
         Bincode(bincode::Error);
+        Redis(redis::RedisError);
     }
 
     errors {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,22 +19,26 @@ use std::io;
 use bincode;
 use futures::Future;
 use futures::future;
+#[cfg(feature = "hyper")]
 use hyper;
 use lru_disk_cache;
+#[cfg(feature = "serde_json")]
 use serde_json;
+#[cfg(feature = "redis")]
 use redis;
 
 error_chain! {
     foreign_links {
+        Hyper(hyper::Error) #[cfg(feature = "hyper")];
         Io(io::Error);
-        Hyper(hyper::Error);
         Lru(lru_disk_cache::Error);
-        Json(serde_json::Error);
+        Json(serde_json::Error) #[cfg(feature = "serde_json")];
         Bincode(bincode::Error);
-        Redis(redis::RedisError);
+        Redis(redis::RedisError) #[cfg(feature = "redis")];
     }
 
     errors {
+        #[cfg(feature = "hyper")]
         BadHTTPStatus(status: hyper::status::StatusCode) {
             description("failed to get a successful HTTP status")
             display("didn't get a successful HTTP status, got `{}`", status)

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ extern crate libc;
 #[cfg(windows)]
 extern crate mio_named_pipes;
 extern crate number_prefix;
+extern crate redis;
 extern crate regex;
 extern crate retry;
 extern crate rustc_serialize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,10 @@
 extern crate app_dirs;
 extern crate bincode;
 extern crate byteorder;
+#[cfg(feature = "chrono")]
 extern crate chrono;
 extern crate clap;
+#[cfg(feature = "rust-crypto")]
 extern crate crypto;
 #[cfg(unix)]
 extern crate daemonize;
@@ -27,7 +29,9 @@ extern crate filetime;
 #[macro_use]
 extern crate futures;
 extern crate futures_cpupool;
+#[cfg(feature = "hyper")]
 extern crate hyper;
+#[cfg(feature = "hyper-tls")]
 extern crate hyper_tls;
 #[cfg(windows)]
 extern crate kernel32;
@@ -40,10 +44,12 @@ extern crate libc;
 #[cfg(windows)]
 extern crate mio_named_pipes;
 extern crate number_prefix;
+#[cfg(feature = "redis")]
 extern crate redis;
 extern crate regex;
 extern crate retry;
 extern crate rustc_serialize;
+#[cfg(feature = "serde_json")]
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
@@ -78,6 +84,7 @@ mod compiler;
 mod mock_command;
 mod protocol;
 mod server;
+#[cfg(feature = "simple-s3")]
 mod simples3;
 mod util;
 


### PR DESCRIPTION
This patch adds support for using a [Redis](http://redis.io) instance as cache. The cache is used when `SCCACHE_REDIS` is set to a url that matches `redis://[:<passwd>@]<hostname>[:port][/<db>]`.  The S3 storage options overrule Redis.

For the connection to the Redis a connection pool is used. It is managed by [r2d2](https://github.com/sfackler/r2d2). The size of the connection pool can be controlled by `SCCACHE_REDIS_CONNECTIONS` and default to the number of cpus multiplied by 2. I'm not sure that this fallback is a good idea, but I wanted to have `SCCACHE_REDIS_CONNECTIONS` optional. What do you think?

The `current_size` method of `Storage` uses a lua script to sum the individual key sizes. This might not perform well on larger systems. During my tests this was not a problem for ~50k keys - but I limited the cache size to 10Gb. 

Everything else is quite straight forward. Some parts are borrowed from the `disk` and `S3` cache implementation. Thanks for that!