### PR TITLE
Fix a regression in us-east-1 buckets

### DIFF
--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -187,7 +187,7 @@ pub fn storage_from_environment() -> Box<Storage> {
             _ => match env::var("SCCACHE_REGION") {
                 Ok(ref region) if region != "us-east-1" =>
                     format!("{}.s3-{}.amazonaws.com", bucket, region),
-                _ => String::from("s3.amazonaws.com"),
+                _ => format!("{}.s3.amazonaws.com", bucket),
             },
         };
         debug!("Trying S3Cache({})", endpoint);


### PR DESCRIPTION
It looks like the logic in #27 changed the default host name from
$bucket.s3.amazonaws.com to s3.amazonaws.com, but didn't accompany with changes
to upload to /$bucket in the path name. This restores the original behavior by
uploading to $bucket.s3.amazonaws.com without requiring changes to how paths are
constructed.