### PR TITLE
Fix default logging initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The environment variables are only taken into account when the server starts, so
 Debugging
 ---------
 
-You can set the `SCCACHE2_LOG_LEVEL` environment variable to `debug` or `trace` (not recommended, it's *very verbose*) to cause sccache to output more fine grained logging about what it is doing. A log file named `sccache2.log` will be output in the current working directory when the server is first started.
+You can set the `SCCACHE_LOG_LEVEL` environment variable to `debug` or `trace` (not recommended, it's *very verbose*) to cause sccache to output more fine grained logging about what it is doing. A log file named `sccache.log` will be output in the current working directory whenever sccache is invoked.
 
 Alternately, you can run the server manually in foreground mode by running `SCCACHE_START_SERVER=1 SCCACHE_NO_DAEMON=1 sccache`, and send logging to stderr by setting the `RUST_LOG` environment variable, the format of which is described in more detail in the [env_logger](http://burntsushi.net/rustdoc/env_logger/index.html#enabling-logging) documentation.
 


### PR DESCRIPTION
If none of the logging environment variables are supplied
sccache creates a `sccache2.log` file on every sccache
invocation. Means, in *every* directory where a compilation takes
place a logfile is left afterwards. In the happy case this file
is empty. This can be kind of messy for larger projects where
the compiler invocation is done from multiple directories. The
information in the README is wrong because the logfile is
also created for "client mode" invocations.

This patch changes the logging initialization:

* `SCCACHE2_LOG_LEVEL` is renamed to `SCCACHE_LOG_LEVEL`
* `sccache2.log` is renamed to `sccache.log`
* If none of `RUST_LOG` or `SCCACHE_LOG_LEVEL` is set, no logging is initialized.
* If `RUST_LOG` is set, only `env_logger` is used - no logfile is created.

I removed the "2" from `SCCACHE2_LOG_LEVEL` and `sccache2.log`, because I think this is a leftover from the rewrite - can add it again if requested...