### PR TITLE
Remove out file from hash generation

### DIFF
--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -308,15 +308,6 @@ mod test {
     }
 
     #[test]
-    fn test_hash_key_out_file_differs() {
-        let f = TestFixture::new();
-        let c = Compiler::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
-        const PREPROCESSED : &'static [u8] = b"hello world";
-        assert_neq!(hash_key(&c, vec!["a", "b", "-o", "somefile"], &PREPROCESSED),
-                    hash_key(&c, vec!["a", "b", "-o", "otherfile"], &PREPROCESSED));
-    }
-
-    #[test]
     fn test_hash_key_preprocessed_content_differs() {
         let f = TestFixture::new();
         let c = Compiler::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -214,7 +214,7 @@ pub fn storage_from_environment() -> Box<Storage> {
 }
 
 /// The cache is versioned by the inputs to `hash_key`.
-pub const CACHE_VERSION : &'static [u8] = b"2";
+pub const CACHE_VERSION : &'static [u8] = b"3";
 
 /// Environment variables that are factored into the cache key.
 pub const CACHED_ENV_VARS : &'static [&'static str] = &[
@@ -224,17 +224,14 @@ pub const CACHED_ENV_VARS : &'static [&'static str] = &[
 
 /// Compute the hash key of `compiler` compiling `preprocessor_output` with `args`.
 #[allow(dead_code)]
-pub fn hash_key(compiler: &Compiler, args: &[String], preprocessor_output: &[u8]) -> String {
+pub fn hash_key(compiler: &Compiler, args: Vec<&str>, preprocessor_output: &[u8]) -> String {
     // If you change any of the inputs to the hash, you should change `CACHE_VERSION`.
     let mut m = sha1::Sha1::new();
     m.update(compiler.digest.as_bytes());
     //TODO: drop the compiler filename from the hash
     m.update(compiler.executable.as_bytes());
     m.update(CACHE_VERSION);
-    for (i, arg) in args.iter().enumerate() {
-        if i != 0 {
-            m.update(&b" "[..]);
-        }
+    for arg in args {
         m.update(arg.as_bytes());
     }
     //TODO: should propogate these over from the client.
@@ -275,10 +272,10 @@ mod test {
         // Try to avoid testing exact hashes.
         let c1 = Compiler::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
         let c2 = Compiler::new(f.bins[1].to_str().unwrap(), CompilerKind::Gcc).unwrap();
-        let args = stringvec!["a", "b", "c"];
+        let args = vec!["a", "b", "c"];
         const PREPROCESSED : &'static [u8] = b"hello world";
-        assert_neq!(hash_key(&c1, &args, &PREPROCESSED),
-                    hash_key(&c2, &args, &PREPROCESSED));
+        assert_neq!(hash_key(&c1, args.clone(), &PREPROCESSED),
+                    hash_key(&c2, args, &PREPROCESSED));
     }
 
     #[test]
@@ -289,10 +286,10 @@ mod test {
         // Overwrite the contents of the binary.
         mk_bin_contents(f.tempdir.path(), "a/bin", |mut f| f.write_all(b"hello")).unwrap();
         let c2 = Compiler::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
-        let args = stringvec!["a", "b", "c"];
+        let args = vec!["a", "b", "c"];
         const PREPROCESSED : &'static [u8] = b"hello world";
-        assert_neq!(hash_key(&c1, &args, &PREPROCESSED),
-                    hash_key(&c2, &args, &PREPROCESSED));
+        assert_neq!(hash_key(&c1, args.clone(), &PREPROCESSED),
+                    hash_key(&c2, args, &PREPROCESSED));
     }
 
     #[test]
@@ -300,40 +297,48 @@ mod test {
         let f = TestFixture::new();
         let c = Compiler::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
         const PREPROCESSED : &'static [u8] = b"hello world";
-        assert_neq!(hash_key(&c, &stringvec!["a", "b", "c"], &PREPROCESSED),
-                    hash_key(&c, &stringvec!["x", "y", "z"], &PREPROCESSED));
+        assert_neq!(hash_key(&c, vec!["a", "b", "c"], &PREPROCESSED),
+                    hash_key(&c, vec!["x", "y", "z"], &PREPROCESSED));
 
-        assert_neq!(hash_key(&c, &stringvec!["a", "b", "c"], &PREPROCESSED),
-                    hash_key(&c, &stringvec!["a", "b"], &PREPROCESSED));
+        assert_neq!(hash_key(&c, vec!["a", "b", "c"], &PREPROCESSED),
+                    hash_key(&c, vec!["a", "b"], &PREPROCESSED));
 
-        assert_neq!(hash_key(&c, &stringvec!["a", "b", "c"], &PREPROCESSED),
-                    hash_key(&c, &stringvec!["a"], &PREPROCESSED));
+        assert_neq!(hash_key(&c, vec!["a", "b", "c"], &PREPROCESSED),
+                    hash_key(&c, vec!["a"], &PREPROCESSED));
+    }
 
+    #[test]
+    fn test_hash_key_out_file_differs() {
+        let f = TestFixture::new();
+        let c = Compiler::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
+        const PREPROCESSED : &'static [u8] = b"hello world";
+        assert_neq!(hash_key(&c, vec!["a", "b", "-o", "somefile"], &PREPROCESSED),
+                    hash_key(&c, vec!["a", "b", "-o", "otherfile"], &PREPROCESSED));
     }
 
     #[test]
     fn test_hash_key_preprocessed_content_differs() {
         let f = TestFixture::new();
         let c = Compiler::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
-        let args = stringvec!["a", "b", "c"];
-        assert_neq!(hash_key(&c, &args, &b"hello world"[..]),
-                    hash_key(&c, &args, &b"goodbye"[..]));
+        let args = vec!["a", "b", "c"];
+        assert_neq!(hash_key(&c, args.clone(), &b"hello world"[..]),
+                    hash_key(&c, args, &b"goodbye"[..]));
     }
 
     #[test]
     fn test_hash_key_env_var_differs() {
         let f = TestFixture::new();
         let c = Compiler::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
-        let args = stringvec!["a", "b", "c"];
+        let args = vec!["a", "b", "c"];
         const PREPROCESSED : &'static [u8] = b"hello world";
         for var in CACHED_ENV_VARS.iter() {
             let old = env::var_os(var);
             env::remove_var(var);
-            let h1 = hash_key(&c, &args, &PREPROCESSED);
+            let h1 = hash_key(&c, args.clone(), &PREPROCESSED);
             env::set_var(var, "something");
-            let h2 = hash_key(&c, &args, &PREPROCESSED);
+            let h2 = hash_key(&c, args.clone(), &PREPROCESSED);
             env::set_var(var, "something else");
-            let h3 = hash_key(&c, &args, &PREPROCESSED);
+            let h3 = hash_key(&c, args.clone(), &PREPROCESSED);
             match old {
                 Some(val) => env::set_var(var, val),
                 None => env::remove_var(var),

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -290,12 +290,12 @@ impl Compiler {
         }
         trace!("[{}]: Preprocessor output is {} bytes", out_file, preprocessor_result.stdout.len());
 
-        // Remove out_file because it has no effect on the output
-        let arguments = parsed_args.common_args.iter()
+        // Remove object file from arguments before hash calculation
+        let arguments = arguments.iter()
             .filter(|a| **a != out_file)
-            .map(|a| a.as_str())
-            .collect::<Vec<&str>>();
-        let key = hash_key(self, arguments, &preprocessor_result.stdout);
+            .map(|a| &**a)
+            .collect::<String>();
+        let key = hash_key(self, &arguments, &preprocessor_result.stdout);
         trace!("[{}]: Hash key: {}", out_file, key);
         let pwd = Path::new(cwd);
         let outputs = parsed_args.outputs.iter()

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -290,6 +290,11 @@ impl Compiler {
         }
         trace!("[{}]: Preprocessor output is {} bytes", out_file, preprocessor_result.stdout.len());
 
+        // Remove out_file because it has no effect on the output
+        let arguments = parsed_args.common_args.iter()
+            .filter(|a| **a != out_file)
+            .map(|a| a.as_str())
+            .collect::<Vec<&str>>();
         let key = hash_key(self, arguments, &preprocessor_result.stdout);
         trace!("[{}]: Hash key: {}", out_file, key);
         let pwd = Path::new(cwd);


### PR DESCRIPTION
The name and path of the output file of a compilation shall not be used for the hash calculation. This improves the hit rate when building two modules `A` and `B` and both have a dependency on `C` **and** the build systems composes the object file path from the path of the module that introduces the dependency.

Example:

Three individual modules exist with on source file each:

```
A/a.c
B/b.c
C/c.c
```

where A and B depend on C. A and B are independent projects.

The build systems produces two objects when building A:

```
A/build/a.o
C/build_A/c.o
```

and when building B:

```
B/build/b.o
C/build_B/c.o
``````

The `build_A` and `build_B` is (sadly) the default behaviour of the [build system](https://github.com/esrlabs/bake).


Without this patch `sccache` would end in a cache miss when building `c.c` the second time (as a dep of B). This scenario often happens when `C` is a common thing like e.g `gtest` etc...

This patch also removes the artificial space that is used during iteration over the arguments because it also should not have a effect in the result and the hash.

To check that the output file has no effect on the result do the following (same for gcc):

```
# clang -c test.c -o test0.o
# clang -c test.c -o test1.o
# shasum test0.o test1.o
-> 5999b7872181e9121ad17d33b828757a86318dc2  test0.o
-> 5999b7872181e9121ad17d33b828757a86318dc2  test1.o
```

The `args` can be passed in various ways to `hash_key`. I'm unsure if a `&str`, `&String` would result in better performance.