### PR TITLE
Remove unused import

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -104,7 +104,6 @@ fn run_server_process() -> io::Result<ServerStartup> {
     use tempdir::TempDir;
     use std::os::unix::io::AsRawFd;
     use std::os::unix::net::UnixListener;
-    use std::time::Duration;
 
     trace!("run_server_process");
     let tempdir = try!(TempDir::new("sccache"));


### PR DESCRIPTION
warning: unused import: `std::time::Duration`, #[warn(unused_imports)] on by default
   --> src/commands.rs:107:9
    |
107 |     use std::time::Duration;
    |         ^^^^^^^^^^^^^^^^^^^