### PR TITLE
Rewrite the server module with Tokio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 cache: cargo
 
 rust:
-  - 1.12.0
+  - 1.13.0
   - stable
   - beta
   - nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,14 +10,14 @@ dependencies = [
  "error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-cpupool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-disk-cache 0.1.0",
- "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "named_pipe 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -29,6 +29,9 @@ dependencies = [
  "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-proto 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -61,17 +64,7 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bytes"
-version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -95,7 +88,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_size 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -108,15 +101,20 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "crossbeam"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "daemonize"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -151,7 +149,7 @@ name = "filetime"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -159,16 +157,26 @@ name = "flate2"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "futures"
-version = "0.1.3"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-cpupool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -191,27 +199,27 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.1.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.9.10"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -219,9 +227,9 @@ name = "idna"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -244,8 +252,13 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazycell"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
-version = "0.2.14"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -290,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -298,12 +311,12 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mime"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -315,28 +328,27 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mio"
-version = "0.5.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "miow"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -371,18 +383,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "nix"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -453,10 +456,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num_cpus"
-version = "0.2.13"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -499,7 +502,7 @@ name = "rand"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -533,7 +536,7 @@ version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -551,6 +554,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "semver"
@@ -598,7 +606,12 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.1.3"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "smallvec"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -616,6 +629,11 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "take"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "tempdir"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,7 +646,7 @@ name = "term_size"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -637,7 +655,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -654,8 +672,44 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-proto"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-service"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -678,15 +732,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -696,11 +750,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "url"
-version = "1.1.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -735,7 +789,7 @@ name = "which"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -777,13 +831,12 @@ dependencies = [
 "checksum aho-corasick 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2b3fb52b09c1710b961acb35390d514be82e4ac96a9969a8e38565a29b878dc9"
 "checksum ansi_term 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "30275ad0ad84ec1c06dde3b3f7d23c6006b7d76d61a85e7060b426b747eff70d"
 "checksum app_dirs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7d1c0d48a81bbb13043847f957971f4d87c81542d80ece5e84ba3cba4058fd4"
-"checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
-"checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum clap 2.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4cbebe3ce784f9c63d83684d07cf2da470b88bb149ac17dc262b3062e6fe8d93"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
+"checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
 "checksum daemonize 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0239832c1b4ca406d5ec73728cf4c7336d25cf85dd32db9e047e9e706ee0e935"
 "checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
 "checksum env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "82dcb9ceed3868a03b335657b85a159736c961900f7e7747d3b0b97b9ccb5ccb"
@@ -791,31 +844,32 @@ dependencies = [
 "checksum fern 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4d2f58d053ad7791bfaad58a3f3541fe2d2aecc564dd82aee7f92fa402c054b2"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
 "checksum flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "3eeb481e957304178d2e782f2da1257f1434dfecbae883bafb61ada2a9fea3bb"
-"checksum futures 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd89497091f8c5d3a65c6b4baf6d2f0731937a7c9217d2f89141b21437a9d96"
+"checksum futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c1913eb7083840b1bbcbf9631b7fda55eaf35fe7ead13cca034e8946f9e2bc41"
+"checksum futures-cpupool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bb982bb25cd8fa5da6a8eb3a460354c984ff1113da82bcb4f0b0862b5795db82"
 "checksum gcc 0.3.31 (registry+https://github.com/rust-lang/crates.io-index)" = "cfe877476e53690ebb0ce7325d0bf43e198d9500291b54b3c65e518de5039b07"
 "checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
 "checksum hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2da7d3a34cf6406d9d700111b8eafafe9a251de41ae71d8052748259343b58"
-"checksum httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46534074dbb80b070d60a5cb8ecadd8963a00a438ae1a95268850a7ef73b67ae"
-"checksum hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "eb27e8a3e8f17ac43ffa41bbda9cf5ad3f9f13ef66fa4873409d4902310275f7"
+"checksum httparse 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e7a63e511f9edffbab707141fbb8707d1a3098615fb2adbd5769cdfcc9b17d"
+"checksum hyper 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)" = "c1925f6242cc3933f83c264ff732b898ab5e8c122f77b1f9aa61b2b2af261f56"
 "checksum idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1053236e00ce4f668aeca4a769a09b3bf5a682d802abd6f3cb39374f6b162c11"
 "checksum itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3088ea4baeceb0284ee9eea42f591226e6beaecf65373e41b38d95a1b8e7a1"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-"checksum libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "39dfaaa0f4da0f1a06876c5d94329d739ad0150868069cc235f1ddf80a0480e7"
+"checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
+"checksum libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "684f330624d8c3784fb9558ca46c4ce488073a8d22450415c5eb4f4cfb0d11b5"
 "checksum linked-hash-map 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bda158e0dabeb97ee8a401f4d17e479d6b891a14de0bba79d5cc2d4d325b5e48"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum lru-cache 0.1.0 (git+https://github.com/luser/lru-cache?branch=non-mut-get)" = "<none>"
-"checksum matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "15305656809ce5a4805b1ff2946892810992197ce1270ff79baded852187942e"
+"checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
-"checksum mime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf93a79c700c9df8227ec6a4f0f27a8948373c079312bac24549d944cef85f64"
+"checksum mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5c93a4bd787ddc6e7833c519b73a50883deb5863d76d9b71eb8216fb7f94e66"
 "checksum miniz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d1f4d337a01c32e1f2122510fed46393d53ca35a7f429cb0450abaedfa3ed54"
-"checksum mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a637d1ca14eacae06296a008fa7ad955347e34efcb5891cfd8ba05491a37907e"
-"checksum miow 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4e93d633d34b8ff65a24566d67d49703e7a5c7ac2844d6139a9fc441a799e89a"
+"checksum mio 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "eecdbdd49a849336e77b453f021c89972a2cfb5b51931a0026ae0ac4602de681"
+"checksum miow 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3a78d2605eb97302c10cf944b8d96b0a2a890c52957caf92fcd1f24f69049579"
 "checksum msdos_time 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c04b68cc63a8480fb2550343695f7be72effdec953a9d4508161c3e69041c7d8"
 "checksum named_pipe 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57495d00ae2cf44c03e8cd9246f9a00eb803e63e9664ff61b5cc288c328ca9b8"
 "checksum net2 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "1dd775c6de972a1f57a34016f3b2bdc9e086e948f870b38675d1db410a21566b"
-"checksum nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bfb3ddedaa14746434a02041940495bf11325c22f6d36125d3bdd56090d50a79"
 "checksum num 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "d2ee34a0338c16ae67afb55824aaf8852700eb0f77ccd977807ccb7606b295f6"
 "checksum num-bigint 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc450723a2fe91d332a29edd8660e099b937d29e1a3ebe914e0da3f77ac1ad3"
 "checksum num-complex 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "8aabbc079e1855ce8415141fee0ebebf171f56505373b3a966e2716ad7c0e555"
@@ -823,7 +877,7 @@ dependencies = [
 "checksum num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "287a1c9969a847055e1122ec0ea7a5c5d6f72aad97934e131c83d5c08ab4e45c"
 "checksum num-rational 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "48cdcc9ff4ae2a8296805ac15af88b3d88ce62128ded0cb74ffb63a587502a84"
 "checksum num-traits 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "9d06e4a6e3873968e97c0f9e6abbe4220d53793f63cdd87dbf0a90fe3b140d87"
-"checksum num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "cee7e88156f3f9e19bdd598f8d6c9db7bf4078f99f8381f43a55b09648d1a6e3"
+"checksum num_cpus 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a225d1e2717567599c24f88e49f00856c6e825a12125181ee42c4257e3688d39"
 "checksum number_prefix 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "084d05f4bf60621a9ac9bde941a410df548f4de9545f06e5ee9d3aef4b97cd77"
 "checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
 "checksum podio 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e5422a1ee1bc57cc47ae717b0137314258138f38fd5f3cea083f43a9725383a0"
@@ -836,27 +890,33 @@ dependencies = [
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum serde 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ad09a04412d1ac27ab9c1170190cfed637e0463f2f2ce79e718141624f43a45"
 "checksum serde_json 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e10f8a9d94b06cf5d3bef66475f04c8ff90950f1be7004c357ff9472ccbaebc"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72f20b8f3c060374edb8046591ba28f62448c369ccbdc7b02075103fb3a9e38d"
 "checksum skeptic 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24ebf8a06f5f8bae61ae5bbc7af7aac4ef6907ae975130faba1199e5fe82256a"
-"checksum slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d807fd58c4181bbabed77cb3b891ba9748241a552bcc5be698faaebefc54f46e"
+"checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
+"checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
 "checksum strsim 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d5f575d5ced6634a5c4cb842163dab907dc7e9148b28dc482d81b8855cbe985"
+"checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0b62933a3f96cd559700662c34f8bab881d9e3540289fb4f368419c7f13a5aa9"
 "checksum term_size 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6a7c9a4de31e5622ec38533988a9e965aab09b26ee8bd7b8b0f56d488c3784d"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "55dd963dbaeadc08aa7266bf7f91c3154a7805e32bb94b820b769d2ef3b4744d"
 "checksum time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7ec6d62a20df54e07ab3b78b9a3932972f4b7981de295563686849eb3989af"
+"checksum tokio-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3d1be481b55126f02ef88ff86748086473cb537a949fc4a8f4be403a530ae54b"
+"checksum tokio-proto 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c0d6031f94d78d7b4d509d4a7c5e1cdf524a17e7b08d1c188a83cf720e69808"
+"checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
 "checksum traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "07eaeb7689bb7fca7ce15628319635758eda769fed481ecfe6686ddef2600616"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a5906ca2b98c799f4b1ab4557b76367ebd6ae5ef14930ec841c74aed5f3764"
-"checksum unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c1f7ceb96afdfeedee42bade65a0d585a6a0106f681b6749c8ff4daa8df30b3f"
-"checksum unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "26643a2f83bac55f1976fb716c10234485f9202dcd65cfbdf9da49867b271172"
+"checksum unicode-bidi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b61814f3e7fd0e0f15370f767c7c943e08bc2e3214233ae8f88522b334ceb778"
+"checksum unicode-normalization 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5e94e9f6961090fcc75180629c4ef33e5310d6ed2c0dd173f4ca63c9043b669e"
 "checksum unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"
-"checksum url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8ab4ca6f0107350f41a59a51cb0e71a04d905bc6a29181d2cb42fa4f040c65c9"
+"checksum url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5ba8a749fb4479b043733416c244fa9d1d3af3d7c23804944651c8a448cb87e"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a9ff57156caf7e22f37baf3c9d8f6ce8194842c23419dafcb0716024514d162"
 "checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ error-chain = { version = "0.7.2", default-features = false }
 fern = "0.3.5"
 filetime = "0.1"
 futures = "0.1"
-hyper = { version = "0.9.10", default-features = false }
+futures-cpupool = "0.1"
+hyper = { version = "0.9", default-features = false }
 libc = "0.2.10"
 local-encoding = "0.2.0"
 log = "0.3.6"
 lru-disk-cache = { path = "lru-disk-cache" }
-mio = "0.5"
 number_prefix = "0.2.5"
 protobuf = "1.0.18"
 regex = "0.1.65"
@@ -32,6 +32,9 @@ serde_json = "0.8.0"
 sha1 = "0.2.0"
 tempdir = "0.3.4"
 time = "0.1.35"
+tokio-core = "0.1"
+tokio-proto = "0.1"
+tokio-service = "0.1"
 uuid = { version = "0.3.1", features = ["v4"] }
 which = "0.2.1"
 zip = { version = "0.1", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,9 @@ extern crate env_logger;
 #[macro_use]
 extern crate error_chain;
 extern crate filetime;
+#[macro_use]
 extern crate futures;
+extern crate futures_cpupool;
 extern crate hyper;
 #[cfg(windows)]
 extern crate kernel32;
@@ -34,7 +36,6 @@ extern crate log;
 extern crate lru_disk_cache;
 extern crate fern;
 extern crate libc;
-extern crate mio;
 #[cfg(windows)]
 extern crate named_pipe;
 extern crate number_prefix;
@@ -46,6 +47,9 @@ extern crate serde_json;
 extern crate sha1;
 extern crate tempdir;
 extern crate time;
+extern crate tokio_core;
+extern crate tokio_proto;
+extern crate tokio_service;
 extern crate uuid;
 #[cfg(windows)]
 extern crate winapi;

--- a/src/mock_command.rs
+++ b/src/mock_command.rs
@@ -129,7 +129,7 @@ pub trait CommandCreator: Send {
 }
 
 /// A trait for simplifying the normal case while still allowing the mock case requiring mutability.
-pub trait CommandCreatorSync: Clone + Send {
+pub trait CommandCreatorSync: Clone + Send + 'static {
     type Cmd: RunCommand;
 
     fn new() -> Self;
@@ -400,7 +400,7 @@ impl CommandCreator for MockCommandCreator {
 }
 
 /// To simplify life for using a `CommandCreator` across multiple threads.
-impl<T : CommandCreator> CommandCreatorSync for Arc<Mutex<T>> {
+impl<T : CommandCreator + 'static> CommandCreatorSync for Arc<Mutex<T>> {
     type Cmd = T::Cmd;
 
     fn new() -> Arc<Mutex<T>> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,8 +18,6 @@ use cache::{
 };
 use compiler::{
     CacheControl,
-    CacheWriteFuture,
-    CacheWriteResult,
     Compiler,
     CompilerArguments,
     CompileResult,
@@ -28,19 +26,17 @@ use compiler::{
     get_compiler_info,
 };
 use filetime::FileTime;
-use futures::Future;
-use mio::*;
-use mio::tcp::{
-    TcpListener,
-    TcpStream,
-};
-use mio::util::Slab;
+use futures::future;
+use futures::sync::mpsc;
+use futures::task::{self, Task};
+use futures::{Stream, Sink, Async, AsyncSink, Poll, StartSend, Future};
+use futures_cpupool::CpuPool;
 use mock_command::{
     CommandCreatorSync,
     ProcessCommandCreator,
 };
 use protobuf::{
-    Message,
+    self,
     ProtobufError,
     RepeatedField,
     parse_length_delimited_from_bytes,
@@ -58,65 +54,575 @@ use protocol::{
     UnknownCommand,
 };
 use std::collections::HashMap;
+use std::cell::RefCell;
 use std::env;
-use std::error::Error;
-use std::ffi::OsStr;
+use std::ffi::OsString;
 use std::fs::metadata;
 use std::io::{self, ErrorKind, Write};
-use std::net::{SocketAddr, SocketAddrV4};
+use std::marker;
+use std::net::{SocketAddr, SocketAddrV4, Ipv4Addr};
 use std::process::Output;
+use std::rc::Rc;
 use std::sync::Arc;
-use std::thread;
 use std::time::Duration;
+use tokio_core::reactor::{Handle, Core, Timeout};
+use tokio_core::io::{Codec, EasyBuf, Io, Framed};
+use tokio_core::net::TcpListener;
+use tokio_proto::BindServer;
+use tokio_proto::streaming::pipeline::{Frame, ServerProto, Transport};
+use tokio_proto::streaming::{Body, Message};
+use tokio_service::Service;
 
 /// If the server is idle for this many milliseconds, shut down.
-const DEFAULT_IDLE_TIMEOUT: u64 = 600000;
+const DEFAULT_IDLE_TIMEOUT: u64 = 600_000;
 
-/// A background task.
-struct Task<C : CommandCreatorSync + 'static> {
-    /// A callback to call when the task finishes.
-    callback: Box<Fn(Token, TaskResult, &mut SccacheServer<C>, &mut EventLoop<SccacheServer<C>>)>,
+fn notify_server_startup_internal<W: Write>(mut w: W, success: bool) -> io::Result<()> {
+    let data = [ if success { 0 } else { 1 }; 1];
+    try!(w.write_all(&data));
+    Ok(())
 }
 
-/// Represents an sccache server instance.
-pub struct SccacheServer<C: CommandCreatorSync + 'static> {
-    /// The listen socket for the server.
-    sock: TcpListener,
+#[cfg(unix)]
+fn notify_server_startup(name: &Option<OsString>, success: bool) -> io::Result<()> {
+    use std::os::unix::net::UnixStream;
+    let name = match *name {
+        Some(ref s) => s,
+        None => return Ok(()),
+    };
+    debug!("notify_server_startup(success: {})", success);
+    let stream = try!(UnixStream::connect(name));
+    notify_server_startup_internal(stream, success)
+}
 
-    /// The mio `Token` for `self.sock`.
-    token: Token,
+#[cfg(windows)]
+fn notify_server_startup(name: &Option<OsString>, success: bool) -> io::Result<()> {
+    use named_pipe::PipeClient;
+    let name = match *name {
+        Some(ref s) => s,
+        None => return Ok(()),
+    };
+    let pipe = try!(PipeClient::connect(name));
+    notify_server_startup_internal(pipe, success)
+}
 
-    /// A list of accepted connections.
-    conns: Slab<ClientConnection<C>>,
+/// Start an sccache server, listening on `port`.
+///
+/// Spins an event loop handling client connections until a client
+/// requests a shutdown.
+pub fn start_server(port: u16) -> io::Result<()> {
+    let pool = CpuPool::new(20);
+    let storage = storage_from_environment(&pool);
+    let res = SccacheServer::<ProcessCommandCreator>::new(port, pool, storage);
+    let notify = env::var_os("SCCACHE_STARTUP_NOTIFY");
+    match res {
+        Ok(srv) => {
+            notify_server_startup(&notify, true)?;
+            srv.run(future::empty::<(), ()>())
+        }
+        Err(e) => {
+            notify_server_startup(&notify, false)?;
+            Err(e)
+        }
+    }
+}
+
+pub struct SccacheServer<C: CommandCreatorSync> {
+    core: Core,
+    listener: TcpListener,
+    rx: mpsc::Receiver<ServerMessage>,
+    timeout: Duration,
+    service: SccacheService<C>,
+    wait: WaitUntilZero,
+}
+
+impl<C: CommandCreatorSync> SccacheServer<C> {
+    pub fn new(port: u16,
+               pool: CpuPool,
+               storage: Arc<Storage>) -> io::Result<SccacheServer<C>> {
+        let core = Core::new()?;
+        let handle = core.handle();
+        let addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), port);
+        let listener = TcpListener::bind(&SocketAddr::V4(addr), &handle)?;
+
+        // Prepare the service which we'll use to service all incoming TCP
+        // connections.
+        let (tx, rx) = mpsc::channel(100);
+        let (wait, info) = WaitUntilZero::new();
+        let service = SccacheService::new(storage, core.handle(), pool, tx, info);
+
+        Ok(SccacheServer {
+            core: core,
+            listener: listener,
+            rx: rx,
+            service: service,
+            timeout: Duration::from_millis(DEFAULT_IDLE_TIMEOUT),
+            wait: wait,
+        })
+    }
+
+    /// Configures how long this server will be idle before shutting down.
+    #[allow(dead_code)]
+    pub fn set_idle_timeout(&mut self, timeout: Duration) {
+        self.timeout = timeout;
+    }
+
+    /// Set the `force_recache` setting.
+    #[allow(dead_code)]
+    pub fn set_force_recache(&mut self, force_recache: bool) {
+        self.service.force_recache = force_recache;
+    }
+
+    /// Set the storage this server will use.
+    #[allow(dead_code)]
+    pub fn set_storage(&mut self, storage: Arc<Storage>) {
+        self.service.storage = storage;
+    }
+
+    /// Returns a reference to a thread pool to run work on
+    #[allow(dead_code)]
+    pub fn pool(&self) -> &CpuPool {
+        &self.service.pool
+    }
+
+    /// Returns a reference to the command creator this server will use
+    #[allow(dead_code)]
+    pub fn command_creator(&self) -> &C {
+        &self.service.creator
+    }
+
+    /// Returns the port that this server is bound to
+    #[allow(dead_code)]
+    pub fn port(&self) -> u16 {
+        self.listener.local_addr().unwrap().port()
+    }
+
+    /// Runs this server to completion.
+    ///
+    /// If the `shutdown` future resolves then the server will be shut down,
+    /// otherwise the server may naturally shut down if it becomes idle for too
+    /// long anyway.
+    pub fn run<F>(self, shutdown: F) -> io::Result<()>
+        where F: Future,
+    {
+        self._run(Box::new(shutdown.then(|_| Ok(()))))
+    }
+
+    fn _run<'a>(self, shutdown: Box<Future<Item = (), Error = ()> + 'a>)
+                -> io::Result<()>
+    {
+        let SccacheServer { mut core, listener, rx, service, timeout, wait } = self;
+
+        // Create our "server future" which will simply handle all incoming
+        // connections in separate tasks.
+        let handle = core.handle();
+        let server = listener.incoming().for_each(move |(socket, _addr)| {
+            SccacheProto.bind_server(&handle, socket, service.clone());
+            Ok(())
+        });
+
+        // Right now there's a whole bunch of ways to shut down this server for
+        // various purposes. These include:
+        //
+        // 1. The `shutdown` future above.
+        // 2. An RPC indicating the server should shut down
+        // 3. A period of inactivity (no requests serviced)
+        //
+        // These are all encapsulated wih the future that we're creating below.
+        // The `ShutdownOrInactive` indicates the RPC or the period of
+        // inactivity, and this is then select'd with the `shutdown` future
+        // passed to this function.
+        let handle = core.handle();
+        let shutdown_idle = ShutdownOrInactive {
+            rx: rx,
+            timeout: Timeout::new(timeout, &handle)?,
+            handle: handle.clone(),
+            timeout_dur: timeout,
+        };
+
+        let server = future::select_all(vec![
+            Box::new(server) as Box<Future<Item=_, Error=_>>,
+            Box::new(shutdown_idle),
+            Box::new(shutdown.map_err(|()| {
+                io::Error::new(io::ErrorKind::Other, "shutdown signal failed")
+            })),
+        ]);
+        core.run(server)
+            .map_err(|p| p.0)?;
+
+        // Once our server has shut down either due to inactivity or a manual
+        // request we still need to give a bit of time for all active
+        // connections to finish. This `wait` future will resolve once all
+        // instances of `SccacheService` have been dropped.
+        //
+        // Note that we cap the amount of time this can take, however, as we
+        // don't want to wait *too* long.
+        core.run(wait.select(Timeout::new(Duration::new(10, 0), &handle)?))
+            .map_err(|p| p.0)?;
+
+        Ok(())
+    }
+}
+
+/// Service implementation for sccache
+#[derive(Clone)]
+struct SccacheService<C: CommandCreatorSync> {
+    /// Server statistics.
+    stats: Rc<RefCell<ServerStats>>,
 
     /// Cache storage.
-    storage: Arc<Box<Storage>>,
-
-    /// Server statistics.
-    stats: ServerStats,
-
-    /// True if the server is actively shutting down.
-    shutting_down: bool,
-
-    /// After this number of milliseconds with no client requests, shut down.
-    idle_timeout: u64,
-
-    /// A `Timeout` handle for the server idle shutdown timeout.
-    timeout: Option<Timeout>,
+    storage: Arc<Storage>,
 
     /// A cache of known compiler info.
-    compilers: HashMap<String, Option<Compiler>>,
+    compilers: Rc<RefCell<HashMap<String, Option<Compiler>>>>,
 
     /// True if all compiles should be forced, ignoring existing cache entries.
     ///
     /// This can be controlled with the `SCCACHE_RECACHE` environment variable.
     force_recache: bool,
 
+    /// Thread pool to execute work in
+    pool: CpuPool,
+
+    /// Handle to the event loop that we're running on.
+    handle: Handle,
+
     /// An object for creating commands.
     ///
     /// This is mostly useful for unit testing, where we
     /// can mock this out.
     creator: C,
+
+    /// Message channel used to learn about requests received by this server.
+    ///
+    /// Note that messages sent along this channel will keep the server alive
+    /// (reset the idle timer) and this channel can also be used to shut down
+    /// the entire server immediately via a message.
+    tx: mpsc::Sender<ServerMessage>,
+
+    /// Information tracking how many services (connected clients) are active.
+    info: ActiveInfo,
+}
+
+type SccacheRequest = Message<ClientRequest, Body<(), io::Error>>;
+type SccacheResponse = Message<ServerResponse, Body<ServerResponse, io::Error>>;
+
+/// Messages sent from all services to the main event loop indicating activity.
+///
+/// Whenever a request is receive a `Request` message is sent which will reset
+/// the idle shutdown timer, and otherwise a `Shutdown` message indicates that
+/// a server shutdown was requested via an RPC.
+pub enum ServerMessage {
+    /// A message sent whenever a request is received.
+    Request,
+    /// Message sent whenever a shutdown request is received.
+    Shutdown,
+}
+
+impl<C> Service for SccacheService<C>
+    where C: CommandCreatorSync + 'static,
+{
+    type Request = SccacheRequest;
+    type Response = SccacheResponse;
+    type Error = io::Error;
+    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+
+    fn call(&self, req: Self::Request) -> Self::Future {
+        let mut req = req.into_inner();
+        trace!("handle_client");
+
+        // Opportunistically let channel know that we've received a request. We
+        // ignore failures here as well as backpressure as it's not imperative
+        // that every message is received.
+        drop(self.tx.clone().start_send(ServerMessage::Request));
+
+        if req.has_compile() {
+            debug!("handle_client: compile");
+            self.stats.borrow_mut().compile_requests += 1;
+            self.handle_compile(req.take_compile())
+        } else {
+            // Simple requests that can generate responses right away.
+            let mut res = ServerResponse::new();
+            if req.has_get_stats() {
+                debug!("handle_client: get_stats");
+                res.set_stats(self.get_stats());
+            } else if req.has_zero_stats() {
+                debug!("handle_client: zero_stats");
+                res.set_stats(self.zero_stats());
+            } else if req.has_shutdown() {
+                debug!("handle_client: shutdown");
+                let future = self.tx.clone().send(ServerMessage::Shutdown);
+                let me = self.clone();
+                return Box::new(future.then(move |_| {
+                    let mut shutting_down = ShuttingDown::new();
+                    shutting_down.set_stats(me.get_stats());
+                    res.set_shutting_down(shutting_down);
+                    Ok(Message::WithoutBody(res))
+                }))
+            } else {
+                warn!("handle_client: unknown command");
+                res.set_unknown(UnknownCommand::new());
+            }
+
+            future::ok(Message::WithoutBody(res)).boxed()
+        }
+    }
+}
+
+impl<C> SccacheService<C>
+    where C: CommandCreatorSync,
+{
+    pub fn new(storage: Arc<Storage>,
+               handle: Handle,
+               pool: CpuPool,
+               tx: mpsc::Sender<ServerMessage>,
+               info: ActiveInfo) -> SccacheService<C> {
+        SccacheService {
+            stats: Rc::new(RefCell::new(ServerStats::default())),
+            storage: storage,
+            compilers: Rc::new(RefCell::new(HashMap::new())),
+            force_recache: env::var("SCCACHE_RECACHE").is_ok(),
+            pool: pool,
+            handle: handle,
+            creator: C::new(),
+            tx: tx,
+            info: info,
+        }
+    }
+
+    /// Get stats about the cache.
+    fn get_stats(&self) -> CacheStats {
+        let mut stats = CacheStats::new();
+        let mut stats_vec = self.stats.borrow().to_cache_statistics();
+
+        let mut stat = CacheStatistic::new();
+        stat.set_name(String::from("Cache location"));
+        stat.set_str(self.storage.location());
+        stats_vec.insert(0, stat);
+
+        for &(s, v) in [("Cache size", self.storage.current_size()),
+                       ("Max cache size", self.storage.max_size())].iter() {
+            v.map(|val| {
+                let mut stat = CacheStatistic::new();
+                stat.set_name(String::from(s));
+                stat.set_size(val as u64);
+                stats_vec.insert(0, stat);
+            });
+        }
+
+        stats.set_stats(RepeatedField::from_vec(stats_vec));
+        stats
+    }
+
+    /// Zero and return stats about the cache.
+    fn zero_stats(&self) -> CacheStats {
+        *self.stats.borrow_mut() = ServerStats::default();
+        self.get_stats()
+    }
+
+
+    /// Handle a compile request from a client.
+    ///
+    /// This will handle a compile request entirely, generating a response with
+    /// the inital information and an optional body which will eventually
+    /// contain the results of the compilation.
+    fn handle_compile(&self, mut compile: Compile)
+                      -> Box<Future<Item = SccacheResponse, Error = io::Error>>
+    {
+        let exe = compile.take_exe();
+        let cmd = compile.take_command().into_vec();
+        let cwd = compile.take_cwd();
+        let me = self.clone();
+        Box::new(self.compiler_info(&exe).map(move |info| {
+            me.check_compiler(info, cmd, cwd)
+        }))
+    }
+
+    /// Look up compiler info from the cache for the compiler `path`.
+    fn compiler_info(&self, path: &str)
+                     -> Box<Future<Item=Option<Compiler>, Error=io::Error>> {
+        trace!("compiler_info_cached");
+        let result = match metadata(path) {
+            Ok(attr) => {
+                let mtime = FileTime::from_last_modification_time(&attr);
+                match self.compilers.borrow().get(path) {
+                    // It's a hit only if the mtime matches.
+                    Some(&Some(ref c)) if c.mtime == mtime => Some(Some(c.clone())),
+                    // We cache non-results.
+                    Some(&None) => Some(None),
+                    _ => None,
+                }
+            }
+            Err(_) => None,
+        };
+        match result {
+            Some(info) => {
+                trace!("compiler_info cache hit");
+                future::ok(info).boxed()
+            }
+            None => {
+                trace!("compiler_info cache miss");
+                // Run a Task to check the compiler type.
+                let exe2 = path.to_string();
+                let path = path.to_string();
+                let me = self.clone();
+                let creator = me.creator.clone();
+
+                Box::new(self.pool.spawn_fn(move || {
+                    Ok(get_compiler_info(creator, &exe2))
+                }).map(move |info| {
+                    me.compilers.borrow_mut().insert(path, info.clone());
+                    info
+                }))
+            }
+        }
+    }
+
+    fn check_compiler(&self,
+                      compiler: Option<Compiler>,
+                      cmd: Vec<String>,
+                      cwd: String)
+                      -> SccacheResponse {
+        let mut res = ServerResponse::new();
+        let mut stats = self.stats.borrow_mut();
+        match compiler {
+            None => {
+                debug!("check_compiler: Unsupported compiler");
+                stats.requests_unsupported_compiler += 1;
+            }
+            Some(c) => {
+                debug!("check_compiler: Supported compiler");
+                // Now check that we can handle this compiler with
+                // the provided commandline.
+                match c.parse_arguments(&cmd, cwd.as_ref()) {
+                    CompilerArguments::Ok(args) => {
+                        stats.requests_executed += 1;
+                        res.set_compile_started(CompileStarted::new());
+                        let (tx, rx) = Body::pair();
+                        self.start_compile_task(c, args, cmd, cwd, tx);
+                        return Message::WithBody(res, rx)
+                    }
+                    CompilerArguments::CannotCache => {
+                        stats.requests_not_cacheable += 1;
+                    }
+                    CompilerArguments::NotCompilation => {
+                        stats.requests_not_compile += 1;
+                    }
+                }
+            }
+        }
+
+        res.set_unhandled_compile(UnhandledCompile::new());
+        Message::WithoutBody(res)
+    }
+
+    /// Start running `cmd` in a thread on our thread pool, in `cwd`.
+    fn start_compile_task(&self,
+                          compiler: Compiler,
+                          parsed_arguments: ParsedArguments,
+                          arguments: Vec<String>,
+                          cwd: String,
+                          tx: mpsc::Sender<io::Result<ServerResponse>>) {
+        let creator = self.creator.clone();
+        let storage = self.storage.clone();
+        let cache_control = if self.force_recache {
+            CacheControl::ForceRecache
+        } else {
+            CacheControl::Default
+        };
+        let result = self.pool.spawn_fn(move || {
+            let parsed_args = parsed_arguments;
+            let args = arguments;
+            let c = cwd;
+            compiler.get_cached_or_compile(creator,
+                                           &*storage,
+                                           &args,
+                                           &parsed_args,
+                                           &c,
+                                           cache_control)
+        });
+
+        let me = self.clone();
+        let task = result.then(move |result| {
+            let mut res = ServerResponse::new();
+            let mut finish = CompileFinished::new();
+            let mut cache_write = None;
+            let mut stats = me.stats.borrow_mut();
+            match result {
+                Ok((compiled, out)) => {
+                    match compiled {
+                        CompileResult::Error => {
+                            stats.cache_errors += 1;
+                        }
+                        CompileResult::CacheHit(duration) => {
+                            stats.cache_hits += 1;
+                            stats.cache_read_hit_duration += duration;
+                        },
+                        CompileResult::CacheMiss(miss_type, duration, future) => {
+                            match miss_type {
+                                MissType::Normal => {
+                                    stats.cache_misses += 1;
+                                }
+                                MissType::CacheReadError => {
+                                    stats.cache_read_errors += 1;
+                                }
+                                MissType::ForcedRecache => {
+                                    stats.cache_misses += 1;
+                                    stats.forced_recaches += 1;
+                                }
+                            }
+                            stats.cache_read_miss_duration += duration;
+                            cache_write = Some(future);
+                        }
+                        CompileResult::NotCacheable => {
+                            stats.cache_misses += 1;
+                            stats.non_cacheable_compilations += 1;
+                        }
+                        CompileResult::CompileFailed => {
+                            stats.compile_fails += 1;
+                        }
+                    };
+                    let Output { status, stdout, stderr } = out;
+                    status.code()
+                        .map_or_else(
+                            || trace!("CompileFinished missing retcode"),
+                            |s| { trace!("CompileFinished retcode: {}", s); finish.set_retcode(s) });
+                    //TODO: sort out getting signal return on Unix
+                    finish.set_stdout(stdout);
+                    finish.set_stderr(stderr);
+                }
+                Err(_) => {
+                    me.stats.borrow_mut().cache_errors += 1;
+                    //TODO: figure out a better way to communicate this?
+                    finish.set_retcode(-2);
+                }
+            };
+            res.set_compile_finished(finish);
+            let send = tx.send(Ok(res));
+
+            let me = me.clone();
+            let cache_write = cache_write.then(move |result| {
+                match result {
+                    Err(e) => {
+                        debug!("Error executing cache write: {}", e);
+                        me.stats.borrow_mut().cache_write_errors += 1;
+                    }
+                    //TODO: save cache stats!
+                    Ok(Some(info)) => {
+                        debug!("[{}]: Cache write finished in {}.{:03}s", info.object_file, info.duration.as_secs(), info.duration.subsec_nanos() / 1000_000);
+                        me.stats.borrow_mut().cache_writes += 1;
+                        me.stats.borrow_mut().cache_write_duration += info.duration;
+                    }
+
+                    Ok(None) => {}
+                }
+                Ok(())
+            });
+
+            send.join(cache_write).then(|_| Ok(()))
+        });
+
+        self.handle.spawn(task);
+    }
 }
 
 /// Statistics about the cache.
@@ -227,855 +733,233 @@ impl ServerStats {
     }
 }
 
-impl<C : CommandCreatorSync + 'static> SccacheServer<C> {
-    /// Create an `SccacheServer` bound to `port`, using `storage` as cache storage.
-    fn new(port: u16, storage: Box<Storage>) -> io::Result<SccacheServer<C>> {
-        let listener = try!(TcpListener::bind(&SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), port))));
-        Ok(SccacheServer {
-            sock: listener,
-            token: Token(1),
-            conns: Slab::new_starting_at(Token(2), 128),
-            storage: Arc::new(storage),
-            stats: ServerStats::default(),
-            shutting_down: false,
-            idle_timeout: DEFAULT_IDLE_TIMEOUT,
-            timeout: None,
-            compilers: HashMap::new(),
-            force_recache: env::var("SCCACHE_RECACHE").is_ok(),
-            creator: C::new(),
+/// tokio-proto protocol implementation for sccache
+struct SccacheProto;
+
+impl<I> ServerProto<I> for SccacheProto
+    where I: Io + 'static,
+{
+    type Request = ClientRequest;
+    type RequestBody = ();
+    type Response = ServerResponse;
+    type ResponseBody = ServerResponse;
+    type Error = io::Error;
+    type Transport = SccacheTransport<I>;
+    type BindTransport = future::FutureResult<Self::Transport, io::Error>;
+
+    fn bind_transport(&self, io: I) -> Self::BindTransport {
+        future::ok(SccacheTransport {
+            inner: io.framed(ProtobufCodec::new()),
         })
     }
+}
 
-    /// Get the port on which this server is listening for connections.
-    #[allow(dead_code)]
-    pub fn port(&self) -> u16 { self.sock.local_addr().unwrap().port() }
+/// Implementation of `Stream + Sink` that tokio-proto is expecting. This takes
+/// a `Framed` instance using `ProtobufCodec` and performs a simple map
+/// operation on the sink/stream halves to translate the protobuf message types
+/// to the `Frame` types that tokio-proto expects.
+struct SccacheTransport<I> {
+    inner: Framed<I, ProtobufCodec<ClientRequest, ServerResponse>>,
+}
 
-    /// Set the idle shutdown timeout, in milliseconds.
-    ///
-    /// Note: Does not clear a pending shutdown timer! Intended for use
-    /// in tests, where it will be called before `run_server`.
-    #[allow(dead_code)]
-    pub fn set_idle_timeout(&mut self, timeout: u64) {
-        self.idle_timeout = timeout;
-    }
+impl<I: Io> Stream for SccacheTransport<I> {
+    type Item = Frame<ClientRequest, (), io::Error>;
+    type Error = io::Error;
 
-    /// Set the `force_recache` setting.
-    #[allow(dead_code)]
-    pub fn set_force_recache(&mut self, force_recache: bool) {
-        self.force_recache = force_recache;
-    }
-
-    /// Return a clone of the object implementing `CommandCreatorSync` that this server uses to create processes.
-    ///
-    /// This is intended for use in testing. In non-testing, this will
-    /// just return a `ProcessCommandCreator` which is a unit struct.
-    #[allow(dead_code)]
-    pub fn command_creator(&self) -> C {
-        self.creator.clone()
-    }
-
-    /// Register Server with the event loop.
-    fn register(&mut self, mut event_loop: &mut EventLoop<SccacheServer<C>>) -> io::Result<()> {
-        event_loop.register(
-            &self.sock,
-            self.token,
-            EventSet::readable(),
-            PollOpt::edge() | PollOpt::oneshot()
-        ).and_then(|_| {
-            self.reset_idle_timer(&mut event_loop);
-            Ok(())
-        })
-    }
-
-    /// Re-register Server with the event loop.
-    fn reregister(&mut self, event_loop: &mut EventLoop<SccacheServer<C>>) {
-        if !self.shutting_down {
-            event_loop.reregister(
-                &self.sock,
-                self.token,
-                EventSet::readable(),
-                PollOpt::edge() | PollOpt::oneshot()
-             ).unwrap_or_else(|_e| {
-                 let server_token = self.token;
-                 self.reset_connection(event_loop, server_token);
-             })
-        }
-    }
-
-    /// Accept a new client connection.
-    fn accept(&mut self, event_loop: &mut EventLoop<SccacheServer<C>>) {
-        debug!("Client connecting");
-        let sock = match self.sock.accept() {
-            Ok(Some((sock, _addr))) => sock,
-            Err(_) | Ok(None) => {
-                self.reregister(event_loop);
-                return;
+    fn poll(&mut self) -> Poll<Option<Self::Item>, io::Error> {
+        let msg = try_ready!(self.inner.poll());
+        Ok(msg.map(|m| {
+            Frame::Message {
+                message: m,
+                body: false,
             }
-        };
-
-        if let Some(token) = self.conns.insert_with(|token|
-        {
-            ClientConnection::new(sock, token)
-        })
-        {
-            match self.conns[token].register(event_loop) {
-                Ok(_) => {},
-                Err(_e) => {
-                    self.conns.remove(token);
-                }
-            }
-        };
-
-
-        self.reregister(event_loop);
-    }
-
-    /// Reset a connection, either the listen socket or a client socket.
-    fn reset_connection(&mut self, event_loop: &mut EventLoop<SccacheServer<C>>, token: Token) {
-        if self.token == token {
-            if !self.shutting_down {
-                // Not actively trying to shut down, but something bad happened.
-                event_loop.shutdown();
-            }
-        } else {
-            debug!("reset connection; token={:?}", token);
-            self.conns.remove(token);
-            self.check_shutdown(event_loop);
-        }
-    }
-
-    /// Check if the server is finished handling in-progress client requests.
-    fn check_shutdown(&mut self, event_loop: &mut EventLoop<SccacheServer<C>>) {
-        if self.shutting_down && self.conns.is_empty() {
-            // All done.
-            trace!("check_shutdown: shutting down");
-            event_loop.shutdown();
-        }
-    }
-
-    /// Start server shutdown.
-    ///
-    /// The server will stop accepting incoming requests, and shut down
-    /// after it finishes processing any in-progress requests.
-    fn initiate_shutdown(&mut self, event_loop: &mut EventLoop<SccacheServer<C>>) {
-        trace!("initiate_shutdown");
-        if !self.shutting_down {
-            self.shutting_down = true;
-        }
-        self.check_shutdown(event_loop);
-    }
-
-    /// Run `task` on a background thread, sending the result back to `event_loop` when it completes.
-    fn run_task<F, G>(&mut self, token: Token, event_loop: &mut EventLoop<SccacheServer<C>>, task : F, callback : G) where
-    F : FnOnce() -> TaskResult + Send + 'static,
-    G : Fn(Token, TaskResult, &mut SccacheServer<C>, &mut EventLoop<SccacheServer<C>>) + 'static {
-        trace!("run_task");
-        let task_sender = event_loop.channel();
-        match thread::Builder::new().spawn(move || {
-            let msg = ServerMessage::TaskDone {
-                res: task(),
-                token: token
-            };
-            task_sender.send(msg).unwrap();
-        }) {
-            Ok(handle) => {
-                // Save the callback in the ClientConnection.
-                self.conns[token].set_task(Task { callback: Box::new(callback) });
-                // Wait on the task thread handle as well.
-                let wait_sender = event_loop.channel();
-                thread::spawn(move || {
-                    match handle.join() {
-                        Ok(_) => {},
-                        Err(e) => {
-                            e.downcast::<String>()
-                                .map(|s| error!("Task thread panicked: {}", s))
-                                .unwrap_or_else(|_| error!("Task thread panicked (panic argument was not a String)"));
-                            let msg = ServerMessage::TaskDone {
-                                res: TaskResult::Panic,
-                                token: token
-                            };
-                            wait_sender.send(msg).unwrap();
-                        },
-                    }
-                });
-            },
-            //TODO: this should probably just disconnect the client.
-            Err(e) => error!("Failed to spawn task: {}", e),
-        }
-    }
-
-    /// Look up compiler info from the cache for the compiler `path`.
-    fn compiler_info_cached(&mut self, path: &str) -> Option<Option<Compiler>> {
-        trace!("compiler_info_cached");
-        match metadata(path) {
-            Ok(attr) => {
-                let mtime = FileTime::from_last_modification_time(&attr);
-                match self.compilers.get(path) {
-                    // It's a hit only if the mtime matches.
-                    Some(&Some(ref c)) if c.mtime == mtime => Some(Some(c.clone())),
-                    // We cache non-results.
-                    Some(&None) => Some(None),
-                    _ => None,
-                }
-            }
-            Err(_) => None,
-        }
-    }
-
-    /// Store `info` in the compiler info cache for `path`.
-    fn cache_compiler_info(&mut self, path : String, info : &Option<Compiler>) {
-        self.compilers.insert(path, info.clone());
-    }
-
-    /// Send an `UnhandledCompile` response to the client at `token`.
-    ///
-    /// The server only supports a fixed set of compilers, and can't
-    /// cache results for certain compiler options, so `UnhandledCompile`
-    /// tells the client to just run the command locally.
-    fn send_unhandled_compile(&mut self, token: Token, event_loop: &mut EventLoop<SccacheServer<C>>) {
-        let mut res = ServerResponse::new();
-        res.set_unhandled_compile(UnhandledCompile::new());
-        match self.conns[token].send(res, event_loop) {
-            Ok(_) => {}
-            Err(_) => {
-                error!("Failed to send response");
-            }
-        };
-    }
-
-    /// Send a `CompileStarted` response to the client at `token`.
-    ///
-    /// This indicates that the server has started a compile with
-    /// the requested commandline, and will send a `CompileFinished`
-    /// message when it completes.
-    fn send_compile_started(&mut self, token: Token, event_loop: &mut EventLoop<SccacheServer<C>>) {
-        let mut res = ServerResponse::new();
-        res.set_compile_started(CompileStarted::new());
-        match self.conns[token].send(res, event_loop) {
-            Ok(_) => {}
-            Err(_) => {
-                error!("Failed to send response");
-            }
-        };
-    }
-
-    fn await_cache_write(&mut self, event_loop: &mut EventLoop<SccacheServer<C>>, future: CacheWriteFuture) {
-        // This would be much nicer if we rewrote the whole server
-        // event loop to use futures!
-        let sender = event_loop.channel();
-        //TODO: should really keep track of these somewhere...
-        thread::spawn(move || {
-            sender.send(ServerMessage::CacheWriteDone(match future.wait() {
-                Err(e) => Err(e.description().to_owned()),
-                Ok(res) => res,
-            })).unwrap();
-        });
-    }
-
-    /// Send a `CompileFinished` response to the client at `token`.
-    ///
-    /// This indicates that the server has finished running a compile,
-    /// and contains the process exit status and stdout/stderr.
-    fn send_compile_finished(&mut self, result: Option<(CompileResult, Output)>, token: Token, mut event_loop: &mut EventLoop<SccacheServer<C>>) {
-        let mut res = ServerResponse::new();
-        let mut finish = CompileFinished::new();
-        match result {
-            Some((compiled, out)) => {
-                match compiled {
-                    CompileResult::Error => self.stats.cache_errors += 1,
-                    CompileResult::CacheHit(duration) => {
-                        self.stats.cache_hits += 1;
-                        self.stats.cache_read_hit_duration += duration;
-                    },
-                    CompileResult::CacheMiss(miss_type, duration, future) => {
-                        match miss_type {
-                            MissType::Normal => self.stats.cache_misses += 1,
-                            MissType::CacheReadError => self.stats.cache_read_errors += 1,
-                            MissType::ForcedRecache => {
-                                self.stats.cache_misses += 1;
-                                self.stats.forced_recaches += 1;
-                            }
-                        }
-                        self.stats.cache_read_miss_duration += duration;
-                        self.await_cache_write(&mut event_loop, future)
-                    }
-                    CompileResult::NotCacheable => {
-                        self.stats.cache_misses += 1;
-                        self.stats.non_cacheable_compilations += 1;
-                    }
-                    CompileResult::CompileFailed => self.stats.compile_fails += 1,
-                };
-                let Output { status, stdout, stderr } = out;
-                status.code()
-                    .map_or_else(
-                        || trace!("CompileFinished missing retcode"),
-                        |s| { trace!("CompileFinished retcode: {}", s); finish.set_retcode(s) });
-                //TODO: sort out getting signal return on Unix
-                finish.set_stdout(stdout);
-                finish.set_stderr(stderr);
-            }
-            None => {
-                self.stats.cache_errors += 1;
-                //TODO: figure out a better way to communicate this?
-                finish.set_retcode(-2);
-            }
-        };
-        res.set_compile_finished(finish);
-        match self.conns[token].send(res, event_loop) {
-            Ok(_) => {}
-            Err(_) => {
-                error!("Failed to send response");
-            }
-        };
-    }
-
-
-    /// Check that `compiler` is `Some` and can handle `cmd`.
-    ///
-    /// If `cmd` is `Some` and does not contain unsupported options
-    /// (see `compiler_commandline_ok`), send the client a `CompileStarted`
-    /// message and begin compilation on a background task. Otherwise,
-    /// send the client an `UnhandledCompile` message.
-    fn check_compiler(&mut self, compiler: Option<Compiler>, cmd: Vec<String>, cwd: String, token: Token, event_loop: &mut EventLoop<SccacheServer<C>>) {
-        match compiler {
-            None => {
-                debug!("check_compiler: Unsupported compiler");
-                self.stats.requests_unsupported_compiler += 1;
-                self.send_unhandled_compile(token, event_loop);
-            }
-            Some(c) => {
-                debug!("check_compiler: Supported compiler");
-                // Now check that we can handle this compiler with
-                // the provided commandline.
-                match c.parse_arguments(&cmd, cwd.as_ref()) {
-                    CompilerArguments::Ok(args) => {
-                        self.stats.requests_executed += 1;
-                        self.send_compile_started(token, event_loop);
-                        self.start_compile_task(c, args, cmd, cwd, token, event_loop);
-                    }
-                    CompilerArguments::CannotCache => {
-                        self.stats.requests_not_cacheable += 1;
-                        self.send_unhandled_compile(token, event_loop);
-                    }
-                    CompilerArguments::NotCompilation => {
-                        self.stats.requests_not_compile += 1;
-                        self.send_unhandled_compile(token, event_loop);
-                    }
-                }
-            }
-        }
-    }
-
-    /// Start running `cmd` in a background task, in `cwd`.
-    fn start_compile_task(&mut self, compiler: Compiler, parsed_arguments: ParsedArguments, arguments: Vec<String>, cwd: String, token: Token, event_loop: &mut EventLoop<SccacheServer<C>>) {
-        let creator = self.creator.clone();
-        let storage = self.storage.clone();
-        let cache_control = if self.force_recache {
-            CacheControl::ForceRecache
-        } else {
-            CacheControl::Default
-        };
-        self.run_task(token, event_loop,
-                      // Task, runs on a background thread.
-                      move || {
-                          let parsed_args = parsed_arguments;
-                          let args = arguments;
-                          let c = cwd;
-                          let res = compiler.get_cached_or_compile(creator, storage.as_ref().as_ref(), &args, &parsed_args, &c, cache_control);
-                          TaskResult::Compiled(res.ok())
-                      },
-                      // Callback, runs on the event loop thread.
-                      move |token, res, this, event_loop| {
-                          match res {
-                              TaskResult::Compiled(res) => {
-                                  this.send_compile_finished(res, token, event_loop);
-                              },
-                              TaskResult::Panic => {
-                                  error!("Compile task panic!");
-                                  this.send_compile_finished(None, token, event_loop);
-                              },
-                              _ => error!("Unexpected task result!"),
-                          };
-                      })
-    }
-
-    /// Handle a compile request from a client.
-    ///
-    /// This will either start compilation and set a `CompileStarted`
-    /// response in `res`, or set an `UnhandledCompile` response in `res`.
-    fn handle_compile(&mut self, token: Token, mut compile: Compile, event_loop: &mut EventLoop<SccacheServer<C>>) {
-        let exe = compile.take_exe();
-        let cmd = compile.take_command().into_vec();
-        let cwd = compile.take_cwd();
-        // See if this compiler is already in the cache.
-        match self.compiler_info_cached(&exe) {
-            Some(c) => {
-                trace!("compiler_info cache hit");
-                self.check_compiler(c, cmd, cwd, token, event_loop);
-            }
-            None => {
-                trace!("compiler_info cache miss");
-                // Run a Task to check the compiler type.
-                let exe = exe.clone();
-                let creator = self.creator.clone();
-                self.run_task(token, event_loop,
-                              // Task, runs on a background thread.
-                              move || {
-                                  let c = get_compiler_info(creator, &exe);
-                                  TaskResult::GetCompilerInfo(exe, c)
-                              },
-                              // Callback, runs on the event loop thread.
-                              move |token, res, this, event_loop| {
-                                  match res {
-                                      TaskResult::GetCompilerInfo(path, c) => {
-                                          this.cache_compiler_info(path, &c);
-                                          //TODO: when FnBox is stable, can use that and avoid the clones here.
-                                          this.check_compiler(c.clone(), cmd.clone(), cwd.clone(), token, event_loop);
-                                      },
-                                      TaskResult::Panic => {
-                                          error!("Compiler detection task panic!");
-                                          this.send_unhandled_compile(token, event_loop);
-                                      },
-                                      _ => error!("Unexpected task result!"),
-                                  };
-                              })
-            }
-        }
-    }
-
-    /// Get stats about the cache.
-    fn get_stats(&self) -> CacheStats {
-        let mut stats = CacheStats::new();
-        let mut stats_vec = self.stats.to_cache_statistics();
-
-        let mut stat = CacheStatistic::new();
-        stat.set_name(String::from("Cache location"));
-        stat.set_str(self.storage.location());
-        stats_vec.insert(0, stat);
-
-        for &(s, v) in [("Cache size", self.storage.current_size()),
-                       ("Max cache size", self.storage.max_size())].iter() {
-            v.map(|val| {
-                let mut stat = CacheStatistic::new();
-                stat.set_name(String::from(s));
-                stat.set_size(val as u64);
-                stats_vec.insert(0, stat);
-            });
-        }
-
-        stats.set_stats(RepeatedField::from_vec(stats_vec));
-        stats
-    }
-
-    /// Zero and return stats about the cache.
-    fn zero_stats(&mut self) -> CacheStats {
-        self.stats = ServerStats::default();
-        self.get_stats()
-    }
-
-    /// Reset the server timeout on client activity.
-    fn reset_idle_timer(&mut self, event_loop: &mut EventLoop<SccacheServer<C>>) {
-        if let Some(timeout) = self.timeout {
-            event_loop.clear_timeout(timeout);
-        }
-        self.timeout = event_loop.timeout_ms((), self.idle_timeout).ok();
-    }
-
-    /// Handle one request from a client and possibly send a response.
-    fn handle_request(&mut self, token: Token, mut req: ClientRequest, mut event_loop: &mut EventLoop<SccacheServer<C>>) {
-        trace!("handle_request");
-        self.reset_idle_timer(&mut event_loop);
-        if req.has_compile() {
-            // This may need to do some work before even
-            // sending the initial response.
-            debug!("handle_client: compile");
-            self.stats.compile_requests += 1;
-            self.handle_compile(token, req.take_compile(), event_loop);
-        } else {
-            // Simple requests that can generate responses right away.
-            let mut res = ServerResponse::new();
-            if req.has_get_stats() {
-                debug!("handle_client: get_stats");
-                res.set_stats(self.get_stats());
-            } else if req.has_zero_stats() {
-                debug!("handle_client: zero_stats");
-                res.set_stats(self.zero_stats());
-            } else if req.has_shutdown() {
-                debug!("handle_client: shutdown");
-                self.initiate_shutdown(event_loop);
-                let mut shutting_down = ShuttingDown::new();
-                shutting_down.set_stats(self.get_stats());
-                res.set_shutting_down(shutting_down);
-            } else {
-                warn!("handle_client: unknown command");
-                res.set_unknown(UnknownCommand::new());
-            }
-            match self.conns[token].send(res, event_loop) {
-                Ok(_) => {}
-                Err(_) => {
-                    error!("Failed to send response");
-                }
-            };
-        }
+        }).into())
     }
 }
 
-/// Results from background tasks.
-pub enum TaskResult {
-    /// Compiler type detection.
-    GetCompilerInfo(String, Option<Compiler>),
-    /// Compile finished.
-    Compiled(Option<(CompileResult, Output)>),
-    /// Task `panic`ed.
-    Panic,
-}
+impl<I: Io> Sink for SccacheTransport<I> {
+    type SinkItem = Frame<ServerResponse, ServerResponse, io::Error>;
+    type SinkError = io::Error;
 
-/// Messages that can be sent to the server by way of the event loop.
-#[allow(dead_code)]
-pub enum ServerMessage {
-    /// Request shutdown.
-    Shutdown,
-    /// Background task completed.
-    TaskDone { res: TaskResult, token: Token },
-    /// Background cache write completed.
-    CacheWriteDone(CacheWriteResult),
-}
-
-impl<C : CommandCreatorSync + 'static> Handler for SccacheServer<C> {
-    type Timeout = ();
-    type Message = ServerMessage;
-
-    /// Notifications from `Sender`s, either out-of-band shutdown notifications or `Task` results.
-    fn notify(&mut self, event_loop: &mut EventLoop<Self>, msg: Self::Message) {
-        trace!("notify");
-        match msg {
-            ServerMessage::Shutdown => self.initiate_shutdown(event_loop),
-            ServerMessage::TaskDone { res, token } => {
-                trace!("TaskDone: {:?}", token);
-                if self.conns.get(token).is_none() {
-                    // Probably the client just hung up on us.
-                    warn!("Missing client at task completion!");
-                } else {
-                    match self.conns[token].take_task() {
-                        Some(task) => (task.callback)(token, res, self, event_loop),
-                        None => {
-                            //FIXME: should probably hang up on client here.
-                            error!("Client missing task: {:?}", token);
-                        }
+    fn start_send(&mut self, item: Self::SinkItem)
+                  -> StartSend<Self::SinkItem, io::Error> {
+        match item {
+            Frame::Message { message, body } => {
+                match self.inner.start_send(message)? {
+                    AsyncSink::Ready => Ok(AsyncSink::Ready),
+                    AsyncSink::NotReady(message) => {
+                        Ok(AsyncSink::NotReady(Frame::Message {
+                            message: message,
+                            body: body,
+                        }))
                     }
                 }
             }
-            ServerMessage::CacheWriteDone(res) => {
-                match res {
-                    Err(e) => {
-                        debug!("Error executing cache write: {}", e);
-                        self.stats.cache_write_errors += 1;
-                    }
-                    //TODO: save cache stats!
-                    Ok(info) => {
-                        debug!("[{}]: Cache write finished in {}.{:03}s", info.object_file, info.duration.as_secs(), info.duration.subsec_nanos() / 1000_000);
-                        self.stats.cache_writes += 1;
-                        self.stats.cache_write_duration += info.duration;
+            Frame::Body { chunk: Some(chunk) } => {
+                match self.inner.start_send(chunk)? {
+                    AsyncSink::Ready => Ok(AsyncSink::Ready),
+                    AsyncSink::NotReady(chunk) => {
+                        Ok(AsyncSink::NotReady(Frame::Body {
+                            chunk: Some(chunk),
+                        }))
                     }
                 }
             }
-        };
-    }
-
-    /// Handle `token` being ready for I/O.
-    fn ready(&mut self, event_loop: &mut EventLoop<SccacheServer<C>>, token: Token, events: EventSet) {
-        trace!("Handler::ready: events = {:?}", events);
-        assert!(token != Token(0), "[BUG]: Received event for Token(0)");
-
-        if events.is_error() {
-            self.reset_connection(event_loop, token);
-            return;
-        }
-
-        if events.is_hup() {
-            self.reset_connection(event_loop, token);
-            return;
-        }
-
-        if events.is_writable() {
-            assert!(self.token != token, "Received writable event for Server");
-            trace!("Writing to {:?}", token);
-            //FIXME: handle this more usefully? Might just need to kill
-            // the client connection in this case.
-            self.conns[token].write(event_loop).unwrap_or_else(|e| error!("Error writing client response: {}", e));
-        }
-
-        if events.is_readable() {
-            if self.token == token {
-                if !self.shutting_down {
-                    self.accept(event_loop);
-                } else {
-                    //FIXME: we should be closing the listen socket when
-                    // we start shutdown.
-                    trace!("Ignoring client connection during shutdown...");
-                }
-            } else {
-                trace!("Reading from {:?}", token);
-                match { self.conns[token].read(event_loop) } {
-                    Ok(Some(req)) => self.handle_request(token, req, event_loop),
-                    Ok(None) => { trace!("Nothing read?"); },
-                    Err(e) => { error!("Error reading client request: {}", e); }
-                }
-            }
+            Frame::Body { chunk: None } => Ok(AsyncSink::Ready),
+            Frame::Error { error } => Err(error),
         }
     }
 
-    /// Handle the server no-activity timeout.
-    fn timeout(&mut self, event_loop: &mut EventLoop<SccacheServer<C>>, _timeout: ()) {
-        info!("Hit server idle timeout, shutting down");
-        self.timeout = None;
-        self.initiate_shutdown(event_loop);
+    fn poll_complete(&mut self) -> Poll<(), io::Error> {
+        self.inner.poll_complete()
     }
 }
 
-/// A connection to a single sccache client.
-struct ClientConnection<C : CommandCreatorSync + 'static> {
-    /// Client's socket.
-    sock: TcpStream,
+impl<I: Io + 'static> Transport for SccacheTransport<I> {}
 
-    /// mio `Token` mapping to this client.
-    token: Token,
-
-    /// Set of events we are interested in.
-    interest: EventSet,
-
-    /// Receive buffer.
-    recv_buf: Vec<u8>,
-
-    /// Queued messages to send.
-    send_queue: Vec<Vec<u8>>,
-
-    /// In-progress task.
-    task: Option<Task<C>>,
+/// Simple tokio-core `Codec` which uses stock protobuf functions to
+/// decode/encode protobuf messages.
+struct ProtobufCodec<Request, Response> {
+    _marker: marker::PhantomData<fn() -> (Request, Response)>,
 }
 
-impl<C : CommandCreatorSync + 'static> ClientConnection<C> {
-    /// Create a new `ClientConnection`.
-    fn new(sock: TcpStream, token: Token) -> ClientConnection<C> {
-        ClientConnection {
-            sock: sock,
-            token: token,
-            interest: EventSet::hup(),
-            // Arbitrary, should ideally hold a full `ClientRequest`.
-            recv_buf: Vec::with_capacity(2048),
-            send_queue: vec!(),
-            task: None,
-        }
+impl<Request, Response> ProtobufCodec<Request, Response>
+    where Request: protobuf::Message + protobuf::MessageStatic,
+          Response: protobuf::Message,
+{
+    fn new() -> ProtobufCodec<Request, Response> {
+        ProtobufCodec { _marker: marker::PhantomData }
     }
+}
 
-    /// Handle read event from event loop.
-    ///
-    /// If a full request was read, return `Ok(Some(ClientRequest))`.
-    /// If data was read but not a full request, return `Ok(None)`.
-    fn read(&mut self, event_loop : &mut EventLoop<SccacheServer<C>>) -> io::Result<Option<ClientRequest>> {
-        //FIXME: use something from bytes:
-        // http://carllerche.github.io/bytes/bytes/index.html
-        let mut buf : [u8; 2048] = [0; 2048];
-        loop {
-            match self.sock.try_read(&mut buf) {
-                Ok(None) => {
-                    // Read all available data.
-                    trace!("try_read returned Ok(None)");
-                    break;
-                },
-                Ok(Some(n)) => {
-                    trace!("try_read read {} bytes", n);
-                    self.recv_buf.extend_from_slice(&buf[..n])
-                },
-                Err(e) => {
-                    error!("Error reading from client socket: {}", e);
-                    return Err(e);
-                }
-            }
+impl<Request, Response> Codec for ProtobufCodec<Request, Response>
+    where Request: protobuf::Message + protobuf::MessageStatic,
+          Response: protobuf::Message,
+{
+    type In = Request;
+    type Out = Response;
+
+    fn decode(&mut self, buf: &mut EasyBuf) -> io::Result<Option<Request>> {
+        if buf.as_slice().len() == 0 {
+            return Ok(None)
         }
-
-        try!(self.reregister(event_loop));
-
-        parse_length_delimited_from_bytes::<ClientRequest>(&self.recv_buf)
-            .and_then(|req| {
-                self.recv_buf.drain(..(req.compute_size() as usize));
+        match parse_length_delimited_from_bytes::<Request>(buf.as_slice()) {
+            Ok(req) => {
+                let size = req.write_length_delimited_to_bytes().unwrap().len();
+                buf.drain_to(size);
                 Ok(Some(req))
-            })
-            .or_else(|err| match err {
-                // Unexpected EOF is OK, just means we haven't read enough
-                // bytes. It would be nice if this were discriminated more
-                // usefully.
-                // Issue filed: https://github.com/stepancheg/rust-protobuf/issues/154
-                ProtobufError::WireError(s) => {
-                    if s == "truncated message" {
-                        Ok(None)
-                    } else {
-                        Err(io::Error::new(ErrorKind::Other, s))
-                    }
-                },
-                ProtobufError::IoError(ioe) => Err(ioe),
-                ProtobufError::MessageNotInitialized { message } => Err(io::Error::new(ErrorKind::Other, message)),
-            })
-    }
-
-    /// Handle a writable event from the event loop.
-    fn write(&mut self, event_loop : &mut EventLoop<SccacheServer<C>>) -> io::Result<()> {
-        //FIXME: use something from bytes.
-        // http://carllerche.github.io/bytes/bytes/index.html
-        match self.send_queue.first_mut() {
-            None => Err(io::Error::new(ErrorKind::Other,
-                                   "Could not get item from send queue")),
-            Some(buf) => {
-                match self.sock.try_write(buf) {
-                    Ok(None) => {
-                        trace!("try_write wrote no bytes?");
-                        // Try again
-                        Ok(None)
-                    },
-                    Ok(Some(n)) => {
-                        trace!("try_write wrote {} bytes", n);
-                        if n == buf.len() {
-                            Ok(Some(()))
-                        } else {
-                            buf.drain(..n);
-                            Ok(None)
-                        }
-                    },
-                    Err(e) => {
-                        error!("Error writing to client socket: {}", e);
-                        Err(e)
-                    }
+            }
+            // Unexpected EOF is OK, just means we haven't read enough
+            // bytes. It would be nice if this were discriminated more
+            // usefully.
+            // Issue filed: https://github.com/stepancheg/rust-protobuf/issues/154
+            Err(ProtobufError::WireError(s)) => {
+                if s == "truncated message" {
+                    Ok(None)
+                } else {
+                    Err(io::Error::new(ErrorKind::Other, s))
                 }
-            },
+            }
+            Err(ProtobufError::IoError(ioe)) => Err(ioe),
+            Err(ProtobufError::MessageNotInitialized { message }) => {
+                Err(io::Error::new(ErrorKind::Other, message))
+            }
         }
-        .and_then(|res : Option<()>| {
-            match res {
-                Some(_) => self.send_queue.pop()
-                    .and(Some(()))
-                    .ok_or_else(|| io::Error::new(ErrorKind::Other,
-                                      "Could not pop item from send queue")),
-                _ => Ok(()),
-            }
-        })
-        .and_then(|_| {
-            if self.send_queue.is_empty() {
-                self.interest.remove(EventSet::writable());
-            }
-            self.reregister(event_loop)
-        })
     }
 
-    /// Queue an outgoing message to the client.
-    fn send(&mut self, res: ServerResponse, event_loop: &mut EventLoop<SccacheServer<C>>) -> io::Result<()> {
-        let msg = try!(res.write_length_delimited_to_bytes().or_else(|err| {
-            error!("Error serializing message: {:?}", err);
-            match err {
-                ProtobufError::IoError(ioe) => Err(ioe),
-                ProtobufError::WireError(s) => Err(io::Error::new(ErrorKind::Other, s)),
-                ProtobufError::MessageNotInitialized { message } => Err(io::Error::new(ErrorKind::Other, message)),
+    fn encode(&mut self, msg: Response, buf: &mut Vec<u8>) -> io::Result<()> {
+        let bytes = msg.write_length_delimited_to_bytes().map_err(|e| {
+            io::Error::new(io::ErrorKind::Other, e)
+        })?;
+        buf.extend_from_slice(&bytes);
+        Ok(())
+    }
+}
+
+struct ShutdownOrInactive {
+    rx: mpsc::Receiver<ServerMessage>,
+    handle: Handle,
+    timeout: Timeout,
+    timeout_dur: Duration,
+}
+
+impl Future for ShutdownOrInactive {
+    type Item = ();
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<(), io::Error> {
+        loop {
+            match self.rx.poll().unwrap() {
+                Async::NotReady => break,
+                // Shutdown received!
+                Async::Ready(Some(ServerMessage::Shutdown)) => return Ok(().into()),
+                Async::Ready(Some(ServerMessage::Request)) => {
+                    self.timeout = Timeout::new(self.timeout_dur, &self.handle)?;
+                }
+                // All services have shut down, in theory this isn't possible...
+                Async::Ready(None) => return Ok(().into()),
             }
+        }
+        self.timeout.poll()
+    }
+}
+
+/// Helper future which tracks the `ActiveInfo` below. This future will resolve
+/// once all instances of `ActiveInfo` have been dropped.
+struct WaitUntilZero {
+    info: Rc<RefCell<Info>>,
+}
+
+struct ActiveInfo {
+    info: Rc<RefCell<Info>>,
+}
+
+struct Info {
+    active: usize,
+    blocker: Option<Task>,
+}
+
+impl WaitUntilZero {
+    fn new() -> (WaitUntilZero, ActiveInfo) {
+        let info = Rc::new(RefCell::new(Info {
+            active: 1,
+            blocker: None,
         }));
-        trace!("ClientConnection::send: queueing {} bytes", msg.len());
-        self.send_queue.push(msg);
-        self.interest.insert(EventSet::writable());
-        self.reregister(event_loop)
-    }
 
-    /// Set `task` as this client's current background task.
-    fn set_task(&mut self, task: Task<C>) {
-        self.task = Some(task);
-    }
-
-    /// Take this client's current background task.
-    fn take_task(&mut self) -> Option<Task<C>> {
-        self.task.take()
-    }
-
-    /// Register interest in read events with the event_loop.
-    fn register(&mut self, event_loop: &mut EventLoop<SccacheServer<C>>) -> io::Result<()> {
-        self.interest.insert(EventSet::readable());
-
-        event_loop.register(
-            &self.sock,
-            self.token,
-            self.interest,
-            PollOpt::edge() | PollOpt::oneshot()
-        )
-    }
-
-    /// Re-register interest in read events with the event_loop.
-    fn reregister(&mut self, event_loop: &mut EventLoop<SccacheServer<C>>) -> io::Result<()> {
-        trace!("ClientConnection::reregister: interest: {:?}", self.interest);
-        event_loop.reregister(
-            &self.sock,
-            self.token,
-            self.interest,
-            PollOpt::edge() | PollOpt::oneshot()
-        )
+        (WaitUntilZero { info: info.clone() }, ActiveInfo { info: info })
     }
 }
 
-/// Create an sccache server, listening on `port`, using `storage` as cache storage.
-pub fn create_server<C : CommandCreatorSync + 'static>(port: u16, storage: Box<Storage>) -> io::Result<(SccacheServer<C>, EventLoop<SccacheServer<C>>)> {
-    EventLoop::new()
-        .or_else(|e| {
-            error!("event loop creation failed: {}", e); Err(e)
-        })
-        .and_then(|event_loop| {
-            SccacheServer::new(port, storage).and_then(|server| Ok((server, event_loop)))
-        })
+impl Clone for ActiveInfo {
+    fn clone(&self) -> ActiveInfo {
+        self.info.borrow_mut().active += 1;
+        ActiveInfo { info: self.info.clone() }
+    }
 }
 
-/// Run `server`, handling client connections until shutdown is requested.
-pub fn run_server<C : CommandCreatorSync + 'static>(mut server : SccacheServer<C>, mut event_loop : EventLoop<SccacheServer<C>>) -> io::Result<()> {
-    try!(server.register(&mut event_loop).or_else(|e| {
-        error!("server event loop registration failed: {}", e);
-        Err(e)
-    }));
-    try!(event_loop.run(&mut server).or_else(|e| {
-        error!("failed to run event loop: {}", e);
-        Err(e)
-    }));
-    Ok(())
-}
-
-fn notify_server_startup_internal<W: Write>(mut w: W, success: bool) -> io::Result<()> {
-    let data = [ if success { 0 } else { 1 }; 1];
-    try!(w.write_all(&data));
-    Ok(())
-}
-
-#[cfg(unix)]
-fn notify_server_startup(name: &OsStr, success: bool) -> io::Result<()> {
-    use std::os::unix::net::UnixStream;
-    debug!("notify_server_startup(success: {})", success);
-    let stream = try!(UnixStream::connect(name));
-    notify_server_startup_internal(stream, success)
-}
-
-#[cfg(windows)]
-fn notify_server_startup(name: &OsStr, success: bool) -> io::Result<()> {
-    use named_pipe::PipeClient;
-    let pipe = try!(PipeClient::connect(name));
-    notify_server_startup_internal(pipe, success)
-}
-
-/// Start an sccache server, listening on `port`.
-///
-/// Spins an event loop handling client connections until a client
-/// requests a shutdown.
-pub fn start_server(port : u16) -> io::Result<()> {
-    debug!("start_server");
-    let notify = env::var_os("SCCACHE_STARTUP_NOTIFY");
-    let (server, event_loop) = try!(create_server::<ProcessCommandCreator>(port, storage_from_environment()).or_else(|e| {
-        error!("failed to create server: {}", e);
-        if let Some(ref name) = notify {
-            try!(notify_server_startup(name, false));
+impl Drop for ActiveInfo {
+    fn drop(&mut self) {
+        let mut info = self.info.borrow_mut();
+        info.active -= 1;
+        if info.active == 0 {
+            if let Some(task) = info.blocker.take() {
+                task.unpark();
+            }
         }
-        Err(e)
-    }));
-    if let Some(ref name) = notify {
-        try!(notify_server_startup(name, true));
     }
-    run_server(server, event_loop)
+}
+
+impl Future for WaitUntilZero {
+    type Item = ();
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<(), io::Error> {
+        let mut info = self.info.borrow_mut();
+        if info.active == 0 {
+            Ok(().into())
+        } else {
+            info.blocker = Some(task::park());
+            Ok(Async::NotReady)
+        }
+    }
 }


### PR DESCRIPTION
This commit rewrites the `server` module of sccache to be backed with Tokio. The
previous version was written with `mio`, which Tokio is built on, but is
unfortunately less ergonomic. Tokio is the state-of-the-art for asynchronous
programming in Rust and sccache serves as a great testing ground for ergonomics!

It's intended that the support added here will eventually extend to many other
operations that sccache does as well. For example thread spawning has all been
replaced with `CpuPool` to have a shared pool for I/O operations and such
(namely the filesystem). Eventually the HTTP requests made by the S3 backend can
be integrated with the Tokio branch of Hyper as well to run that on the event
loop instead of in a worker thread. I'd also like to eventually extend this with
`tokio-process` as well to move process spawning off helper threads as well, but
I'm leaving that to a future commit as well.

Overall I found the transition was quite smooth, with the high level
architecture look like:

* The `tokio-proto` crate is used in streaming mode. The streaming part is used
  for the one RPC sccache gets which requires a second response to be sent later
  on. This second response is the "response body" in tokio-proto terms.
* All of sccache's logic is manifested in an implementation of the `Service`
  trait.
* The transport layer is provided with `tokio_core::io::{Framed, Codec}`, and
  simple deserialization/serialization is performed with protobuf.

Some differences in design are:

* The `SccacheService` for now is just a bunch of reference-counted pointers,
  making it cheap to clone. As the futures it returns progress they will each
  retain a reference to a cloned copy of the `SccacheService`. Before all this
  data was just stored and manipulated in a struct directly, but it's now
  directly managed through shared memory.
* The storage backends share a thread pool with the main server instead of
  spawning threads.

And finally, some things I've learned along the way:

* Sharing data between futures isn't a trivial operation. It took an explicit
  decision to use `Rc` and I'm not sure I'm 100% happy with how the ergonomics
  played out.
* Shutdown is pretty tricky here. I've tried to carry over all the previous
  logic but it definitely required not using `TcpServer` in tokio-proto at the
  very least, and otherwise required a few custom futures and such to track the
  various states. I have a hunch that tokio-proto could provide more options out
  of the box for something like this.
* Getting a transport up and running isn't always the easiest. I wanted
  to use sink/stream combinators here but was unable to unfortunately.