### PR TITLE
Add support for caching Rust compilations. Fixes #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ sccache - Shared Compilation Cache
 
 Sccache is a [ccache](https://ccache.samba.org/)-like tool. It is used as a compiler wrapper and avoids compilation when possible, storing a cache in a remote storage using the S3 API.
 
+Sccache now includes [experimental Rust support](docs/Rust.md).
+
 It works as a client-server. The client spawns a server if one is not running already, and sends the wrapped command line as a request to the server, which then does the work and returns stdout/stderr for the job.  The client-server model allows the server to be more efficient in its handling of the remote storage.
 
 Sccache can also be used with local storage instead of remote.

--- a/docs/Rust.md
+++ b/docs/Rust.md
@@ -1,0 +1,10 @@
+sccache now includes experimental support for caching Rust compilation. This includes many caveats, and is primarily focused on caching rustc invocations as produced by cargo. A (possibly-incomplete) list follows:
+* `--emit` is required.
+* Only `link` and `dep-info` are supported as `--emit` values, and `link` must be present.
+* `--out-dir` is required.
+* `-o file` is not supported.
+* Compilation from stdin is not supported, a source file must be provided.
+* Values from `env!` will not be tracked in caching.
+* Procedural macros that read files from the filesystem may not be cached properly
+* The system linker is not factored in as a cache input, so changing the linker may produce incorrect cached results.
+* Target specs aren't hashed (e.g. custom target specs)

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -264,7 +264,7 @@ fn test_parse_size() {
 #[cfg(test)]
 mod test {
     use super::*;
-    use compiler::{CompilerInfo,CompilerKind};
+    use compiler::{CompilerInfo, get_gcc};
     use std::env;
     use std::io::Write;
     use test::utils::*;
@@ -273,10 +273,10 @@ mod test {
     fn test_hash_key_executable_contents_differs() {
         let f = TestFixture::new();
         // Try to avoid testing exact hashes.
-        let c1 = CompilerInfo::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
+        let c1 = CompilerInfo::new(f.bins[0].to_str().unwrap(), get_gcc()).unwrap();
         // Overwrite the contents of the binary.
         mk_bin_contents(f.tempdir.path(), "a/bin", |mut f| f.write_all(b"hello")).unwrap();
-        let c2 = CompilerInfo::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
+        let c2 = CompilerInfo::new(f.bins[0].to_str().unwrap(), get_gcc()).unwrap();
         let args = "a b c";
         const PREPROCESSED : &'static [u8] = b"hello world";
         assert_neq!(hash_key(&c1.digest, &args, &PREPROCESSED),
@@ -286,7 +286,7 @@ mod test {
     #[test]
     fn test_hash_key_args_differs() {
         let f = TestFixture::new();
-        let c = CompilerInfo::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
+        let c = CompilerInfo::new(f.bins[0].to_str().unwrap(), get_gcc()).unwrap();
         const PREPROCESSED : &'static [u8] = b"hello world";
         assert_neq!(hash_key(&c.digest, "a b c", &PREPROCESSED),
                     hash_key(&c.digest, "x y z", &PREPROCESSED));
@@ -301,7 +301,7 @@ mod test {
     #[test]
     fn test_hash_key_preprocessed_content_differs() {
         let f = TestFixture::new();
-        let c = CompilerInfo::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
+        let c = CompilerInfo::new(f.bins[0].to_str().unwrap(), get_gcc()).unwrap();
         let args = "a b c";
         assert_neq!(hash_key(&c.digest, &args, &b"hello world"[..]),
                     hash_key(&c.digest, &args, &b"goodbye"[..]));
@@ -310,7 +310,7 @@ mod test {
     #[test]
     fn test_hash_key_env_var_differs() {
         let f = TestFixture::new();
-        let c = CompilerInfo::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
+        let c = CompilerInfo::new(f.bins[0].to_str().unwrap(), get_gcc()).unwrap();
         let args = "a b c";
         const PREPROCESSED : &'static [u8] = b"hello world";
         for var in CACHED_ENV_VARS.iter() {

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -21,7 +21,6 @@ use cache::disk::DiskCache;
 use cache::s3::S3Cache;
 use futures_cpupool::CpuPool;
 use regex::Regex;
-use sha1;
 use std::env;
 use std::fmt;
 use std::io::{
@@ -220,37 +219,6 @@ pub fn storage_from_environment(pool: &CpuPool, handle: &Handle) -> Arc<Storage>
     Arc::new(DiskCache::new(&d, cache_size, pool))
 }
 
-/// The cache is versioned by the inputs to `hash_key`.
-pub const CACHE_VERSION : &'static [u8] = b"3";
-
-/// Environment variables that are factored into the cache key.
-pub const CACHED_ENV_VARS : &'static [&'static str] = &[
-    "MACOSX_DEPLOYMENT_TARGET",
-    "IPHONEOS_DEPLOYMENT_TARGET",
-];
-
-/// Compute the hash key of `compiler` compiling `preprocessor_output` with `args`.
-#[allow(dead_code)]
-pub fn hash_key(compiler_digest: &str, arguments: &str, preprocessor_output: &[u8]) -> String {
-    // If you change any of the inputs to the hash, you should change `CACHE_VERSION`.
-    let mut m = sha1::Sha1::new();
-    m.update(compiler_digest.as_bytes());
-    m.update(CACHE_VERSION);
-    m.update(arguments.as_bytes());
-    //TODO: should propogate these over from the client.
-    // https://github.com/glandium/sccache/issues/5
-    for var in CACHED_ENV_VARS.iter() {
-        if let Ok(val) = env::var(var) {
-            m.update(var.as_bytes());
-            m.update(&b"="[..]);
-            m.update(val.as_bytes());
-        }
-    }
-    m.update(preprocessor_output);
-    m.digest().to_string()
-}
-
-
 #[test]
 fn test_parse_size() {
     assert_eq!(None, parse_size(""));
@@ -259,74 +227,4 @@ fn test_parse_size() {
     assert_eq!(Some(10 * 1024 * 1024), parse_size("10M"));
     assert_eq!(Some(TEN_GIGS), parse_size("10G"));
     assert_eq!(Some(1024 * TEN_GIGS), parse_size("10T"));
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use compiler::{CompilerInfo, get_gcc};
-    use std::env;
-    use std::io::Write;
-    use test::utils::*;
-
-    #[test]
-    fn test_hash_key_executable_contents_differs() {
-        let f = TestFixture::new();
-        // Try to avoid testing exact hashes.
-        let c1 = CompilerInfo::new(f.bins[0].to_str().unwrap(), get_gcc()).unwrap();
-        // Overwrite the contents of the binary.
-        mk_bin_contents(f.tempdir.path(), "a/bin", |mut f| f.write_all(b"hello")).unwrap();
-        let c2 = CompilerInfo::new(f.bins[0].to_str().unwrap(), get_gcc()).unwrap();
-        let args = "a b c";
-        const PREPROCESSED : &'static [u8] = b"hello world";
-        assert_neq!(hash_key(&c1.digest, &args, &PREPROCESSED),
-                    hash_key(&c2.digest, &args, &PREPROCESSED));
-    }
-
-    #[test]
-    fn test_hash_key_args_differs() {
-        let f = TestFixture::new();
-        let c = CompilerInfo::new(f.bins[0].to_str().unwrap(), get_gcc()).unwrap();
-        const PREPROCESSED : &'static [u8] = b"hello world";
-        assert_neq!(hash_key(&c.digest, "a b c", &PREPROCESSED),
-                    hash_key(&c.digest, "x y z", &PREPROCESSED));
-
-        assert_neq!(hash_key(&c.digest, "a b c", &PREPROCESSED),
-                    hash_key(&c.digest, "a b", &PREPROCESSED));
-
-        assert_neq!(hash_key(&c.digest, "a b c", &PREPROCESSED),
-                    hash_key(&c.digest, "a", &PREPROCESSED));
-    }
-
-    #[test]
-    fn test_hash_key_preprocessed_content_differs() {
-        let f = TestFixture::new();
-        let c = CompilerInfo::new(f.bins[0].to_str().unwrap(), get_gcc()).unwrap();
-        let args = "a b c";
-        assert_neq!(hash_key(&c.digest, &args, &b"hello world"[..]),
-                    hash_key(&c.digest, &args, &b"goodbye"[..]));
-    }
-
-    #[test]
-    fn test_hash_key_env_var_differs() {
-        let f = TestFixture::new();
-        let c = CompilerInfo::new(f.bins[0].to_str().unwrap(), get_gcc()).unwrap();
-        let args = "a b c";
-        const PREPROCESSED : &'static [u8] = b"hello world";
-        for var in CACHED_ENV_VARS.iter() {
-            let old = env::var_os(var);
-            env::remove_var(var);
-            let h1 = hash_key(&c.digest, &args, &PREPROCESSED);
-            env::set_var(var, "something");
-            let h2 = hash_key(&c.digest, &args, &PREPROCESSED);
-            env::set_var(var, "something else");
-            let h3 = hash_key(&c.digest, &args, &PREPROCESSED);
-            match old {
-                Some(val) => env::set_var(var, val),
-                None => env::remove_var(var),
-            }
-            assert_neq!(h1, h2);
-            assert_neq!(h2, h3);
-        }
-    }
 }

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -264,7 +264,7 @@ fn test_parse_size() {
 #[cfg(test)]
 mod test {
     use super::*;
-    use compiler::{Compiler,CompilerKind};
+    use compiler::{CompilerInfo,CompilerKind};
     use std::env;
     use std::io::Write;
     use test::utils::*;
@@ -273,10 +273,10 @@ mod test {
     fn test_hash_key_executable_contents_differs() {
         let f = TestFixture::new();
         // Try to avoid testing exact hashes.
-        let c1 = Compiler::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
+        let c1 = CompilerInfo::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
         // Overwrite the contents of the binary.
         mk_bin_contents(f.tempdir.path(), "a/bin", |mut f| f.write_all(b"hello")).unwrap();
-        let c2 = Compiler::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
+        let c2 = CompilerInfo::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
         let args = "a b c";
         const PREPROCESSED : &'static [u8] = b"hello world";
         assert_neq!(hash_key(&c1.digest, &args, &PREPROCESSED),
@@ -286,7 +286,7 @@ mod test {
     #[test]
     fn test_hash_key_args_differs() {
         let f = TestFixture::new();
-        let c = Compiler::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
+        let c = CompilerInfo::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
         const PREPROCESSED : &'static [u8] = b"hello world";
         assert_neq!(hash_key(&c.digest, "a b c", &PREPROCESSED),
                     hash_key(&c.digest, "x y z", &PREPROCESSED));
@@ -301,7 +301,7 @@ mod test {
     #[test]
     fn test_hash_key_preprocessed_content_differs() {
         let f = TestFixture::new();
-        let c = Compiler::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
+        let c = CompilerInfo::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
         let args = "a b c";
         assert_neq!(hash_key(&c.digest, &args, &b"hello world"[..]),
                     hash_key(&c.digest, &args, &b"goodbye"[..]));
@@ -310,7 +310,7 @@ mod test {
     #[test]
     fn test_hash_key_env_var_differs() {
         let f = TestFixture::new();
-        let c = Compiler::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
+        let c = CompilerInfo::new(f.bins[0].to_str().unwrap(), CompilerKind::Gcc).unwrap();
         let args = "a b c";
         const PREPROCESSED : &'static [u8] = b"hello world";
         for var in CACHED_ENV_VARS.iter() {

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -1,0 +1,145 @@
+// Copyright 2016 Mozilla Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cache::hash_key;
+use compiler::{Cacheable, Compiler, CompilerArguments, CompilerKind, Compilation, HashResult, ParsedArguments};
+use futures::Future;
+use futures_cpupool::CpuPool;
+use mock_command::CommandCreatorSync;
+use std::path::Path;
+use std::process;
+
+use errors::*;
+
+/// A generic implementation of the `Compiler` trait for C/C++ compilers.
+#[derive(Clone)]
+pub struct CCompiler<I: CCompilerImpl>(pub I);
+
+/// A generic implementation of the `Compilation` trait for C/C++ compilers.
+struct CCompilation<I: CCompilerImpl> {
+    /// The output from running the preprocessor.
+    preprocessor_output: Vec<u8>,
+    compiler: I,
+}
+
+/// An interface to a specific C compiler.
+pub trait CCompilerImpl: Clone + Send + 'static {
+    /// Return the kind of compiler.
+    fn kind(&self) -> CompilerKind;
+    /// Determine whether `arguments` are supported by this compiler.
+    fn parse_arguments(&self,
+                       arguments: &[String],
+                       cwd: &Path) -> CompilerArguments;
+    /// Run the C preprocessor with the specified set of arguments.
+    fn preprocess<T>(&self,
+                     creator: &T,
+                     executable: &str,
+                     parsed_args: &ParsedArguments,
+                     cwd: &str,
+                     pool: &CpuPool)
+                     -> SFuture<process::Output> where T: CommandCreatorSync;
+    /// Run the C compiler with the specified set of arguments, using the
+    /// previously-generated `preprocessor_output` as input if possible.
+    fn compile<T>(&self,
+                  creator: &T,
+                  executable: &str,
+                  preprocessor_output: Vec<u8>,
+                  parsed_args: &ParsedArguments,
+                  cwd: &str,
+                  pool: &CpuPool)
+                  -> SFuture<(Cacheable, process::Output)>
+        where T: CommandCreatorSync;
+}
+
+impl<T: CommandCreatorSync, I: CCompilerImpl> Compiler<T> for CCompiler<I> {
+    fn kind(&self) -> CompilerKind { self.0.kind() }
+    fn parse_arguments(&self,
+                       arguments: &[String],
+                       cwd: &Path) -> CompilerArguments {
+        self.0.parse_arguments(arguments, cwd)
+    }
+
+    fn generate_hash_key(&self,
+                         creator: &T,
+                         executable: &str,
+                         executable_digest: &str,
+                         parsed_args: &ParsedArguments,
+                         cwd: &str,
+                         pool: &CpuPool)
+                         -> SFuture<HashResult<T>>
+    {
+        let result = self.0.preprocess(creator, executable, parsed_args, cwd, pool);
+        let parsed_args = parsed_args.clone();
+        let out_file = parsed_args.output_file().into_owned();
+        let result = result.map_err(move |e| {
+            debug!("[{}]: preprocessor failed: {:?}", out_file, e);
+            e
+        });
+        let executable_digest = executable_digest.to_string();
+        let compiler = self.0.clone();
+
+        Box::new(result.map(move |preprocessor_result| {
+            // If the preprocessor failed, just return that result.
+            if !preprocessor_result.status.success() {
+                debug!("[{}]: preprocessor returned error status {:?}",
+                       parsed_args.output_file(),
+                       preprocessor_result.status.code());
+                // Drop the stdout since it's the preprocessor output, just hand back stderr and the exit status.
+                let output = process::Output {
+                    stdout: vec!(),
+                    .. preprocessor_result
+                };
+                return HashResult::Error { output: output };
+            }
+            trace!("[{}]: Preprocessor output is {} bytes",
+                   parsed_args.output_file(),
+                   preprocessor_result.stdout.len());
+
+            // Remove object file from arguments before hash calculation
+            let key = {
+                let out_file = parsed_args.output_file();
+                let arguments = parsed_args.common_args.iter()
+                    .filter(|a| **a != out_file)
+                    .map(|a| a.as_str())
+                    .collect::<String>();
+                hash_key(&executable_digest, &arguments, &preprocessor_result.stdout)
+            };
+            HashResult::Ok {
+                key: key,
+                compilation: Box::new(CCompilation {
+                    preprocessor_output: preprocessor_result.stdout,
+                    compiler: compiler,
+                }),
+            }
+        }))
+    }
+    fn box_clone(&self) -> Box<Compiler<T>> {
+        Box::new((*self).clone())
+    }
+}
+
+impl<T: CommandCreatorSync, I: CCompilerImpl> Compilation<T> for CCompilation<I> {
+    fn compile(self: Box<Self>,
+               creator: &T,
+               executable: &str,
+               parsed_args: &ParsedArguments,
+               cwd: &str,
+               pool: &CpuPool)
+               -> SFuture<(Cacheable, process::Output)>
+    {
+        let me = *self;
+        let CCompilation { preprocessor_output, compiler } = me;
+        compiler.compile(creator, executable, preprocessor_output, parsed_args, cwd, pool)
+    }
+}

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -17,7 +17,6 @@
 use ::compiler::{
     gcc,
     Cacheable,
-    Compiler,
     CompilerArguments,
     ParsedArguments,
     run_input_output,
@@ -49,7 +48,7 @@ pub fn argument_takes_value(arg: &str) -> bool {
 }
 
 pub fn compile<T>(creator: &T,
-                  compiler: &Compiler,
+                  compiler: &str,
                   preprocessor_output: Vec<u8>,
                   parsed_args: &ParsedArguments,
                   cwd: &str,
@@ -75,7 +74,7 @@ pub fn compile<T>(creator: &T,
         }
     };
 
-    let mut attempt = creator.clone().new_command_sync(&compiler.executable);
+    let mut attempt = creator.clone().new_command_sync(compiler);
     attempt.arg("-c")
         .arg("-o")
         .arg(&out_file)
@@ -98,7 +97,7 @@ pub fn compile<T>(creator: &T,
         return Box::new(output.map(|output| (Cacheable::Yes, output)))
     }
 
-    let mut cmd = creator.clone().new_command_sync(&compiler.executable);
+    let mut cmd = creator.clone().new_command_sync(compiler);
     cmd.arg("-c")
         .arg(&parsed_args.input)
         .arg("-o")
@@ -178,8 +177,7 @@ mod test {
             preprocessor_args: vec!(),
             common_args: vec!(),
         };
-        let compiler = Compiler::new(f.bins[0].to_str().unwrap(),
-                                     CompilerKind::Clang).unwrap();
+        let compiler = f.bins[0].to_str().unwrap();
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));
         let (cacheable, _) = compile(&creator,
@@ -206,8 +204,7 @@ mod test {
             preprocessor_args: vec!(),
             common_args: stringvec!("-c", "-o", "foo.o", "-Werror=blah", "foo.c"),
         };
-        let compiler = Compiler::new(f.bins[0].to_str().unwrap(),
-                                     CompilerKind::Clang).unwrap();
+        let compiler = f.bins[0].to_str().unwrap();
         // First compiler invocation fails.
         next_command(&creator, Ok(MockChild::new(exit_status(1), "", "")));
         // Second compiler invocation succeeds.

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -19,11 +19,10 @@ use ::compiler::{
     Cacheable,
     CompilerArguments,
     CompilerKind,
-    ParsedArguments,
     run_input_output,
     write_temp_file,
 };
-use compiler::c::CCompilerImpl;
+use compiler::c::{CCompilerImpl, ParsedArguments};
 use futures::future::{self, Future};
 use futures_cpupool::CpuPool;
 use mock_command::{
@@ -42,14 +41,14 @@ use std::process;
 use errors::*;
 
 /// A unit struct on which to implement `CCompilerImpl`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Clang;
 
 impl CCompilerImpl for Clang {
     fn kind(&self) -> CompilerKind { CompilerKind::Clang }
     fn parse_arguments(&self,
                        arguments: &[String],
-                       cwd: &Path) -> CompilerArguments
+                       cwd: &Path) -> CompilerArguments<ParsedArguments>
     {
         gcc::parse_arguments(arguments, cwd, argument_takes_value)
     }
@@ -166,7 +165,7 @@ mod test {
     use super::*;
     use test::utils::*;
 
-    fn _parse_arguments(arguments: &[String]) -> CompilerArguments {
+    fn _parse_arguments(arguments: &[String]) -> CompilerArguments<ParsedArguments> {
         gcc::parse_arguments(arguments, ".".as_ref(), argument_takes_value)
     }
 

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -18,11 +18,10 @@ use ::compiler::{
     gcc,
     Cacheable,
     CompilerArguments,
-    CompilerKind,
     run_input_output,
     write_temp_file,
 };
-use compiler::c::{CCompilerImpl, ParsedArguments};
+use compiler::c::{CCompilerImpl, CCompilerKind, ParsedArguments};
 use futures::future::{self, Future};
 use futures_cpupool::CpuPool;
 use mock_command::{
@@ -45,7 +44,7 @@ use errors::*;
 pub struct Clang;
 
 impl CCompilerImpl for Clang {
-    fn kind(&self) -> CompilerKind { CompilerKind::Clang }
+    fn kind(&self) -> CCompilerKind { CCompilerKind::Clang }
     fn parse_arguments(&self,
                        arguments: &[String],
                        cwd: &Path) -> CompilerArguments<ParsedArguments>

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -148,7 +148,7 @@ fn compile<T>(creator: &T,
                 (Cacheable::Yes, output)
             }))
         } else {
-            future::ok((Cacheable::Yes, output)).boxed()
+            f_ok((Cacheable::Yes, output))
         }
     }))
 }

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -14,7 +14,6 @@
 
 use ::compiler::{
     Cacheable,
-    Compiler,
     CompilerArguments,
     ParsedArguments,
     run_input_output,
@@ -192,7 +191,7 @@ fn _parse_arguments(arguments: &[String],
 }
 
 pub fn preprocess<T>(creator: &T,
-                     compiler: &Compiler,
+                     compiler: &str,
                      parsed_args: &ParsedArguments,
                      cwd: &str,
                      _pool: &CpuPool)
@@ -200,7 +199,7 @@ pub fn preprocess<T>(creator: &T,
     where T: CommandCreatorSync
 {
     trace!("preprocess");
-    let mut cmd = creator.clone().new_command_sync(&compiler.executable);
+    let mut cmd = creator.clone().new_command_sync(compiler);
     cmd.arg("-E")
         .arg(&parsed_args.input)
         .args(&parsed_args.preprocessor_args)
@@ -213,7 +212,7 @@ pub fn preprocess<T>(creator: &T,
 }
 
 pub fn compile<T>(creator: &T,
-                  compiler: &Compiler,
+                  compiler: &str,
                   preprocessor_output: Vec<u8>,
                   parsed_args: &ParsedArguments,
                   cwd: &str,
@@ -230,7 +229,7 @@ pub fn compile<T>(creator: &T,
         }
     };
 
-    let mut cmd = creator.clone().new_command_sync(&compiler.executable);
+    let mut cmd = creator.clone().new_command_sync(compiler);
     cmd.args(&["-c", "-x"])
         .arg(match parsed_args.extension.as_ref() {
             "c" => "cpp-output",

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -16,10 +16,9 @@ use ::compiler::{
     Cacheable,
     CompilerArguments,
     CompilerKind,
-    ParsedArguments,
     run_input_output,
 };
-use compiler::c::CCompilerImpl;
+use compiler::c::{CCompilerImpl, ParsedArguments};
 use log::LogLevel::Trace;
 use futures::future::{self, Future};
 use futures_cpupool::CpuPool;
@@ -36,14 +35,14 @@ use std::process;
 use errors::*;
 
 /// A unit struct on which to implement `CCompilerImpl`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GCC;
 
 impl CCompilerImpl for GCC {
     fn kind(&self) -> CompilerKind { CompilerKind::GCC }
     fn parse_arguments(&self,
                        arguments: &[String],
-                       cwd: &Path) -> CompilerArguments
+                       cwd: &Path) -> CompilerArguments<ParsedArguments>
     {
         parse_arguments(arguments, cwd, argument_takes_value)
     }
@@ -105,13 +104,13 @@ pub fn argument_takes_value(arg: &str) -> bool {
 pub fn parse_arguments<F: Fn(&str) -> bool>(arguments: &[String],
                                             cwd: &Path,
                                             argument_takes_value: F)
-                                            -> CompilerArguments {
+                                            -> CompilerArguments<ParsedArguments> {
     _parse_arguments(arguments, cwd, &argument_takes_value)
 }
 
 fn _parse_arguments(arguments: &[String],
                     cwd: &Path,
-                    argument_takes_value: &Fn(&str) -> bool) -> CompilerArguments {
+                    argument_takes_value: &Fn(&str) -> bool) -> CompilerArguments<ParsedArguments> {
     let mut output_arg = None;
     let mut input_arg = None;
     let mut dep_target = None;
@@ -359,7 +358,7 @@ mod test {
     use ::compiler::*;
     use tempdir::TempDir;
 
-    fn _parse_arguments(arguments: &[String]) -> CompilerArguments {
+    fn _parse_arguments(arguments: &[String]) -> CompilerArguments<ParsedArguments> {
         parse_arguments(arguments, ".".as_ref(), argument_takes_value)
     }
 

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -15,10 +15,9 @@
 use ::compiler::{
     Cacheable,
     CompilerArguments,
-    CompilerKind,
     run_input_output,
 };
-use compiler::c::{CCompilerImpl, ParsedArguments};
+use compiler::c::{CCompilerImpl, CCompilerKind, ParsedArguments};
 use log::LogLevel::Trace;
 use futures::future::{self, Future};
 use futures_cpupool::CpuPool;
@@ -39,7 +38,7 @@ use errors::*;
 pub struct GCC;
 
 impl CCompilerImpl for GCC {
-    fn kind(&self) -> CompilerKind { CompilerKind::GCC }
+    fn kind(&self) -> CCompilerKind { CCompilerKind::GCC }
     fn parse_arguments(&self,
                        arguments: &[String],
                        cwd: &Path) -> CompilerArguments<ParsedArguments>

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -17,5 +17,6 @@ mod clang;
 mod compiler;
 mod gcc;
 mod msvc;
+mod rust;
 
 pub use compiler::compiler::*;

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod c;
 mod clang;
 mod compiler;
 mod gcc;

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -14,7 +14,6 @@
 
 use ::compiler::{
     Cacheable,
-    Compiler,
     CompilerArguments,
     ParsedArguments,
     run_input_output,
@@ -249,7 +248,7 @@ fn normpath(path: &str) -> String {
 }
 
 pub fn preprocess<T>(creator: &T,
-                     compiler: &Compiler,
+                     compiler: &str,
                      parsed_args: &ParsedArguments,
                      cwd: &str,
                      includes_prefix: &str,
@@ -257,7 +256,7 @@ pub fn preprocess<T>(creator: &T,
                      -> SFuture<process::Output>
     where T: CommandCreatorSync
 {
-    let mut cmd = creator.clone().new_command_sync(&compiler.executable);
+    let mut cmd = creator.clone().new_command_sync(compiler);
     cmd.arg("-E")
         .arg(&parsed_args.input)
         .arg("-nologo")
@@ -315,7 +314,7 @@ pub fn preprocess<T>(creator: &T,
 }
 
 pub fn compile<T>(creator: &T,
-                  compiler: &Compiler,
+                  compiler: &str,
                   preprocessor_output: Vec<u8>,
                   parsed_args: &ParsedArguments,
                   cwd: &str,
@@ -353,7 +352,7 @@ pub fn compile<T>(creator: &T,
         write_temp_file(pool, filename.as_ref(), preprocessor_output)
     };
 
-    let mut cmd = creator.clone().new_command_sync(&compiler.executable);
+    let mut cmd = creator.clone().new_command_sync(compiler);
     cmd.arg("-c")
         .arg(&format!("-Fo{}", out_file))
         .args(&parsed_args.common_args)
@@ -372,7 +371,7 @@ pub fn compile<T>(creator: &T,
     //
     // We may just throw away this `cmd` if our execution turns out to be
     // successful.
-    let mut cmd = creator.clone().new_command_sync(&compiler.executable);
+    let mut cmd = creator.clone().new_command_sync(compiler);
     cmd.arg("-c")
         .arg(&parsed_args.input)
         .arg(&format!("-Fo{}", out_file))
@@ -542,8 +541,7 @@ mod test {
             preprocessor_args: vec!(),
             common_args: vec!(),
         };
-        let compiler = Compiler::new(f.bins[0].to_str().unwrap(),
-                                     CompilerKind::Msvc { includes_prefix: String::new() }).unwrap();
+        let compiler = f.bins[0].to_str().unwrap();
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));
         next_command(&creator, Ok(MockChild::new(exit_status(1), "", "")));
@@ -573,8 +571,7 @@ mod test {
             preprocessor_args: vec!(),
             common_args: vec!(),
         };
-        let compiler = Compiler::new(f.bins[0].to_str().unwrap(),
-                                     CompilerKind::Msvc { includes_prefix: String::new() }).unwrap();
+        let compiler = f.bins[0].to_str().unwrap();
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));
         next_command(&creator, Ok(MockChild::new(exit_status(1), "", "")));
@@ -602,8 +599,7 @@ mod test {
             preprocessor_args: vec!(),
             common_args: vec!(),
         };
-        let compiler = Compiler::new(f.bins[0].to_str().unwrap(),
-                                     CompilerKind::Msvc { includes_prefix: String::new() }).unwrap();
+        let compiler = f.bins[0].to_str().unwrap();
         // First compiler invocation fails.
         next_command(&creator, Ok(MockChild::new(exit_status(1), "", "")));
         // Second compiler invocation succeeds.

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -16,11 +16,10 @@ use ::compiler::{
     Cacheable,
     CompilerArguments,
     CompilerKind,
-    ParsedArguments,
     run_input_output,
     write_temp_file,
 };
-use compiler::c::CCompilerImpl;
+use compiler::c::{CCompilerImpl, ParsedArguments};
 use local_encoding::{Encoding, Encoder};
 use log::LogLevel::{Debug, Trace};
 use futures::future::{self, Future};
@@ -54,7 +53,7 @@ impl CCompilerImpl for MSVC {
     fn kind(&self) -> CompilerKind { CompilerKind::MSVC }
     fn parse_arguments(&self,
                        arguments: &[String],
-                       _cwd: &Path) -> CompilerArguments
+                       _cwd: &Path) -> CompilerArguments<ParsedArguments>
     {
         parse_arguments(arguments)
     }
@@ -144,7 +143,7 @@ pub fn detect_showincludes_prefix<T>(creator: &T, exe: &OsStr, pool: &CpuPool)
     }))
 }
 
-pub fn parse_arguments(arguments: &[String]) -> CompilerArguments {
+pub fn parse_arguments(arguments: &[String]) -> CompilerArguments<ParsedArguments> {
     let mut output_arg = None;
     let mut input_arg = None;
     let mut common_args = vec!();

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -21,7 +21,7 @@ use ::compiler::{
 use compiler::c::{CCompilerImpl, CCompilerKind, ParsedArguments};
 use local_encoding::{Encoding, Encoder};
 use log::LogLevel::{Debug, Trace};
-use futures::future::{self, Future};
+use futures::future::Future;
 use futures_cpupool::CpuPool;
 use mock_command::{
     CommandCreatorSync,
@@ -369,7 +369,7 @@ fn compile<T>(creator: &T,
     let out_file = match parsed_args.outputs.get("obj") {
         Some(obj) => obj,
         None => {
-            return future::err("Missing object file output".into()).boxed()
+            return f_err("Missing object file output")
         }
     };
 
@@ -390,7 +390,7 @@ fn compile<T>(creator: &T,
     let write = {
         let filename = match Path::new(&parsed_args.input).file_name() {
             Some(name) => name,
-            None => return future::err("missing input filename".into()).boxed(),
+            None => return f_err("missing input filename"),
         };
         write_temp_file(pool, filename.as_ref(), preprocessor_output)
     };
@@ -422,7 +422,7 @@ fn compile<T>(creator: &T,
         .current_dir(cwd);
     Box::new(output.and_then(move |output| -> SFuture<_> {
         if output.status.success() {
-            future::ok((cacheable, output)).boxed()
+            f_ok((cacheable, output))
         } else {
             debug!("compile: {:?}", cmd);
             Box::new(run_input_output(cmd, None).map(|output| {

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -15,11 +15,10 @@
 use ::compiler::{
     Cacheable,
     CompilerArguments,
-    CompilerKind,
     run_input_output,
     write_temp_file,
 };
-use compiler::c::{CCompilerImpl, ParsedArguments};
+use compiler::c::{CCompilerImpl, CCompilerKind, ParsedArguments};
 use local_encoding::{Encoding, Encoder};
 use log::LogLevel::{Debug, Trace};
 use futures::future::{self, Future};
@@ -50,7 +49,7 @@ pub struct MSVC {
 }
 
 impl CCompilerImpl for MSVC {
-    fn kind(&self) -> CompilerKind { CompilerKind::MSVC }
+    fn kind(&self) -> CCompilerKind { CCompilerKind::MSVC }
     fn parse_arguments(&self,
                        arguments: &[String],
                        _cwd: &Path) -> CompilerArguments<ParsedArguments>

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1,0 +1,750 @@
+// Copyright 2016 Mozilla Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use compiler::{Cacheable, Compiler, CompilerArguments, CompilerHasher, CompilerKind, Compilation,
+               HashResult, run_input_output};
+use futures::{Future, future};
+use futures_cpupool::CpuPool;
+use log::LogLevel::Trace;
+use mock_command::{CommandCreatorSync, RunCommand};
+use sha1;
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::Read;
+use std::iter::FromIterator;
+use std::path::{Path, PathBuf};
+use std::process;
+use tempdir::TempDir;
+use util::sha1_digest;
+
+use errors::*;
+
+/// A unit struct on which to hang a `Compiler` impl.
+#[derive(Debug, Clone)]
+pub struct Rust;
+
+/// A struct on which to hang a `CompilerHasher` impl.
+#[derive(Debug, Clone)]
+pub struct RustHasher {
+    /// The full commandline.
+    arguments: Vec<String>,
+    /// The commandline without any --emit or --out-dir arguments.
+    filtered_arguments: Vec<String>,
+    /// The location of compiler outputs.
+    output_dir: String,
+    /// Paths to extern crates used in the compile.
+    externs: Vec<String>,
+    /// The crate name passed to --crate-name.
+    crate_name: String,
+    /// If dependency info is being emitted, the name of the dep info file.
+    dep_info: Option<String>,
+}
+
+/// A struct on which to hang a `Compilation` impl.
+#[derive(Debug, Clone)]
+pub struct RustCompilation {
+    /// The full commandline.
+    arguments: Vec<String>,
+    /// The compiler outputs.
+    outputs: HashMap<String, String>,
+}
+
+/// Arguments that take a value.
+const ARGS_WITH_VALUE: &'static [&'static str] = &[
+    // These are taken from https://github.com/rust-lang/rust/blob/b671c32ddc8c36d50866428d83b7716233356721/src/librustc/session/config.rs#L1186
+    "--cfg",
+    "-L",
+    "-l",
+    "--crate-type",
+    "--crate-name",
+    "--emit",
+    "--print",
+    "-o",
+    "--out-dir",
+    "--explain",
+    "--target",
+    "-W", "--warn",
+    "-A", "--allow",
+    "-D", "--deny",
+    "-F", "--forbid",
+    "--cap-lints",
+    "-C", "--codegen",
+    "--extern",
+    "--sysroot",
+    "-Z",
+    "--error-format",
+    "--color",
+    "--pretty",
+    "--unpretty",
+];
+
+/// Emit types that we will cache.
+const ALLOWED_EMIT: &'static [&'static str] = &["link", "dep-info"];
+
+/// Version number for cache key.
+const CACHE_VERSION: &'static [u8] = b"1";
+
+/// Parse the value passed to a commandline argument `arg`, either after
+/// an '=' in `arg` or in the next argument from `it`.
+fn arg_val<'a, 'b, T>(arg: &'a str, it: &'b mut T) -> Option<&'a str>
+    where T: Iterator<Item=&'a String>,
+{
+    if let Some(i) = arg.find('=') {
+        Some(&arg[i+1..])
+    } else {
+        it.next().map(|v| v.as_str())
+    }
+}
+
+/// Return true if `arg` is in the set of arguments `set`.
+fn arg_in(arg: &str, set: &HashSet<&str>) -> bool
+{
+    set.contains(arg) || set.iter().any(|a| arg.starts_with(a))
+}
+
+/// Calculate the SHA-1 digest of each file in `files` on background threads
+/// in `pool`.
+fn hash_all(files: Vec<String>, pool: &CpuPool) -> SFuture<Vec<String>>
+{
+    let pool = pool.clone();
+    Box::new(future::join_all(files.into_iter().map(move |f| sha1_digest(f, &pool))))
+}
+
+/// Calculate SHA-1 digests for all source files listed in rustc's dep-info output.
+fn hash_source_files<T>(creator: &T, executable: &str, arguments: &[String], cwd: &str, pool: &CpuPool) -> SFuture<Vec<String>>
+    where T: CommandCreatorSync,
+{
+    // Get the full list of source files from rustc's dep-info.
+    let temp_dir = match TempDir::new("sccache") {
+        Ok(d) => d,
+        _ => return Box::new(future::err("Failed to create temp dir".into())),
+    };
+    let dep_file = temp_dir.path().join("deps.d");
+    let mut cmd = creator.clone().new_command_sync(executable);
+    cmd.args(&arguments)
+        .args(&["--emit", "dep-info"])
+        .arg("-o")
+        .arg(&dep_file)
+        .current_dir(cwd);
+    if log_enabled!(Trace) {
+        trace!("get dep-info: {:?}", cmd);
+    }
+    let dep_info = run_input_output(cmd, None);
+    // Parse the dep-info file, then hash the contents of those files.
+    let pool = pool.clone();
+    let cwd = cwd.to_owned();
+    Box::new(dep_info.and_then(move |output| -> SFuture<_> {
+        if output.status.success() {
+            match parse_dep_file(&dep_file, &cwd) {
+                Ok(files) => {
+                    // Just to make sure we capture temp_dir.
+                    drop(temp_dir);
+                    hash_all(files, &pool)
+                }
+                Err(e) => return Box::new(future::err(e)),
+            }
+        } else {
+            Box::new(future::err("Failed run rustc --dep-info".into()))
+        }
+    }))
+}
+
+/// Parse dependency info from `file` and return a Vec of files mentioned.
+/// Treat paths as relative to `cwd`.
+fn parse_dep_file<T, U>(file: T, cwd: U) -> Result<Vec<String>>
+    where T: AsRef<Path>,
+          U: AsRef<Path>,
+{
+    let mut f = File::open(file)?;
+    let mut deps = String::new();
+    f.read_to_string(&mut deps)?;
+    Ok(parse_dep_info(&deps, cwd))
+}
+
+fn parse_dep_info<T>(dep_info: &str, cwd: T) -> Vec<String>
+    where T: AsRef<Path>
+{
+    let cwd = cwd.as_ref();
+    //TODO: sort files.
+    let mut deps = dep_info.lines()
+        // The first line is the dependencies on the dep file itself.
+        .skip(1)
+        .filter_map(|l| if l.is_empty() { None } else { l.split(":").next() })
+        .map(|s| cwd.join(s).to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    deps.sort();
+    deps
+}
+
+/// Run `rustc --print file-names` to get the outputs of compilation.
+fn get_compiler_outputs<T>(creator: &T, executable: &str, arguments: &[String], cwd: &str) -> SFuture<Vec<String>>
+    where T: CommandCreatorSync,
+{
+    let mut cmd = creator.clone().new_command_sync(executable);
+    cmd.args(&arguments)
+        .args(&["--print", "file-names"])
+        .current_dir(cwd);
+    if log_enabled!(Trace) {
+        trace!("get_compiler_outputs: {:?}", cmd);
+    }
+    let outputs = run_input_output(cmd, None);
+    Box::new(outputs.and_then(move |output| -> Result<_> {
+        if output.status.success() {
+            let outstr = String::from_utf8(output.stdout).chain_err(|| "Error parsing rustc output")?;
+            Ok(outstr.lines().map(|l| l.to_owned()).collect())
+        } else {
+            bail!("Failed to run `rustc --print file-names`");
+        }
+    }))
+}
+
+impl<T> Compiler<T> for Rust
+    where T: CommandCreatorSync,
+{
+    fn kind(&self) -> CompilerKind { CompilerKind::Rust }
+    /// Parse `arguments` as rustc command-line arguments, determine if
+    /// we can cache the result of compilation. This is only intended to
+    /// cover a subset of rustc invocations, primarily focused on those
+    /// that will occur when cargo invokes rustc.
+    ///
+    /// Caveats:
+    /// * We don't support compilation from stdin.
+    /// * We require --emit.
+    /// * We only support `link` and `dep-info` in --emit (and don't support *just* 'dep-info')
+    /// * We require `--out-dir`.
+    /// * We don't support `-o file`.
+    fn parse_arguments(&self,
+                       arguments: &[String],
+                       cwd: &Path) -> CompilerArguments<Box<CompilerHasher<T> + 'static>>
+    {
+        match parse_arguments(arguments, cwd) {
+            CompilerArguments::Ok(h) => CompilerArguments::Ok(Box::new(h)),
+            CompilerArguments::NotCompilation => CompilerArguments::NotCompilation,
+            CompilerArguments::CannotCache => CompilerArguments::CannotCache,
+        }
+    }
+
+
+    fn box_clone(&self) -> Box<Compiler<T>> {
+        Box::new((*self).clone())
+    }
+}
+
+fn parse_arguments(arguments: &[String], _cwd: &Path) -> CompilerArguments<RustHasher>
+{
+    //TODO: use lazy_static for this.
+    let args_with_val: HashSet<&'static str> = HashSet::from_iter(ARGS_WITH_VALUE.iter().map(|v| *v));
+    let mut emit: Option<HashSet<&str>> = None;
+    let mut input = None;
+    let mut output_dir = None;
+    let mut crate_name = None;
+    let mut extra_filename = None;
+    let mut externs = vec![];
+    let mut filtered_arguments = vec![];
+
+    let mut it = arguments.iter();
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            // Various non-compilation options.
+            "--help" | "-V" | "--version" => return CompilerArguments::NotCompilation,
+            v if v.starts_with("--print") || v.starts_with("--explain") || v.starts_with("--pretty") || v.starts_with("--unpretty") => return CompilerArguments::NotCompilation,
+            // Could support `-o file` but it'd be more complicated.
+            "-o" => return CompilerArguments::CannotCache,
+            //TODO: support linking against native libraries. This
+            // will require replicating the linker search strategy
+            // so we can *find* them.
+            "-l" => return CompilerArguments::CannotCache,
+            v if v.starts_with("--emit") => {
+                //XXX: do we need to handle --emit specified more than once?
+                emit = arg_val(v, &mut it).map(|a| a.split(",").collect());
+            }
+            v if v.starts_with("--out-dir") => {
+                output_dir = arg_val(v, &mut it);
+            }
+            v if v.starts_with("--crate-name") => {
+                filtered_arguments.push("--crate-name".to_owned());
+                crate_name = arg_val(v, &mut it);
+                if let Some(name) = crate_name {
+                    filtered_arguments.push(name.to_owned());
+                }
+            }
+            v if v.starts_with("--extern") => {
+                if let Some(val) = arg_val(v, &mut it) {
+                    filtered_arguments.push("--extern".to_owned());
+                    filtered_arguments.push(val.to_owned());
+                    if let Some(crate_file) = val.splitn(2, "=").nth(1) {
+                        externs.push(crate_file.to_owned());
+                    }
+                }
+            }
+            "-C" => {
+                // We want to capture some info from codegen options.
+                filtered_arguments.push("-C".to_owned());
+                if let Some(codegen_arg) = it.next() {
+                    filtered_arguments.push(codegen_arg.to_owned());
+                    let mut split_it = codegen_arg.splitn(2, "=");
+                    let name = split_it.next();
+                    let val = split_it.next();
+                    if let (Some(name), Some(val)) = (name, val) {
+                        match name {
+                            "extra-filename" => extra_filename = Some(val),
+                            _ => {},
+                        }
+                    }
+                }
+            }
+            // Handle arguments that take a value.
+            v if v.starts_with("-") && arg_in(v, &args_with_val) => {
+                filtered_arguments.push(v.to_owned());
+                if v.find('=').is_none() {
+                    if let Some(a) = it.next() {
+                        filtered_arguments.push(a.to_owned());
+                    }
+                }
+            }
+            // Other arguments that don't take a value can just be passed on.
+            v if v.starts_with("-") && v != "-" => {
+                filtered_arguments.push(v.to_owned());
+            }
+            // Anything else is an input file.
+            _ => {
+                if input.is_some() || arg == "-" {
+                    // Can't cache compilations with multiple inputs
+                    // or compilation from stdin.
+                    return CompilerArguments::CannotCache;
+                }
+                filtered_arguments.push(arg.to_owned());
+                input = Some(arg);
+            }
+        }
+    }
+    // Unwrap required values.
+    macro_rules! req {
+        ($x:ident) => {
+            let $x = if let Some($x) = $x {
+                $x
+            } else {
+                debug!("Can't cache compilation, missing `{}`", stringify!($x));
+                return CompilerArguments::CannotCache;
+            };
+        }
+    };
+    // We don't actually save the input value, but there needs to be one.
+    req!(input);
+    drop(input);
+    req!(output_dir);
+    req!(emit);
+    // We won't cache invocations that are not producing
+    // binary output.
+    if !emit.is_empty() && !emit.contains("link") {
+        return CompilerArguments::NotCompilation;
+    }
+    // We won't cache invocations that are outputting anything but
+    // linker output and dep-info.
+    //TODO: use lazy_static for this.
+    let allowed_emit = HashSet::from_iter(ALLOWED_EMIT.iter().map(|v| *v));
+    let l = allowed_emit.len();
+    if emit.union(&allowed_emit).count() > l {
+        return CompilerArguments::CannotCache;
+    }
+    // Figure out the dep-info filename, if emitting dep-info.
+    let dep_info = if emit.contains("dep-info") {
+        if let (Some(crate_name), Some(extra_filename)) = (crate_name, extra_filename) {
+            Some([crate_name, extra_filename, ".d"].iter().map(|s| *s).collect::<String>())
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    // We'll figure out the source files and outputs later in
+    // `generate_hash_key` where we can run rustc.
+    CompilerArguments::Ok(RustHasher {
+        arguments: arguments.to_owned(),
+        filtered_arguments: filtered_arguments,
+        output_dir: output_dir.to_owned(),
+        externs: externs,
+        crate_name: crate_name.unwrap_or("<unknown>").to_string(),
+        dep_info: dep_info,
+    })
+}
+
+impl<T> CompilerHasher<T> for RustHasher
+    where T: CommandCreatorSync,
+{
+    fn generate_hash_key(self: Box<Self>,
+                         creator: &T,
+                         executable: &str,
+                         executable_digest: &str,
+                         cwd: &str,
+                         pool: &CpuPool)
+                         -> SFuture<HashResult<T>>
+    {
+        let me = *self;
+        let RustHasher { arguments, filtered_arguments, output_dir, externs, dep_info, .. } = me;
+        let source_hashes = hash_source_files(creator, executable, &filtered_arguments, cwd, pool);
+        // Hash the contents of the externs listed on the commandline.
+        let cwp = Path::new(cwd);
+        let extern_hashes = hash_all(externs.iter()
+                                     .map(|e| cwp.join(e).to_string_lossy().into_owned())
+                                     .collect(),
+                                     &pool);
+        let creator = creator.clone();
+        let executable_digest = executable_digest.to_owned();
+        let executable = executable.to_owned();
+        let cwd = cwd.to_owned();
+        let hashes = source_hashes.join(extern_hashes);
+        Box::new(hashes.and_then(move |(source_hashes, extern_hashes)| -> SFuture<_> {
+            // If you change any of the inputs to the hash, you should change `CACHE_VERSION`.
+            let mut m = sha1::Sha1::new();
+            // Hash inputs:
+            // 1. A version
+            trace!("CACHE_VERSION: {:?}", CACHE_VERSION);
+            m.update(CACHE_VERSION);
+            // 2. The executable_digest
+            trace!("executable_digest: {}", executable_digest);
+            m.update(executable_digest.as_bytes());
+            // 3. The full commandline (self.arguments)
+            // TODO: there will be full paths here, it would be nice to
+            // normalize them so we can get cross-machine cache hits.
+            let args = arguments.iter().map(|s| s.as_str()).collect::<String>();
+            trace!("args: {}", args);
+            m.update(args.as_bytes());
+            // 4. The sha-1 digests of all source files (this includes src file from cmdline).
+            // 5. The sha-1 digests of all files listed on the commandline (self.externs)
+            for h in source_hashes.into_iter().chain(extern_hashes) {
+                trace!("file hash: {}", h);
+                m.update(h.as_bytes());
+            }
+            // 6. TODO: Environment variables:
+            //    RUSTFLAGS, maybe CARGO_PKG_*?
+            // 7. TODO: native libraries being linked.
+            Box::new(get_compiler_outputs(&creator, &executable, &arguments, &cwd).map(move |outputs| {
+                let output_dir = PathBuf::from(output_dir);
+                // Convert output files into a map of basename -> full path.
+                let mut outputs = outputs.into_iter()
+                    .map(|o| {
+                        let p = output_dir.join(&o).to_string_lossy().into_owned();
+                        (o, p)
+                    })
+                    .collect::<HashMap<_, _>>();
+                if let Some(dep_info) = dep_info {
+                    let p = output_dir.join(&dep_info).to_string_lossy().into_owned();
+                    outputs.insert(dep_info, p);
+                }
+                HashResult::Ok {
+                    key: m.digest().to_string(),
+                    compilation: Box::new(RustCompilation {
+                        arguments: arguments,
+                        outputs: outputs,
+                    }),
+                }
+            }))
+        }))
+    }
+
+    fn output_file(&self) -> Cow<str> {
+        Cow::Borrowed(&self.crate_name)
+    }
+
+    fn box_clone(&self) -> Box<CompilerHasher<T>> {
+        Box::new((*self).clone())
+    }
+}
+
+impl<T> Compilation<T> for RustCompilation
+    where T: CommandCreatorSync,
+{
+    fn compile(self: Box<Self>,
+               creator: &T,
+               executable: &str,
+               cwd: &str,
+               _pool: &CpuPool)
+               -> SFuture<(Cacheable, process::Output)>
+    {
+        let me = *self;
+        let RustCompilation { arguments, .. } = me;
+        let mut cmd = creator.clone().new_command_sync(executable);
+        cmd.args(&arguments)
+            .current_dir(cwd);
+        if log_enabled!(Trace) {
+            trace!("compile: {:?}", cmd);
+        }
+        Box::new(run_input_output(cmd, None).map(|output| {
+            (Cacheable::Yes, output)
+        }))
+    }
+
+    fn outputs<'a>(&'a self) -> Box<Iterator<Item=(&'a str, &'a String)> + 'a> {
+        Box::new(self.outputs.iter().map(|(k, v)| (k.as_str(), v)))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use ::compiler::*;
+    use mock_command::*;
+    use sha1;
+    use std::fs::File;
+    use std::io::Write;
+    use test::utils::*;
+
+    fn _parse_arguments(arguments: &[String]) -> CompilerArguments<RustHasher>
+    {
+        parse_arguments(arguments, ".".as_ref())
+    }
+
+    macro_rules! parses {
+        ( $( $s:expr ),* ) => {
+            match _parse_arguments(&[ $( $s.to_string(), )* ]) {
+                CompilerArguments::Ok(a) => a,
+                o @ _ => panic!("Got unexpected parse result: {:?}", o),
+            }
+        }
+    }
+
+    macro_rules! fails {
+        ( $( $s:expr ),* ) => {
+            match _parse_arguments(&[ $( $s.to_string(), )* ]) {
+                CompilerArguments::Ok(_) => panic!("Should not have parsed ok: `{}`", stringify!($( $s, )*)),
+
+                _ => {}
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_arguments_simple() {
+        let h = parses!("--emit", "link", "foo.rs", "--out-dir", "out");
+        assert_eq!(h.filtered_arguments, &["foo.rs"]);
+        assert_eq!(h.output_dir, "out");
+        assert!(h.dep_info.is_none());
+        assert!(h.externs.is_empty());
+        let h = parses!("--emit=link", "foo.rs", "--out-dir", "out");
+        assert_eq!(h.filtered_arguments, &["foo.rs"]);
+        assert_eq!(h.output_dir, "out");
+        assert!(h.dep_info.is_none());
+        let h = parses!("--emit", "link", "foo.rs", "--out-dir=out");
+        assert_eq!(h.filtered_arguments, &["foo.rs"]);
+        assert_eq!(h.output_dir, "out");
+        let h = parses!("--emit", "link,dep-info", "foo.rs", "--out-dir", "out",
+                        "--crate-name", "my_crate",
+                        "-C", "extra-filename=-abcxyz");
+        assert_eq!(h.filtered_arguments,
+                   &["foo.rs", "--crate-name", "my_crate", "-C", "extra-filename=-abcxyz"]);
+        assert_eq!(h.output_dir, "out");
+        assert_eq!(h.dep_info.unwrap(), "my_crate-abcxyz.d");
+        fails!("--emit", "link", "--out-dir", "out");
+        fails!("--emit", "link", "foo.rs");
+        fails!("--emit", "asm", "foo.rs", "--out-dir", "out");
+        fails!("--emit", "asm,link", "foo.rs", "--out-dir", "out");
+        fails!("--emit", "asm,link,dep-info", "foo.rs", "--out-dir", "out");
+        // From an actual cargo compilation, with some args shortened:
+        let h = parses!("--crate-name", "foo", "src/lib.rs",
+                        "--crate-type", "lib", "--emit=dep-info,link",
+                        "-C", "debuginfo=2", "-C", "metadata=d6ae26f5bcfb7733",
+                        "-C", "extra-filename=-d6ae26f5bcfb7733",
+                        "--out-dir", "/foo/target/debug/deps",
+                        "-L", "dependency=/foo/target/debug/deps",
+                        "--extern", "libc=/foo/target/debug/deps/liblibc-89a24418d48d484a.rlib",
+                        "--extern", "log=/foo/target/debug/deps/liblog-2f7366be74992849.rlib");
+        assert_eq!(h.filtered_arguments,
+                   &["--crate-name", "foo", "src/lib.rs", "--crate-type", "lib",
+                     "-C", "debuginfo=2", "-C", "metadata=d6ae26f5bcfb7733",
+                     "-C", "extra-filename=-d6ae26f5bcfb7733",
+                     "-L", "dependency=/foo/target/debug/deps",
+                     "--extern", "libc=/foo/target/debug/deps/liblibc-89a24418d48d484a.rlib",
+                     "--extern", "log=/foo/target/debug/deps/liblog-2f7366be74992849.rlib"]);
+        assert_eq!(h.output_dir, "/foo/target/debug/deps");
+        assert_eq!(h.crate_name, "foo");
+        assert_eq!(h.dep_info.unwrap(), "foo-d6ae26f5bcfb7733.d");
+        assert_eq!(h.externs, &["/foo/target/debug/deps/liblibc-89a24418d48d484a.rlib", "/foo/target/debug/deps/liblog-2f7366be74992849.rlib"]);
+    }
+
+    #[test]
+    fn test_parse_arguments_native_libs() {
+        //TODO: deal with native libs
+        fails!("--emit", "link", "-l", "bar", "foo.rs", "--out-dir", "out");
+    }
+
+    #[test]
+    fn test_arg_val() {
+        let a = stringvec!["a", "b", "c"];
+        let mut it = a.iter();
+        let first = it.next().unwrap();
+        assert_eq!(arg_val(first, &mut it).unwrap(), "b");
+
+        let a = stringvec!["a=x", "b", "c"];
+        let mut it = a.iter();
+        let first = it.next().unwrap();
+        assert_eq!(arg_val(first, &mut it).unwrap(), "x");
+
+        let a = stringvec!["a"];
+        let mut it = a.iter();
+        let first = it.next().unwrap();
+        assert!(arg_val(first, &mut it).is_none());
+    }
+
+    #[test]
+    fn test_arg_in() {
+        let mut args: HashSet<&'static str> = HashSet::new();
+        args.insert("--foo");
+        args.insert("--bar");
+        args.insert("--baz");
+        assert!(arg_in("--foo", &args));
+        assert!(arg_in("--foo=abc", &args));
+        assert!(arg_in("--bar", &args));
+        assert!(arg_in("--baz", &args));
+        assert!(!arg_in("--xyz", &args));
+        assert!(!arg_in("--xyz=123", &args));
+    }
+
+    #[test]
+    fn test_get_compiler_outputs() {
+        let creator = new_creator();
+        next_command(&creator, Ok(MockChild::new(exit_status(0), "foo\nbar\nbaz", "")));
+        let outputs = get_compiler_outputs(&creator, "rustc", &stringvec!("a", "b"), "cwd").wait().unwrap();
+        assert_eq!(outputs, &["foo", "bar", "baz"]);
+    }
+
+    #[test]
+    fn test_get_compiler_outputs_fail() {
+        let creator = new_creator();
+        next_command(&creator, Ok(MockChild::new(exit_status(1), "", "error")));
+        assert!(get_compiler_outputs(&creator, "rustc", &stringvec!("a", "b"), "cwd").wait().is_err());
+    }
+
+    #[test]
+    fn test_parse_dep_info() {
+        let deps = "foo: baz.rs abc.rs bar.rs
+
+baz.rs:
+
+abc.rs:
+
+bar.rs:
+";
+        assert_eq!(stringvec!["abc.rs", "bar.rs", "baz.rs"],
+                   parse_dep_info(&deps, ""));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_parse_dep_info_cwd() {
+        let deps = "foo: baz.rs abc.rs bar.rs
+
+baz.rs:
+
+abc.rs:
+
+bar.rs:
+";
+        assert_eq!(stringvec!["foo/abc.rs", "foo/bar.rs", "foo/baz.rs"],
+                   parse_dep_info(&deps, "foo/"));
+
+        assert_eq!(stringvec!["/foo/bar/abc.rs", "/foo/bar/bar.rs", "/foo/bar/baz.rs"],
+                   parse_dep_info(&deps, "/foo/bar/"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_parse_dep_info_abs_paths() {
+        let deps = "/foo/foo: /foo/baz.rs /foo/abc.rs /foo/bar.rs
+
+/foo/baz.rs:
+
+/foo/abc.rs:
+
+/foo/bar.rs:
+";
+        assert_eq!(stringvec!["/foo/abc.rs", "/foo/bar.rs", "/foo/baz.rs"],
+                   parse_dep_info(&deps, "/bar/"));
+    }
+
+    #[test]
+    fn test_generate_hash_key() {
+        use env_logger;
+        drop(env_logger::init());
+        let f = TestFixture::new();
+        // We'll just use empty files for each of these.
+        for s in ["foo.rs", "bar.rs", "bar.rlib"].iter() {
+            f.touch(s).unwrap();
+        }
+        let hasher = Box::new(RustHasher {
+            arguments: stringvec!["a", "b"],
+            filtered_arguments: stringvec![],
+            output_dir: "foo/".to_string(),
+            externs: stringvec!["bar.rlib"],
+            crate_name: "foo".to_string(),
+            dep_info: None,
+        });
+        let creator = new_creator();
+        // Mock the `rustc --emit=dep-info` process by writing
+        // a dep-info file.
+        next_command_calls(&creator, |args| {
+            let mut dep_info_path = None;
+            let mut it = args.iter();
+            while let Some(a) = it.next() {
+                if a == "-o" {
+                    dep_info_path = it.next();
+                    break;
+                }
+            }
+            let dep_info_path = dep_info_path.unwrap();
+            trace!("dep_info_path: {:?}", dep_info_path.to_string_lossy());
+            let mut f = File::create(dep_info_path)?;
+            f.write_all(b"blah: foo.rs bar.rs
+
+foo.rs:
+bar.rs:
+")?;
+            Ok(MockChild::new(exit_status(0), "", ""))
+        });
+        // Mock the `rustc --print=file-names` process output.
+        next_command(&creator, Ok(MockChild::new(exit_status(0), "foo.rlib\nfoo.a", "")));
+        const RUSTC_DIGEST: &'static str = "1234abcd";
+        // SHA-1 digest of an empty file.
+        const EMPTY_DIGEST: &'static [u8] = b"da39a3ee5e6b4b0d3255bfef95601890afd80709";
+        let pool = CpuPool::new(1);
+        let res = hasher.generate_hash_key(&creator, "rustc", RUSTC_DIGEST,
+                                           &f.tempdir.path().to_string_lossy(),
+                                           &pool).wait().unwrap();
+        let mut m = sha1::Sha1::new();
+        // Version.
+        m.update(CACHE_VERSION);
+        // Compiler digest.
+        m.update(RUSTC_DIGEST.as_bytes());
+        // Arguments.
+        m.update(b"ab");
+        // bar.rs (source file, from dep-info)
+        m.update(EMPTY_DIGEST);
+        // foo.rs (source file, from dep-info)
+        m.update(EMPTY_DIGEST);
+        // bar.rlib (extern crate, from externs)
+        m.update(EMPTY_DIGEST);
+        let digest = m.digest().to_string();
+        match res {
+            HashResult::Ok { key, compilation } => {
+                assert_eq!(key, digest);
+                let mut out = compilation.outputs().map(|(k, _)| k.to_owned()).collect::<Vec<_>>();
+                out.sort();
+                assert_eq!(out, vec!["foo.a", "foo.rlib"]);
+            }
+            _ => panic!("generate_hash_key returned Error!"),
+        }
+    }
+}

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -21,28 +21,50 @@ use mock_command::{CommandCreatorSync, RunCommand};
 use sha1;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
+use std::env::consts::DLL_EXTENSION;
+use std::fs::{self, File};
 use std::io::Read;
 use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
-use std::process;
+use std::process::{self, Stdio};
+use std::slice;
 use std::time::Instant;
 use tempdir::TempDir;
 use util::{fmt_duration_as_secs, sha1_digest};
 
 use errors::*;
 
-/// A unit struct on which to hang a `Compiler` impl.
+/// Directory in the sysroot containing shared libraries to which rustc is linked.
+#[cfg(not(windows))]
+const LIBS_DIR: &'static str = "lib";
+
+/// Directory in the sysroot containing shared libraries to which rustc is linked.
+#[cfg(windows)]
+const LIBS_DIR: &'static str = "bin";
+
+/// A struct on which to hang a `Compiler` impl.
 #[derive(Debug, Clone)]
-pub struct Rust;
+pub struct Rust {
+    /// The path to the rustc executable.
+    executable: String,
+    /// The SHA-1 digests of all the shared libraries in rustc's $sysroot/lib (or /bin on Windows).
+    compiler_shlibs_digests: Vec<String>,
+}
 
 /// A struct on which to hang a `CompilerHasher` impl.
 #[derive(Debug, Clone)]
 pub struct RustHasher {
-    /// The full commandline.
-    arguments: Vec<String>,
-    /// The commandline without any --emit or --out-dir arguments.
-    filtered_arguments: Vec<String>,
+    /// The path to the rustc executable.
+    executable: String,
+    /// The SHA-1 digests of all the shared libraries in rustc's $sysroot/lib (or /bin on Windows).
+    compiler_shlibs_digests: Vec<String>,
+    parsed_args: ParsedArguments,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParsedArguments {
+    /// The full commandline, with arguments and their values as pairs.
+    arguments: Vec<(String, Option<String>)>,
     /// The location of compiler outputs.
     output_dir: String,
     /// Paths to extern crates used in the compile.
@@ -56,6 +78,8 @@ pub struct RustHasher {
 /// A struct on which to hang a `Compilation` impl.
 #[derive(Debug, Clone)]
 pub struct RustCompilation {
+    /// The path to the rustc executable.
+    executable: String,
     /// The full commandline.
     arguments: Vec<String>,
     /// The compiler outputs.
@@ -99,18 +123,6 @@ const ALLOWED_EMIT: &'static [&'static str] = &["link", "dep-info"];
 /// Version number for cache key.
 const CACHE_VERSION: &'static [u8] = b"1";
 
-/// Parse the value passed to a commandline argument `arg`, either after
-/// an '=' in `arg` or in the next argument from `it`.
-fn arg_val<'a, 'b, T>(arg: &'a str, it: &'b mut T) -> Option<&'a str>
-    where T: Iterator<Item=&'a String>,
-{
-    if let Some(i) = arg.find('=') {
-        Some(&arg[i+1..])
-    } else {
-        it.next().map(|v| v.as_str())
-    }
-}
-
 /// Return true if `arg` is in the set of arguments `set`.
 fn arg_in(arg: &str, set: &HashSet<&str>) -> bool
 {
@@ -139,7 +151,7 @@ fn hash_source_files<T>(creator: &T, crate_name: &str, executable: &str, argumen
     // Get the full list of source files from rustc's dep-info.
     let temp_dir = match TempDir::new("sccache") {
         Ok(d) => d,
-        _ => return Box::new(future::err("Failed to create temp dir".into())),
+        _ => return f_err("Failed to create temp dir"),
     };
     let dep_file = temp_dir.path().join("deps.d");
     let mut cmd = creator.clone().new_command_sync(executable);
@@ -156,7 +168,7 @@ fn hash_source_files<T>(creator: &T, crate_name: &str, executable: &str, argumen
     let crate_name = crate_name.to_owned();
     Box::new(dep_info.and_then(move |output| -> SFuture<_> {
         if output.status.success() {
-            match parse_dep_file(&dep_file, &cwd) {
+            match parse_dep_file(&dep_file, &cwd).chain_err(|| format!("Failed to parse dep info for {}", crate_name)) {
                 Ok(files) => {
                     trace!("[{}]: got {} source files from dep-info in {}", crate_name,
                            files.len(), fmt_duration_as_secs(&start.elapsed()));
@@ -164,10 +176,11 @@ fn hash_source_files<T>(creator: &T, crate_name: &str, executable: &str, argumen
                     drop(temp_dir);
                     hash_all(files, &pool)
                 }
-                Err(e) => return Box::new(future::err(e)),
+                Err(e) => return f_err(e),
             }
         } else {
-            Box::new(future::err("Failed run rustc --dep-info".into()))
+            f_err(format!("Failed run rustc --dep-info. rustc stderr: `{}`",
+                          String::from_utf8_lossy(&output.stderr)))
         }
     }))
 }
@@ -188,7 +201,6 @@ fn parse_dep_info<T>(dep_info: &str, cwd: T) -> Vec<String>
     where T: AsRef<Path>
 {
     let cwd = cwd.as_ref();
-    //TODO: sort files.
     let mut deps = dep_info.lines()
         // The first line is the dependencies on the dep file itself.
         .skip(1)
@@ -221,6 +233,49 @@ fn get_compiler_outputs<T>(creator: &T, executable: &str, arguments: &[String], 
     }))
 }
 
+impl Rust {
+    /// Create a new Rust compiler instance, calculating the hashes of
+    /// all the shared libraries in its sysroot.
+    pub fn new<T>(mut creator: T, executable: String, pool: CpuPool) -> SFuture<Rust>
+        where T: CommandCreatorSync,
+    {
+        let mut cmd = creator.new_command_sync(&executable);
+        cmd.stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .arg("--print=sysroot");
+        let output = run_input_output(cmd, None);
+        let libs = output.and_then(move |output| -> Result<_> {
+            if !output.status.success() {
+                bail!("Failed to determine sysroot");
+            }
+            let outstr = String::from_utf8(output.stdout).chain_err(|| "Error parsing sysroot")?;
+            let libs_path = Path::new(outstr.trim_right()).join(LIBS_DIR);
+            let mut libs = fs::read_dir(&libs_path).chain_err(|| format!("Failed to list rustc sysroot: `{:?}`", libs_path))?.filter_map(|e| {
+                e.ok().and_then(|e| {
+                    e.file_type().ok().and_then(|t| {
+                        let p = e.path();
+                        if t.is_file() && p.extension().map(|e| e == DLL_EXTENSION).unwrap_or(false) {
+                            p.into_os_string().into_string().ok()
+                        } else {
+                            None
+                        }
+                    })
+                })
+            }).collect::<Vec<_>>();
+            libs.sort();
+            Ok(libs)
+        });
+        Box::new(libs.and_then(move |libs| {
+            hash_all(libs, &pool).map(move |digests| {
+                Rust {
+                    executable: executable,
+                    compiler_shlibs_digests: digests,
+                }
+            })
+        }))
+    }
+}
+
 impl<T> Compiler<T> for Rust
     where T: CommandCreatorSync,
 {
@@ -241,7 +296,13 @@ impl<T> Compiler<T> for Rust
                        cwd: &Path) -> CompilerArguments<Box<CompilerHasher<T> + 'static>>
     {
         match parse_arguments(arguments, cwd) {
-            CompilerArguments::Ok(h) => CompilerArguments::Ok(Box::new(h)),
+            CompilerArguments::Ok(args) => {
+                CompilerArguments::Ok(Box::new(RustHasher {
+                    executable: self.executable.clone(),
+                    compiler_shlibs_digests: self.compiler_shlibs_digests.clone(),
+                    parsed_args: args,
+                }))
+            }
             CompilerArguments::NotCompilation => CompilerArguments::NotCompilation,
             CompilerArguments::CannotCache => CompilerArguments::CannotCache,
         }
@@ -253,7 +314,42 @@ impl<T> Compiler<T> for Rust
     }
 }
 
-fn parse_arguments(arguments: &[String], _cwd: &Path) -> CompilerArguments<RustHasher>
+/// An iterator over (argument, argument value) pairs.
+struct ArgsIter<'a> {
+    arguments: slice::Iter<'a, String>,
+    args_with_val: &'a HashSet<&'static str>,
+}
+
+impl<'a> ArgsIter<'a> {
+    fn new(arguments: &'a [String], args_with_val: &'a HashSet<&'static str>) -> ArgsIter<'a> {
+        ArgsIter {
+            arguments: arguments.iter(),
+            args_with_val: args_with_val,
+        }
+    }
+}
+
+impl<'a> Iterator for ArgsIter<'a> {
+    type Item = (&'a str, Option<&'a str>);
+
+    fn next(&mut self) -> Option<(&'a str, Option<&'a str>)> {
+        if let Some(arg) = self.arguments.next() {
+            if arg_in(arg, &self.args_with_val) {
+                if let Some(i) = arg.find('=') {
+                    Some((&arg[..i], Some(&arg[i+1..])))
+                } else {
+                    Some((arg, self.arguments.next().map(|v| v.as_str())))
+                }
+            } else {
+                Some((arg, None))
+            }
+        } else {
+            None
+        }
+    }
+}
+
+fn parse_arguments(arguments: &[String], _cwd: &Path) -> CompilerArguments<ParsedArguments>
 {
     //TODO: use lazy_static for this.
     let args_with_val: HashSet<&'static str> = HashSet::from_iter(ARGS_WITH_VALUE.iter().map(|v| *v));
@@ -263,48 +359,42 @@ fn parse_arguments(arguments: &[String], _cwd: &Path) -> CompilerArguments<RustH
     let mut crate_name = None;
     let mut extra_filename = None;
     let mut externs = vec![];
-    let mut filtered_arguments = vec![];
 
-    let mut it = arguments.iter();
-    while let Some(arg) = it.next() {
-        match arg.as_str() {
+    let it = ArgsIter::new(arguments, &args_with_val);
+    for (arg, val) in it {
+        match arg {
             // Various non-compilation options.
-            "--help" | "-V" | "--version" => return CompilerArguments::NotCompilation,
-            v if v.starts_with("--print") || v.starts_with("--explain") || v.starts_with("--pretty") || v.starts_with("--unpretty") => return CompilerArguments::NotCompilation,
+            "--help" | "-V" | "--version" | "--print" | "--explain" | "--pretty" | "--unpretty" => return CompilerArguments::NotCompilation,
             // Could support `-o file` but it'd be more complicated.
             "-o" => return CompilerArguments::CannotCache,
             //TODO: support linking against native libraries. This
             // will require replicating the linker search strategy
             // so we can *find* them.
+            // https://github.com/mozilla/sccache/issues/88
             "-l" => return CompilerArguments::CannotCache,
-            v if v.starts_with("--emit") => {
-                //XXX: do we need to handle --emit specified more than once?
-                emit = arg_val(v, &mut it).map(|a| a.split(",").collect());
-            }
-            v if v.starts_with("--out-dir") => {
-                output_dir = arg_val(v, &mut it);
-            }
-            v if v.starts_with("--crate-name") => {
-                filtered_arguments.push("--crate-name".to_owned());
-                crate_name = arg_val(v, &mut it);
-                if let Some(name) = crate_name {
-                    filtered_arguments.push(name.to_owned());
+            "--emit" => {
+                if emit.is_some() {
+                    // We don't support passing --emit more than once.
+                    return CompilerArguments::CannotCache;
                 }
+                emit = val.map(|a| a.split(",").collect());
             }
-            v if v.starts_with("--extern") => {
-                if let Some(val) = arg_val(v, &mut it) {
-                    filtered_arguments.push("--extern".to_owned());
-                    filtered_arguments.push(val.to_owned());
+            "--out-dir" => {
+                output_dir = val;
+            }
+            "--crate-name" => {
+                crate_name = val;
+            }
+            "--extern" => {
+                if let Some(val) = val {
                     if let Some(crate_file) = val.splitn(2, "=").nth(1) {
                         externs.push(crate_file.to_owned());
                     }
                 }
             }
-            "-C" => {
+            "-C" | "--codegen" => {
                 // We want to capture some info from codegen options.
-                filtered_arguments.push("-C".to_owned());
-                if let Some(codegen_arg) = it.next() {
-                    filtered_arguments.push(codegen_arg.to_owned());
+                if let Some(codegen_arg) = val {
                     let mut split_it = codegen_arg.splitn(2, "=");
                     let name = split_it.next();
                     let val = split_it.next();
@@ -316,28 +406,17 @@ fn parse_arguments(arguments: &[String], _cwd: &Path) -> CompilerArguments<RustH
                     }
                 }
             }
-            // Handle arguments that take a value.
-            v if v.starts_with("-") && arg_in(v, &args_with_val) => {
-                filtered_arguments.push(v.to_owned());
-                if v.find('=').is_none() {
-                    if let Some(a) = it.next() {
-                        filtered_arguments.push(a.to_owned());
-                    }
-                }
-            }
-            // Other arguments that don't take a value can just be passed on.
-            v if v.starts_with("-") && v != "-" => {
-                filtered_arguments.push(v.to_owned());
-            }
-            // Anything else is an input file.
+            // Can't cache compilation from stdin.
+            "-" => return CompilerArguments::CannotCache,
             _ => {
-                if input.is_some() || arg == "-" {
-                    // Can't cache compilations with multiple inputs
-                    // or compilation from stdin.
-                    return CompilerArguments::CannotCache;
+                if !arg.starts_with("-") {
+                    // Anything else is an input file.
+                    if input.is_some() {
+                        // Can't cache compilations with multiple inputs.
+                        return CompilerArguments::CannotCache;
+                    }
+                    input = Some(arg);
                 }
-                filtered_arguments.push(arg.to_owned());
-                input = Some(arg);
             }
         }
     }
@@ -380,11 +459,13 @@ fn parse_arguments(arguments: &[String], _cwd: &Path) -> CompilerArguments<RustH
     } else {
         None
     };
+    let arguments = ArgsIter::new(arguments, &args_with_val)
+        .map(|(arg, val)| (arg.to_owned(), val.map(|v| v.to_owned())))
+        .collect::<Vec<_>>();
     // We'll figure out the source files and outputs later in
     // `generate_hash_key` where we can run rustc.
-    CompilerArguments::Ok(RustHasher {
-        arguments: arguments.to_owned(),
-        filtered_arguments: filtered_arguments,
+    CompilerArguments::Ok(ParsedArguments {
+        arguments: arguments,
         output_dir: output_dir.to_owned(),
         externs: externs,
         crate_name: crate_name.unwrap_or("<unknown>").to_string(),
@@ -397,16 +478,26 @@ impl<T> CompilerHasher<T> for RustHasher
 {
     fn generate_hash_key(self: Box<Self>,
                          creator: &T,
-                         executable: &str,
-                         executable_digest: &str,
                          cwd: &str,
                          pool: &CpuPool)
                          -> SFuture<HashResult<T>>
     {
         let me = *self;
-        let RustHasher { arguments, filtered_arguments, output_dir, externs, crate_name, dep_info } = me;
+        let RustHasher { executable, compiler_shlibs_digests, parsed_args: ParsedArguments { arguments, output_dir, externs, crate_name, dep_info } } = me;
         trace!("[{}]: generate_hash_key", crate_name);
-        let source_hashes = hash_source_files(creator, &crate_name, executable, &filtered_arguments, cwd, pool);
+        // filtered_arguments omits --emit and --out-dir arguments.
+        let filtered_arguments = arguments.iter()
+            .filter_map(|&(ref arg, ref val)| {
+                if arg == "--emit" || arg == "--out-dir" {
+                    None
+                } else {
+                    Some((arg, val))
+                }
+            })
+            .flat_map(|(arg, val)| Some(arg).into_iter().chain(val))
+            .map(|a| a.clone())
+            .collect::<Vec<_>>();
+        let source_hashes = hash_source_files(creator, &crate_name, &executable, &filtered_arguments, cwd, pool);
         // Hash the contents of the externs listed on the commandline.
         let cwp = Path::new(cwd);
         trace!("[{}]: hashing {} externs", crate_name, externs.len());
@@ -415,8 +506,6 @@ impl<T> CompilerHasher<T> for RustHasher
                                      .collect(),
                                      &pool);
         let creator = creator.clone();
-        let executable_digest = executable_digest.to_owned();
-        let executable = executable.to_owned();
         let cwd = cwd.to_owned();
         let hashes = source_hashes.join(extern_hashes);
         Box::new(hashes.and_then(move |(source_hashes, extern_hashes)| -> SFuture<_> {
@@ -425,21 +514,37 @@ impl<T> CompilerHasher<T> for RustHasher
             // Hash inputs:
             // 1. A version
             m.update(CACHE_VERSION);
-            // 2. The executable_digest
-            m.update(executable_digest.as_bytes());
+            // 2. compiler_shlibs_digests
+            for d in compiler_shlibs_digests {
+                m.update(d.as_bytes());
+            }
             // 3. The full commandline (self.arguments)
             // TODO: there will be full paths here, it would be nice to
             // normalize them so we can get cross-machine cache hits.
-            let args = arguments.iter().map(|s| s.as_str()).collect::<String>();
+            // Sort --extern args because cargo does not provide them in
+            // a deterministic order.
+            let args = {
+                let (mut extern_args, rest): (Vec<_>, Vec<_>) = arguments.iter()
+                    .partition(|&&(ref arg, ref _v)| arg == "--extern");
+                extern_args.sort();
+                rest.into_iter().chain(extern_args)
+                    .flat_map(|&(ref arg, ref val)| Some(arg).into_iter().chain(val))
+                    .map(|s| s.as_str()).collect::<String>()
+            };
             m.update(args.as_bytes());
             // 4. The sha-1 digests of all source files (this includes src file from cmdline).
             // 5. The sha-1 digests of all files listed on the commandline (self.externs)
             for h in source_hashes.into_iter().chain(extern_hashes) {
                 m.update(h.as_bytes());
             }
-            // 6. TODO: Environment variables:
-            //    RUSTFLAGS, maybe CARGO_PKG_*?
+            // 6. TODO: Environment variables: CARGO_* at the very least.
+            // https://github.com/mozilla/sccache/issues/89
             // 7. TODO: native libraries being linked.
+            // https://github.com/mozilla/sccache/issues/88
+            // Turn arguments into a simple Vec<String> for compilation.
+            let arguments = arguments.into_iter()
+                .flat_map(|(arg, val)| Some(arg).into_iter().chain(val))
+                .collect::<Vec<_>>();
             Box::new(get_compiler_outputs(&creator, &executable, &arguments, &cwd).map(move |outputs| {
                 let output_dir = PathBuf::from(output_dir);
                 // Convert output files into a map of basename -> full path.
@@ -456,6 +561,7 @@ impl<T> CompilerHasher<T> for RustHasher
                 HashResult::Ok {
                     key: m.digest().to_string(),
                     compilation: Box::new(RustCompilation {
+                        executable: executable,
                         arguments: arguments,
                         outputs: outputs,
                         crate_name: crate_name,
@@ -466,7 +572,7 @@ impl<T> CompilerHasher<T> for RustHasher
     }
 
     fn output_file(&self) -> Cow<str> {
-        Cow::Borrowed(&self.crate_name)
+        Cow::Borrowed(&self.parsed_args.crate_name)
     }
 
     fn box_clone(&self) -> Box<CompilerHasher<T>> {
@@ -479,21 +585,17 @@ impl<T> Compilation<T> for RustCompilation
 {
     fn compile(self: Box<Self>,
                creator: &T,
-               executable: &str,
                cwd: &str,
                _pool: &CpuPool)
                -> SFuture<(Cacheable, process::Output)>
     {
         let me = *self;
-        let RustCompilation { arguments, crate_name, .. } = me;
+        let RustCompilation { executable, arguments, crate_name, .. } = me;
         trace!("[{}]: compile", crate_name);
-        let mut cmd = creator.clone().new_command_sync(executable);
-        trace!("");
+        let mut cmd = creator.clone().new_command_sync(&executable);
         cmd.args(&arguments)
             .current_dir(cwd);
-        if log_enabled!(Trace) {
-            trace!("compile: {:?}", cmd);
-        }
+        trace!("compile: {:?}", cmd);
         Box::new(run_input_output(cmd, None).map(|output| {
             (Cacheable::Yes, output)
         }))
@@ -515,7 +617,7 @@ mod test {
     use std::io::Write;
     use test::utils::*;
 
-    fn _parse_arguments(arguments: &[String]) -> CompilerArguments<RustHasher>
+    fn _parse_arguments(arguments: &[String]) -> CompilerArguments<ParsedArguments>
     {
         parse_arguments(arguments, ".".as_ref())
     }
@@ -542,22 +644,17 @@ mod test {
     #[test]
     fn test_parse_arguments_simple() {
         let h = parses!("--emit", "link", "foo.rs", "--out-dir", "out");
-        assert_eq!(h.filtered_arguments, &["foo.rs"]);
         assert_eq!(h.output_dir, "out");
         assert!(h.dep_info.is_none());
         assert!(h.externs.is_empty());
         let h = parses!("--emit=link", "foo.rs", "--out-dir", "out");
-        assert_eq!(h.filtered_arguments, &["foo.rs"]);
         assert_eq!(h.output_dir, "out");
         assert!(h.dep_info.is_none());
         let h = parses!("--emit", "link", "foo.rs", "--out-dir=out");
-        assert_eq!(h.filtered_arguments, &["foo.rs"]);
         assert_eq!(h.output_dir, "out");
         let h = parses!("--emit", "link,dep-info", "foo.rs", "--out-dir", "out",
                         "--crate-name", "my_crate",
                         "-C", "extra-filename=-abcxyz");
-        assert_eq!(h.filtered_arguments,
-                   &["foo.rs", "--crate-name", "my_crate", "-C", "extra-filename=-abcxyz"]);
         assert_eq!(h.output_dir, "out");
         assert_eq!(h.dep_info.unwrap(), "my_crate-abcxyz.d");
         fails!("--emit", "link", "--out-dir", "out");
@@ -574,13 +671,6 @@ mod test {
                         "-L", "dependency=/foo/target/debug/deps",
                         "--extern", "libc=/foo/target/debug/deps/liblibc-89a24418d48d484a.rlib",
                         "--extern", "log=/foo/target/debug/deps/liblog-2f7366be74992849.rlib");
-        assert_eq!(h.filtered_arguments,
-                   &["--crate-name", "foo", "src/lib.rs", "--crate-type", "lib",
-                     "-C", "debuginfo=2", "-C", "metadata=d6ae26f5bcfb7733",
-                     "-C", "extra-filename=-d6ae26f5bcfb7733",
-                     "-L", "dependency=/foo/target/debug/deps",
-                     "--extern", "libc=/foo/target/debug/deps/liblibc-89a24418d48d484a.rlib",
-                     "--extern", "log=/foo/target/debug/deps/liblog-2f7366be74992849.rlib"]);
         assert_eq!(h.output_dir, "/foo/target/debug/deps");
         assert_eq!(h.crate_name, "foo");
         assert_eq!(h.dep_info.unwrap(), "foo-d6ae26f5bcfb7733.d");
@@ -590,25 +680,26 @@ mod test {
     #[test]
     fn test_parse_arguments_native_libs() {
         //TODO: deal with native libs
+        // https://github.com/mozilla/sccache/issues/88
         fails!("--emit", "link", "-l", "bar", "foo.rs", "--out-dir", "out");
     }
 
     #[test]
-    fn test_arg_val() {
-        let a = stringvec!["a", "b", "c"];
-        let mut it = a.iter();
-        let first = it.next().unwrap();
-        assert_eq!(arg_val(first, &mut it).unwrap(), "b");
+    fn test_args_iter() {
+        let args_with_val: HashSet<&'static str> = HashSet::from_iter(ARGS_WITH_VALUE.iter().map(|v| *v));
+        macro_rules! t {
+            ( [ $( $s:expr ),* ], [ $( $t:expr ),* ] ) => {
+                let v = vec!( $( $s.to_string(), )* );
+                let it = ArgsIter::new(&v, &args_with_val);
+                assert_eq!(it.collect::<Vec<_>>(),
+                           vec!( $( $t, )* ));
+            }
+        }
+        t!(["--emit", "link", "-g", "foo.rs", "--out-dir", "out"],
+           [("--emit", Some("link")), ("-g", None), ("foo.rs", None), ("--out-dir", Some("out"))]);
 
-        let a = stringvec!["a=x", "b", "c"];
-        let mut it = a.iter();
-        let first = it.next().unwrap();
-        assert_eq!(arg_val(first, &mut it).unwrap(), "x");
-
-        let a = stringvec!["a"];
-        let mut it = a.iter();
-        let first = it.next().unwrap();
-        assert!(arg_val(first, &mut it).is_none());
+        t!(["--emit=link", "-g", "foo.rs", "--out-dir=out"],
+           [("--emit", Some("link")), ("-g", None), ("foo.rs", None), ("--out-dir", Some("out"))]);
     }
 
     #[test]
@@ -692,17 +783,27 @@ bar.rs:
         use env_logger;
         drop(env_logger::init());
         let f = TestFixture::new();
+        // SHA-1 digest of an empty file.
+        const EMPTY_DIGEST: &'static str = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+        const FAKE_DIGEST: &'static str = "abcd1234";
         // We'll just use empty files for each of these.
         for s in ["foo.rs", "bar.rs", "bar.rlib"].iter() {
             f.touch(s).unwrap();
         }
         let hasher = Box::new(RustHasher {
-            arguments: stringvec!["a", "b"],
-            filtered_arguments: stringvec![],
-            output_dir: "foo/".to_string(),
-            externs: stringvec!["bar.rlib"],
-            crate_name: "foo".to_string(),
-            dep_info: None,
+            executable: "rustc".to_owned(),
+            compiler_shlibs_digests: vec![FAKE_DIGEST.to_owned()],
+            parsed_args: ParsedArguments {
+                arguments: vec![("a".to_string(), None),
+                                ("--extern".to_string(), Some("xyz".to_string())),
+                                ("b".to_string(), None),
+                                ("--extern".to_string(), Some("abc".to_string())),
+                                ],
+                output_dir: "foo/".to_string(),
+                externs: stringvec!["bar.rlib"],
+                crate_name: "foo".to_string(),
+                dep_info: None,
+            }
         });
         let creator = new_creator();
         // Mock the `rustc --emit=dep-info` process by writing
@@ -727,26 +828,23 @@ bar.rs:
         });
         // Mock the `rustc --print=file-names` process output.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "foo.rlib\nfoo.a", "")));
-        const RUSTC_DIGEST: &'static str = "1234abcd";
-        // SHA-1 digest of an empty file.
-        const EMPTY_DIGEST: &'static [u8] = b"da39a3ee5e6b4b0d3255bfef95601890afd80709";
         let pool = CpuPool::new(1);
-        let res = hasher.generate_hash_key(&creator, "rustc", RUSTC_DIGEST,
+        let res = hasher.generate_hash_key(&creator,
                                            &f.tempdir.path().to_string_lossy(),
                                            &pool).wait().unwrap();
         let mut m = sha1::Sha1::new();
         // Version.
         m.update(CACHE_VERSION);
-        // Compiler digest.
-        m.update(RUSTC_DIGEST.as_bytes());
-        // Arguments.
-        m.update(b"ab");
+        // sysroot shlibs digests.
+        m.update(FAKE_DIGEST.as_bytes());
+        // Arguments, with externs sorted at the end.
+        m.update(b"ab--externabc--externxyz");
         // bar.rs (source file, from dep-info)
-        m.update(EMPTY_DIGEST);
+        m.update(EMPTY_DIGEST.as_bytes());
         // foo.rs (source file, from dep-info)
-        m.update(EMPTY_DIGEST);
+        m.update(EMPTY_DIGEST.as_bytes());
         // bar.rlib (extern crate, from externs)
-        m.update(EMPTY_DIGEST);
+        m.update(EMPTY_DIGEST.as_bytes());
         let digest = m.digest().to_string();
         match res {
             HashResult::Ok { key, compilation } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ mod mock_command;
 mod protocol;
 mod server;
 mod simples3;
+mod util;
 
 use std::env;
 use std::io::Write;

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,12 +61,14 @@ extern crate zip;
 #[macro_use]
 mod test;
 
+#[macro_use]
+mod errors;
+
 mod cache;
 mod client;
 mod cmdline;
 mod commands;
 mod compiler;
-mod errors;
 mod mock_command;
 mod protocol;
 mod server;

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,8 +18,8 @@ use cache::{
 };
 use compiler::{
     CacheControl,
-    Compiler,
     CompilerArguments,
+    CompilerInfo,
     CompileResult,
     MissType,
     ParsedArguments,
@@ -278,7 +278,7 @@ struct SccacheService<C: CommandCreatorSync> {
     storage: Arc<Storage>,
 
     /// A cache of known compiler info.
-    compilers: Rc<RefCell<HashMap<String, Option<Compiler>>>>,
+    compilers: Rc<RefCell<HashMap<String, Option<CompilerInfo>>>>,
 
     /// True if all compiles should be forced, ignoring existing cache entries.
     ///
@@ -445,7 +445,7 @@ impl<C> SccacheService<C>
     /// Look up compiler info from the cache for the compiler `path`.
     /// If not cached, determine the compiler type and cache the result.
     fn compiler_info(&self, path: &str)
-                     -> SFuture<Option<Compiler>> {
+                     -> SFuture<Option<CompilerInfo>> {
         trace!("compiler_info_cached");
         let result = match metadata(path) {
             Ok(attr) => {
@@ -486,7 +486,7 @@ impl<C> SccacheService<C>
     /// Check that we can handle and cache `cmd` when run with `compiler`.
     /// If so, run `start_compile_task` to execute it.
     fn check_compiler(&self,
-                      compiler: Option<Compiler>,
+                      compiler: Option<CompilerInfo>,
                       cmd: Vec<String>,
                       cwd: String)
                       -> SccacheResponse {
@@ -530,7 +530,7 @@ impl<C> SccacheService<C>
     /// a compile result in the cache or execute the compilation and store
     /// the result in the cache.
     fn start_compile_task(&self,
-                          compiler: Compiler,
+                          compiler: CompilerInfo,
                           parsed_arguments: ParsedArguments,
                           arguments: Vec<String>,
                           cwd: String,

--- a/src/server.rs
+++ b/src/server.rs
@@ -540,13 +540,13 @@ impl<C> SccacheService<C>
         } else {
             CacheControl::Default
         };
-        let result = compiler.get_cached_or_compile(&self.creator,
-                                                    &self.storage,
-                                                    &arguments,
-                                                    &parsed_arguments,
-                                                    &cwd,
+        let result = compiler.get_cached_or_compile(self.creator.clone(),
+                                                    self.storage.clone(),
+                                                    arguments,
+                                                    parsed_arguments,
+                                                    cwd,
                                                     cache_control,
-                                                    &self.pool);
+                                                    self.pool.clone());
         let me = self.clone();
         let task = result.then(move |result| {
             let mut res = ServerResponse::new();

--- a/src/server.rs
+++ b/src/server.rs
@@ -278,7 +278,7 @@ struct SccacheService<C: CommandCreatorSync> {
     storage: Arc<Storage>,
 
     /// A cache of known compiler info.
-    compilers: Rc<RefCell<HashMap<String, Option<CompilerInfo>>>>,
+    compilers: Rc<RefCell<HashMap<String, Option<CompilerInfo<C>>>>>,
 
     /// True if all compiles should be forced, ignoring existing cache entries.
     ///
@@ -445,7 +445,7 @@ impl<C> SccacheService<C>
     /// Look up compiler info from the cache for the compiler `path`.
     /// If not cached, determine the compiler type and cache the result.
     fn compiler_info(&self, path: &str)
-                     -> SFuture<Option<CompilerInfo>> {
+                     -> SFuture<Option<CompilerInfo<C>>> {
         trace!("compiler_info_cached");
         let result = match metadata(path) {
             Ok(attr) => {
@@ -486,7 +486,7 @@ impl<C> SccacheService<C>
     /// Check that we can handle and cache `cmd` when run with `compiler`.
     /// If so, run `start_compile_task` to execute it.
     fn check_compiler(&self,
-                      compiler: Option<CompilerInfo>,
+                      compiler: Option<CompilerInfo<C>>,
                       cmd: Vec<String>,
                       cwd: String)
                       -> SccacheResponse {
@@ -530,7 +530,7 @@ impl<C> SccacheService<C>
     /// a compile result in the cache or execute the compilation and store
     /// the result in the cache.
     fn start_compile_task(&self,
-                          compiler: CompilerInfo,
+                          compiler: CompilerInfo<C>,
                           parsed_arguments: ParsedArguments,
                           arguments: Vec<String>,
                           cwd: String,

--- a/src/server.rs
+++ b/src/server.rs
@@ -72,6 +72,7 @@ use tokio_proto::BindServer;
 use tokio_proto::streaming::pipeline::{Frame, ServerProto, Transport};
 use tokio_proto::streaming::{Body, Message};
 use tokio_service::Service;
+use util::fmt_duration_as_secs;
 
 use errors::*;
 
@@ -618,7 +619,7 @@ impl<C> SccacheService<C>
                     }
                     //TODO: save cache stats!
                     Ok(Some(info)) => {
-                        debug!("[{}]: Cache write finished in {}.{:03}s", info.object_file, info.duration.as_secs(), info.duration.subsec_nanos() / 1000_000);
+                        debug!("[{}]: Cache write finished in {}", info.object_file, fmt_duration_as_secs(&info.duration));
                         me.stats.borrow_mut().cache_writes += 1;
                         me.stats.borrow_mut().cache_write_duration += info.duration;
                     }
@@ -711,9 +712,9 @@ impl ServerStats {
                 stat.set_name(String::from($name));
                 if $num > 0 {
                     let duration = $dur / $num as u32;
-                    stat.set_str(format!("{}.{:03} s", duration.as_secs(), duration.subsec_nanos() / 1000_000));
+                    stat.set_str(fmt_duration_as_secs(&duration));
                 } else {
-                    stat.set_str("0.000 s".to_owned());
+                    stat.set_str("0.000s".to_owned());
                 }
                 $vec.push(stat);
             }};

--- a/src/simples3/credential.rs
+++ b/src/simples3/credential.rs
@@ -315,7 +315,7 @@ impl IamProvider {
 impl ProvideAwsCredentials for IamProvider {
     fn credentials(&self) -> SFuture<AwsCredentials> {
         let url = match var("AWS_IAM_CREDENTIALS_URL") {
-            Ok(url) => Box::new(future::ok(url)) as SFuture<_>,
+            Ok(url) => f_ok(url),
             Err(_) => self.iam_role(),
         };
         let url = url.and_then(|url| {

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -200,7 +200,7 @@ fn test_server_compile() {
         // Compiler invocation.
         //TODO: wire up a way to get data written to stdin.
         let obj = f.tempdir.path().join("file.o");
-        c.next_command_calls(move || {
+        c.next_command_calls(move |_| {
             // Pretend to compile something.
             match File::create(&obj)
                 .and_then(|mut f| f.write_all(b"file contents")) {

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -71,7 +71,7 @@ pub fn next_command(creator : &Arc<Mutex<MockCommandCreator>>,
     creator.lock().unwrap().next_command_spawns(child);
 }
 
-pub fn next_command_calls<C: Fn() -> io::Result<MockChild> + Send + 'static>(creator : &Arc<Mutex<MockCommandCreator>>, call: C) {
+pub fn next_command_calls<C: Fn(&[OsString]) -> io::Result<MockChild> + Send + 'static>(creator: &Arc<Mutex<MockCommandCreator>>, call: C) {
     creator.lock().unwrap().next_command_calls(call);
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,44 @@
+// Copyright 2017 Mozilla Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use futures_cpupool::CpuPool;
+use sha1;
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::BufReader;
+use std::path::PathBuf;
+
+use errors::*;
+
+/// Calculate the SHA-1 digest of the contents of `path`, running
+/// the actual hash computation on a background thread in `pool`.
+pub fn sha1_digest<T>(path: T, pool: &CpuPool) -> SFuture<String>
+    where T: Into<PathBuf>
+{
+    let path = path.into();
+    Box::new(pool.spawn_fn(move || -> Result<_> {
+        let f = File::open(&path)?;
+        let mut m = sha1::Sha1::new();
+        let mut reader = BufReader::new(f);
+        loop {
+            let mut buffer = [0; 1024];
+            let count = reader.read(&mut buffer[..])?;
+            if count == 0 {
+                break;
+            }
+            m.update(&buffer[..count]);
+        }
+        Ok(m.digest().to_string())
+    }))
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -29,7 +29,7 @@ pub fn sha1_digest<T>(path: T, pool: &CpuPool) -> SFuture<String>
 {
     let path = path.into();
     Box::new(pool.spawn_fn(move || -> Result<_> {
-        let f = File::open(&path)?;
+        let f = File::open(&path).chain_err(|| "Failed to open file for hashing")?;
         let mut m = sha1::Sha1::new();
         let mut reader = BufReader::new(f);
         loop {

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,6 +18,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use errors::*;
 
@@ -41,4 +42,10 @@ pub fn sha1_digest<T>(path: T, pool: &CpuPool) -> SFuture<String>
         }
         Ok(m.digest().to_string())
     }))
+}
+
+/// Format `duration` as seconds with a fractional component.
+pub fn fmt_duration_as_secs(duration: &Duration) -> String
+{
+    format!("{}.{:03}s", duration.as_secs(), duration.subsec_nanos() / 1000_000)
 }


### PR DESCRIPTION
This is a pretty large set of changes, but it breaks down into a few parts:
* First, I spent some time refactoring the existing logic from `CompilerInfo::get_cached_or_compile`, since it was all tangled with the logic of running the C preprocessor. I split that out into a separate method and moved a few other things around while I was there. This is the "Pre-Rust support refactoring, Part 1" change.
* Next, I added some traits to hide implementation details of the actual compilation process: `Compiler`, `CompilerHasher`, and `Compilation`. I changed `get_cached_or_compile` and everywhere else that was interacting with compilers to only work with boxed trait objects of these types, and made it so that `Compiler::parse_arguments` returns a boxed `CompilerHasher`, and then `CompilerHasher::generate_hash_key` returns a boxed `Compilation`. This way the C compiler implementation and the Rust compiler implementation can each persist some private state through the process. I refactored the C compilation bits further into an implementation of these traits that's generic over a `CCompilerImpl` trait, implementations of which simply call into the existing gcc/clang/msvc functions. This is the "Pre-Rust support refactoring, Part 2" and "Part 3" changes.
* Finally, I added a Rust implementation of the traits. A few refactoring-type changes snuck in to this changeset but I was too lazy to split them out at this point.

There are also a few tiny refactoring changesets mixed in there, I tried to split small, separable changes out when possible to make the whole thing easier to follow.