### PR TITLE
Changes for sccache+msvc+LLVM

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -64,6 +64,8 @@ pub struct ParsedArguments {
     pub preprocessor_args: Vec<String>,
     /// Commandline arguments for the preprocessor or the compiler.
     pub common_args: Vec<String>,
+    /// Whether or not the `-showIncludes` argument is passed on MSVC
+    pub msvc_show_includes: bool,
 }
 
 impl ParsedArguments {
@@ -77,7 +79,7 @@ struct CCompilation<I: CCompilerImpl> {
     parsed_args: ParsedArguments,
     executable: String,
     /// The output from running the preprocessor.
-    preprocessor_output: Vec<u8>,
+    preprocessor_result: process::Output,
     compiler: I,
 }
 
@@ -114,7 +116,7 @@ pub trait CCompilerImpl: Clone + fmt::Debug + Send + 'static {
     fn compile<T>(&self,
                   creator: &T,
                   executable: &str,
-                  preprocessor_output: Vec<u8>,
+                  preprocessor_result: process::Output,
                   parsed_args: &ParsedArguments,
                   cwd: &str,
                   env_vars: &[(OsString, OsString)],
@@ -217,7 +219,7 @@ impl<T, I> CompilerHasher<T> for CCompilerHasher<I>
                 compilation: Box::new(CCompilation {
                     parsed_args: parsed_args,
                     executable: executable,
-                    preprocessor_output: preprocessor_result.stdout,
+                    preprocessor_result: preprocessor_result,
                     compiler: compiler,
                 }),
             })
@@ -244,8 +246,8 @@ impl<T: CommandCreatorSync, I: CCompilerImpl> Compilation<T> for CCompilation<I>
                -> SFuture<(Cacheable, process::Output)>
     {
         let me = *self;
-        let CCompilation { parsed_args, executable, preprocessor_output, compiler } = me;
-        compiler.compile(creator, &executable, preprocessor_output, &parsed_args, cwd, env_vars,
+        let CCompilation { parsed_args, executable, preprocessor_result, compiler } = me;
+        compiler.compile(creator, &executable, preprocessor_result, &parsed_args, cwd, env_vars,
                          pool)
     }
 

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -154,9 +154,15 @@ pub fn parse_arguments(arguments: &[String]) -> CompilerArguments<ParsedArgument
     let mut depfile = None;
 
     //TODO: support arguments that start with / as well.
-    let mut it = arguments.iter();
+    let mut it = arguments.iter().map(|i| {
+        if i.starts_with("/") {
+            format!("-{}", &i[1..])
+        } else {
+            i.to_string()
+        }
+    });
     while let Some(arg) = it.next() {
-        match arg.as_ref() {
+        match &arg[..] {
             "-c" => compilation = true,
             v if v.starts_with("-Fo") => {
                 output_arg = Some(String::from(&v[3..]));
@@ -195,7 +201,7 @@ pub fn parse_arguments(arguments: &[String]) -> CompilerArguments<ParsedArgument
                     // Can't cache compilations with multiple inputs.
                     return CompilerArguments::CannotCache("multiple input files");
                 }
-                input_arg = Some(v);
+                input_arg = Some(v.to_owned());
             }
         }
         input_arg = Some(v);
@@ -206,7 +212,7 @@ pub fn parse_arguments(arguments: &[String]) -> CompilerArguments<ParsedArgument
     }
     let (input, extension) = match input_arg {
         Some(i) => {
-            match Path::new(i).extension().and_then(|e| e.to_str()) {
+            match Path::new(&i).extension().and_then(|e| e.to_str()) {
                 Some(e) => (i.to_owned(), e.to_owned()),
                 _ => {
                     trace!("Bad or missing source extension: {:?}", i);

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -155,54 +155,50 @@ pub fn parse_arguments(arguments: &[String]) -> CompilerArguments<ParsedArgument
 
     //TODO: support arguments that start with / as well.
     let mut it = arguments.iter();
-    loop {
-        match it.next() {
-            Some(arg) => {
-                match arg.as_ref() {
-                    "-c" => compilation = true,
-                    v if v.starts_with("-Fo") => {
-                        output_arg = Some(String::from(&v[3..]));
-                    }
-                    // Arguments that take a value.
-                    "-FI" => {
-                        common_args.push(arg.clone());
-                        if let Some(arg_val) = it.next() {
-                            common_args.push(arg_val.clone());
-                        }
-                    }
-                    v @ _ if v.starts_with("-deps") => {
-                        depfile = Some(v[5..].to_owned());
-                    }
-                    // Arguments we can't handle.
-                    "-showIncludes" => return CompilerArguments::CannotCache("-showIncludes"),
-                    a if a.starts_with('@') => return CompilerArguments::CannotCache("@file"),
-                    // Arguments we can't handle because they output more files.
-                    // TODO: support more multi-file outputs.
-                    "-FA" | "-Fa" | "-Fe" | "-Fm" | "-Fp" | "-FR" | "-Fx" => return CompilerArguments::CannotCache("multi-file output"),
-                    "-Zi" => {
-                        debug_info = true;
-                        common_args.push(arg.clone());
-                    }
-                    v if v.starts_with("-Fd") => {
-                        pdb = Some(String::from(&v[3..]));
-                        common_args.push(arg.clone());
-                    }
-                    // Other options.
-                    v if v.starts_with('-') && v.len() > 1 => {
-                        common_args.push(arg.clone());
-                    }
-                    // Anything else is an input file.
-                    v => {
-                        if input_arg.is_some() {
-                            // Can't cache compilations with multiple inputs.
-                            return CompilerArguments::CannotCache("multiple input files");
-                        }
-                        input_arg = Some(v);
-                    }
+    while let Some(arg) = it.next() {
+        match arg.as_ref() {
+            "-c" => compilation = true,
+            v if v.starts_with("-Fo") => {
+                output_arg = Some(String::from(&v[3..]));
+            }
+            // Arguments that take a value.
+            "-FI" => {
+                common_args.push(arg.clone());
+                if let Some(arg_val) = it.next() {
+                    common_args.push(arg_val.clone());
                 }
             }
-            None => break,
+            v @ _ if v.starts_with("-deps") => {
+                depfile = Some(v[5..].to_owned());
+            }
+            // Arguments we can't handle.
+            "-showIncludes" => return CompilerArguments::CannotCache("-showIncludes"),
+            a if a.starts_with('@') => return CompilerArguments::CannotCache("@file"),
+            // Arguments we can't handle because they output more files.
+            // TODO: support more multi-file outputs.
+            "-FA" | "-Fa" | "-Fe" | "-Fm" | "-Fp" | "-FR" | "-Fx" => return CompilerArguments::CannotCache("multi-file output"),
+            "-Zi" => {
+                debug_info = true;
+                common_args.push(arg.clone());
+            }
+            v if v.starts_with("-Fd") => {
+                pdb = Some(String::from(&v[3..]));
+                common_args.push(arg.clone());
+            }
+            // Other options.
+            v if v.starts_with('-') && v.len() > 1 => {
+                common_args.push(arg.clone());
+            }
+            // Anything else is an input file.
+            v => {
+                if input_arg.is_some() {
+                    // Can't cache compilations with multiple inputs.
+                    return CompilerArguments::CannotCache("multiple input files");
+                }
+                input_arg = Some(v);
+            }
         }
+        input_arg = Some(v);
     }
     // We only support compilation.
     if !compilation {

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -33,6 +33,7 @@ use std::io::{
     self,
     Write,
 };
+use std::mem;
 use std::path::Path;
 use std::process::{self,Stdio};
 use util::run_input_output;
@@ -72,7 +73,7 @@ impl CCompilerImpl for MSVC {
     fn compile<T>(&self,
                   creator: &T,
                   executable: &str,
-                  preprocessor_output: Vec<u8>,
+                  preprocessor_result: process::Output,
                   parsed_args: &ParsedArguments,
                   cwd: &str,
                   env_vars: &[(OsString, OsString)],
@@ -80,7 +81,7 @@ impl CCompilerImpl for MSVC {
                   -> SFuture<(Cacheable, process::Output)>
         where T: CommandCreatorSync
     {
-        compile(creator, executable, preprocessor_output, parsed_args, cwd, env_vars, pool)
+        compile(creator, executable, preprocessor_result, parsed_args, cwd, env_vars, pool)
     }
 }
 
@@ -152,8 +153,8 @@ pub fn parse_arguments(arguments: &[String]) -> CompilerArguments<ParsedArgument
     let mut debug_info = false;
     let mut pdb = None;
     let mut depfile = None;
+    let mut show_includes = false;
 
-    //TODO: support arguments that start with / as well.
     let mut it = arguments.iter().map(|i| {
         if i.starts_with("/") {
             format!("-{}", &i[1..])
@@ -177,8 +178,8 @@ pub fn parse_arguments(arguments: &[String]) -> CompilerArguments<ParsedArgument
             v @ _ if v.starts_with("-deps") => {
                 depfile = Some(v[5..].to_owned());
             }
+            "-showIncludes" => show_includes = true,
             // Arguments we can't handle.
-            "-showIncludes" => return CompilerArguments::CannotCache("-showIncludes"),
             a if a.starts_with('@') => return CompilerArguments::CannotCache("@file"),
             // Arguments we can't handle because they output more files.
             // TODO: support more multi-file outputs.
@@ -204,7 +205,6 @@ pub fn parse_arguments(arguments: &[String]) -> CompilerArguments<ParsedArgument
                 input_arg = Some(v.to_owned());
             }
         }
-        input_arg = Some(v);
     }
     // We only support compilation.
     if !compilation {
@@ -250,6 +250,7 @@ pub fn parse_arguments(arguments: &[String]) -> CompilerArguments<ParsedArgument
         outputs: outputs,
         preprocessor_args: vec!(),
         common_args: common_args,
+        msvc_show_includes: show_includes,
     })
 }
 
@@ -365,7 +366,7 @@ pub fn preprocess<T>(creator: &T,
 
 fn compile<T>(creator: &T,
               executable: &str,
-              preprocessor_output: Vec<u8>,
+              preprocessor_result: process::Output,
               parsed_args: &ParsedArguments,
               cwd: &str,
               env_vars: &[(OsString, OsString)],
@@ -400,7 +401,7 @@ fn compile<T>(creator: &T,
             Some(name) => name,
             None => return f_err("missing input filename"),
         };
-        write_temp_file(pool, filename.as_ref(), preprocessor_output)
+        write_temp_file(pool, filename.as_ref(), preprocessor_result.stdout)
     };
 
     let mut cmd = creator.clone().new_command_sync(executable);
@@ -432,7 +433,7 @@ fn compile<T>(creator: &T,
         .env_clear()
         .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
         .current_dir(cwd);
-    Box::new(output.or_else(move |err| -> SFuture<_> {
+    let ret = output.or_else(move |err| -> SFuture<_> {
         match err {
             // If compiling from the preprocessed source failed, try
             // again from the original source.
@@ -444,6 +445,25 @@ fn compile<T>(creator: &T,
             }
             e @ _ => f_err(e),
         }
+    });
+
+    // If the `-showIncludes` command line option was originally passed we need
+    // to be sure to ship the output from the preprocessor as the actual
+    // result of this compilation.
+    //
+    // Note, though, that when we ran the preprocessor we passed `-E` which
+    // means that the "show includes" business when to stderr. Normally, though,
+    // the compiler emits `-showIncludes` output to stdout. To handle that we
+    // take the stderr of the preprocessor and prepend it to the stdout of the
+    // compilation.
+    let mut extra_stdout = Vec::new();
+    if parsed_args.msvc_show_includes {
+        extra_stdout = preprocessor_result.stderr;
+    }
+    Box::new(ret.map(|(cacheable, mut output)| {
+        let prev = mem::replace(&mut output.stdout, extra_stdout);
+        output.stdout.extend(prev);
+        (cacheable, output)
     }))
 }
 
@@ -478,70 +498,132 @@ mod test {
 
     #[test]
     fn test_parse_arguments_simple() {
-        match parse_arguments(&stringvec!["-c", "foo.c", "-Fofoo.obj"]) {
-            CompilerArguments::Ok(ParsedArguments { input, extension, depfile: _depfile, outputs, preprocessor_args, common_args }) => {
-                assert!(true, "Parsed ok");
-                assert_eq!("foo.c", input);
-                assert_eq!("c", extension);
-                assert_map_contains!(outputs, ("obj", "foo.obj"));
-                //TODO: fix assert_map_contains to assert no extra keys!
-                assert_eq!(1, outputs.len());
-                assert!(preprocessor_args.is_empty());
-                assert!(common_args.is_empty());
-            }
-            o @ _ => assert!(false, format!("Got unexpected parse result: {:?}", o)),
-        }
+        let args = stringvec!["-c", "foo.c", "-Fofoo.obj"];
+        let ParsedArguments {
+            input,
+            extension,
+            depfile: _,
+            outputs,
+            preprocessor_args,
+            msvc_show_includes,
+            common_args,
+        } = match parse_arguments(&args) {
+            CompilerArguments::Ok(args) => args,
+            o @ _ => panic!("Got unexpected parse result: {:?}", o),
+        };
+        assert!(true, "Parsed ok");
+        assert_eq!("foo.c", input);
+        assert_eq!("c", extension);
+        assert_map_contains!(outputs, ("obj", "foo.obj"));
+        //TODO: fix assert_map_contains to assert no extra keys!
+        assert_eq!(1, outputs.len());
+        assert!(preprocessor_args.is_empty());
+        assert!(common_args.is_empty());
+        assert!(!msvc_show_includes);
+    }
+
+    #[test]
+    fn parse_argument_slashes() {
+        let args = stringvec!["-c", "foo.c", "/Fofoo.obj"];
+        let ParsedArguments {
+            input,
+            extension,
+            depfile: _,
+            outputs,
+            preprocessor_args,
+            msvc_show_includes,
+            common_args,
+        } = match parse_arguments(&args) {
+            CompilerArguments::Ok(args) => args,
+            o @ _ => panic!("Got unexpected parse result: {:?}", o),
+        };
+        assert!(true, "Parsed ok");
+        assert_eq!("foo.c", input);
+        assert_eq!("c", extension);
+        assert_map_contains!(outputs, ("obj", "foo.obj"));
+        //TODO: fix assert_map_contains to assert no extra keys!
+        assert_eq!(1, outputs.len());
+        assert!(preprocessor_args.is_empty());
+        assert!(common_args.is_empty());
+        assert!(!msvc_show_includes);
     }
 
     #[test]
     fn test_parse_arguments_extra() {
-        match parse_arguments(&stringvec!["-c", "foo.c", "-foo", "-Fofoo.obj", "-bar"]) {
-            CompilerArguments::Ok(ParsedArguments { input, extension, depfile: _depfile, outputs, preprocessor_args, common_args }) => {
-                assert!(true, "Parsed ok");
-                assert_eq!("foo.c", input);
-                assert_eq!("c", extension);
-                assert_map_contains!(outputs, ("obj", "foo.obj"));
-                //TODO: fix assert_map_contains to assert no extra keys!
-                assert_eq!(1, outputs.len());
-                assert!(preprocessor_args.is_empty());
-                assert_eq!(common_args, &["-foo", "-bar"]);
-            }
-            o @ _ => assert!(false, format!("Got unexpected parse result: {:?}", o)),
-        }
+        let args = stringvec!["-c", "foo.c", "-foo", "-Fofoo.obj", "-bar"];
+        let ParsedArguments {
+            input,
+            extension,
+            depfile: _,
+            outputs,
+            preprocessor_args,
+            msvc_show_includes,
+            common_args,
+        } = match parse_arguments(&args) {
+            CompilerArguments::Ok(args) => args,
+            o @ _ => panic!("Got unexpected parse result: {:?}", o),
+        };
+        assert!(true, "Parsed ok");
+        assert_eq!("foo.c", input);
+        assert_eq!("c", extension);
+        assert_map_contains!(outputs, ("obj", "foo.obj"));
+        //TODO: fix assert_map_contains to assert no extra keys!
+        assert_eq!(1, outputs.len());
+        assert!(preprocessor_args.is_empty());
+        assert_eq!(common_args, &["-foo", "-bar"]);
+        assert!(!msvc_show_includes);
     }
 
     #[test]
     fn test_parse_arguments_values() {
-        match parse_arguments(&stringvec!["-c", "foo.c", "-FI", "file", "-Fofoo.obj"]) {
-            CompilerArguments::Ok(ParsedArguments { input, extension, depfile: _depfile, outputs, preprocessor_args, common_args }) => {
-                assert!(true, "Parsed ok");
-                assert_eq!("foo.c", input);
-                assert_eq!("c", extension);
-                assert_map_contains!(outputs, ("obj", "foo.obj"));
-                //TODO: fix assert_map_contains to assert no extra keys!
-                assert_eq!(1, outputs.len());
-                assert!(preprocessor_args.is_empty());
-                assert_eq!(common_args, &["-FI", "file"]);
-            }
-            o @ _ => assert!(false, format!("Got unexpected parse result: {:?}", o)),
-        }
+        let args = stringvec!["-c", "foo.c", "-FI", "file", "-Fofoo.obj", "/showIncludes"];
+        let ParsedArguments {
+            input,
+            extension,
+            depfile: _,
+            outputs,
+            preprocessor_args,
+            msvc_show_includes,
+            common_args,
+        } = match parse_arguments(&args) {
+            CompilerArguments::Ok(args) => args,
+            o @ _ => panic!("Got unexpected parse result: {:?}", o),
+        };
+        assert!(true, "Parsed ok");
+        assert_eq!("foo.c", input);
+        assert_eq!("c", extension);
+        assert_map_contains!(outputs, ("obj", "foo.obj"));
+        //TODO: fix assert_map_contains to assert no extra keys!
+        assert_eq!(1, outputs.len());
+        assert!(preprocessor_args.is_empty());
+        assert_eq!(common_args, &["-FI", "file"]);
+        assert!(msvc_show_includes);
     }
 
     #[test]
     fn test_parse_arguments_pdb() {
-        match parse_arguments(&stringvec!["-c", "foo.c", "-Zi", "-Fdfoo.pdb", "-Fofoo.obj"]) {
-            CompilerArguments::Ok(ParsedArguments { input, extension, depfile: _depfile, outputs, preprocessor_args, common_args }) => {
-                assert!(true, "Parsed ok");
-                assert_eq!("foo.c", input);
-                assert_eq!("c", extension);
-                assert_map_contains!(outputs, ("obj", "foo.obj"), ("pdb", "foo.pdb"));
-                //TODO: fix assert_map_contains to assert no extra keys!
-                assert_eq!(2, outputs.len());
-                assert!(preprocessor_args.is_empty());
-                assert_eq!(common_args, &["-Zi", "-Fdfoo.pdb"]);
-            }
-            o @ _ => assert!(false, format!("Got unexpected parse result: {:?}", o)),
-        }
+        let args = stringvec!["-c", "foo.c", "-Zi", "-Fdfoo.pdb", "-Fofoo.obj"];
+        let ParsedArguments {
+            input,
+            extension,
+            depfile: _,
+            outputs,
+            preprocessor_args,
+            msvc_show_includes,
+            common_args,
+        } = match parse_arguments(&args) {
+            CompilerArguments::Ok(args) => args,
+            o @ _ => panic!("Got unexpected parse result: {:?}", o),
+        };
+        assert!(true, "Parsed ok");
+        assert_eq!("foo.c", input);
+        assert_eq!("c", extension);
+        assert_map_contains!(outputs, ("obj", "foo.obj"), ("pdb", "foo.pdb"));
+        //TODO: fix assert_map_contains to assert no extra keys!
+        assert_eq!(2, outputs.len());
+        assert!(preprocessor_args.is_empty());
+        assert_eq!(common_args, &["-Zi", "-Fdfoo.pdb"]);
+        assert!(!msvc_show_includes);
     }
 
     #[test]
@@ -598,6 +680,7 @@ mod test {
             outputs: vec![("obj", "foo.obj".to_owned())].into_iter().collect::<HashMap<&'static str, String>>(),
             preprocessor_args: vec!(),
             common_args: vec!(),
+            msvc_show_includes: false,
         };
         let compiler = f.bins[0].to_str().unwrap();
         // Compiler invocation.
@@ -605,7 +688,7 @@ mod test {
         next_command(&creator, Ok(MockChild::new(exit_status(1), "", "")));
         let (cacheable, _) = compile(&creator,
                                      &compiler,
-                                     vec!(),
+                                     empty_output(),
                                      &parsed_args,
                                      f.tempdir.path().to_str().unwrap(),
                                      &[],
@@ -629,6 +712,7 @@ mod test {
                           ("pdb", pdb.to_str().unwrap().to_owned())].into_iter().collect::<HashMap<&'static str, String>>(),
             preprocessor_args: vec!(),
             common_args: vec!(),
+            msvc_show_includes: false,
         };
         let compiler = f.bins[0].to_str().unwrap();
         // Compiler invocation.
@@ -636,7 +720,7 @@ mod test {
         next_command(&creator, Ok(MockChild::new(exit_status(1), "", "")));
         let (cacheable, _) = compile(&creator,
                                      &compiler,
-                                     vec!(),
+                                     empty_output(),
                                      &parsed_args,
                                      f.tempdir.path().to_str().unwrap(),
                                      &[],
@@ -658,6 +742,7 @@ mod test {
             outputs: vec![("obj", "foo.obj".to_owned())].into_iter().collect::<HashMap<&'static str, String>>(),
             preprocessor_args: vec!(),
             common_args: vec!(),
+            msvc_show_includes: false,
         };
         let compiler = f.bins[0].to_str().unwrap();
         // First compiler invocation fails.
@@ -666,7 +751,7 @@ mod test {
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));
         let (cacheable, _) = compile(&creator,
                                      &compiler,
-                                     vec!(),
+                                     empty_output(),
                                      &parsed_args,
                                      f.tempdir.path().to_str().unwrap(),
                                      &[],
@@ -674,5 +759,38 @@ mod test {
         assert_eq!(Cacheable::Yes, cacheable);
         // Ensure that we ran all processes.
         assert_eq!(0, creator.lock().unwrap().children.len());
+    }
+
+    #[test]
+    fn preprocess_output_appended() {
+        let creator = new_creator();
+        let pool = CpuPool::new(1);
+        let f = TestFixture::new();
+        let parsed_args = ParsedArguments {
+            input: "foo.c".to_owned(),
+            extension: "c".to_owned(),
+            depfile: None,
+            outputs: vec![("obj", "foo.obj".to_owned())].into_iter().collect::<HashMap<&'static str, String>>(),
+            preprocessor_args: vec!(),
+            common_args: vec!(),
+            msvc_show_includes: true,
+        };
+        let compiler = f.bins[0].to_str().unwrap();
+        // Compiler invocation.
+        next_command(&creator, Ok(MockChild::new(exit_status(0), "stdout1", "stderr1")));
+        next_command(&creator, Ok(MockChild::new(exit_status(1), "", "")));
+        let mut output = empty_output();
+        output.stdout.extend(b"stdout2");
+        output.stderr.extend(b"stderr2");
+        let (_, output) = compile(&creator,
+                                  &compiler,
+                                  output,
+                                  &parsed_args,
+                                  f.tempdir.path().to_str().unwrap(),
+                                  &[],
+                                  &pool).wait().unwrap();
+        assert_eq!(0, creator.lock().unwrap().children.len());
+        assert_eq!(output.stdout, b"stderr2stdout1");
+        assert_eq!(output.stderr, b"stderr1");
     }
 }

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -21,6 +21,8 @@ use std::ffi::OsString;
 use std::fs::{self,File};
 use std::io;
 use std::path::{Path,PathBuf};
+use std::process;
+
 use std::sync::{Arc,Mutex};
 use tempdir::TempDir;
 use tokio_core::reactor::Core;
@@ -174,6 +176,14 @@ impl TestFixture {
     }
 }
 
+
+pub fn empty_output() -> process::Output {
+    process::Output {
+        stdout: Vec::new(),
+        stderr: Vec::new(),
+        status: exit_status(0),
+    }
+}
 
 #[test]
 fn test_map_contains_ok() {


### PR DESCRIPTION
This few commits were what I found was necessary to get sccache fully working on MSVC when compiling LLVM in rust-lang/rust. It basically boiled down to:

Fixes https://github.com/mozilla/sccache/issues/61
Fixes https://github.com/mozilla/sccache/issues/47