### PR TITLE
Add timeouts to cache lookups and handle server eofs

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -562,7 +562,11 @@ fn handle_compile_response<T>(mut creator: T,
                 // get a response then we just forge ahead locally and run the
                 // compilation ourselves.
                 Err(ProtobufError::IoError(ref e))
-                    if e.kind() == io::ErrorKind::UnexpectedEof => {}
+                    if e.kind() == io::ErrorKind::UnexpectedEof => {
+                    writeln!(io::stderr(),
+                             "warning: sccache server looks like it shut down \
+                              unexpectedly, compiling locally instead").unwrap();
+                }
 
                 Err(e) => return Err(e).chain_err(|| {
                     //TODO: something better here?

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -32,7 +32,7 @@ use number_prefix::{
     Prefixed,
     Standalone,
 };
-use protobuf::RepeatedField;
+use protobuf::{RepeatedField, ProtobufError};
 use protocol::{
     CacheStats,
     ClientRequest,
@@ -545,43 +545,57 @@ fn handle_compile_response<T>(mut creator: T,
         CompileResponse::CompileStarted(_) => {
             debug!("Server sent CompileStarted");
             // Wait for CompileFinished.
-            let mut res = conn.read_one_response().chain_err(|| {
-                //TODO: something better here?
-                "error reading compile response from server"
-            })?;
-            if res.has_compile_finished() {
-                trace!("Server sent CompileFinished");
-                handle_compile_finished(res.take_compile_finished(),
-                                        stdout, stderr)
-            } else {
-                bail!("unexpected response from server")
+            match conn.read_one_response() {
+                Ok(mut res) => {
+                    if res.has_compile_finished() {
+                        trace!("Server sent CompileFinished");
+                        return handle_compile_finished(res.take_compile_finished(),
+                                                       stdout, stderr)
+                    } else {
+                        bail!("unexpected response from server")
+                    }
+                }
+
+                // Currently the shutdown behavior of the remote sccache server
+                // is to wait at most N seconds for all active connections to
+                // finish and then close everything. If we get unlucky and don't
+                // get a response then we just forge ahead locally and run the
+                // compilation ourselves.
+                Err(ProtobufError::IoError(ref e))
+                    if e.kind() == io::ErrorKind::UnexpectedEof => {}
+
+                Err(e) => return Err(e).chain_err(|| {
+                    //TODO: something better here?
+                    "error reading compile response from server"
+                })
             }
         }
         CompileResponse::UnhandledCompile(_) => {
             debug!("Server sent UnhandledCompile");
-            //TODO: possibly capture output here for testing.
-            let mut cmd = creator.new_command_sync(exe);
-            cmd.args(&cmdline)
-                .current_dir(cwd);
-            if log_enabled!(Trace) {
-                trace!("running command: {:?}", cmd);
-            }
-            let output = try!(core.run(run_input_output(cmd, None)));
-            if !output.stdout.is_empty() {
-                try!(stdout.write_all(&output.stdout));
-            }
-            if !output.stderr.is_empty() {
-                try!(stderr.write_all(&output.stderr));
-            }
-            Ok(output.status.code().unwrap_or_else(|| {
-                if let Some(sig) = status_signal(output.status) {
-                   println!("Compile terminated by signal {}", sig);
-                }
-                // Arbitrary.
-                2
-            }))
         }
+    };
+
+    //TODO: possibly capture output here for testing.
+    let mut cmd = creator.new_command_sync(exe);
+    cmd.args(&cmdline)
+        .current_dir(cwd);
+    if log_enabled!(Trace) {
+        trace!("running command: {:?}", cmd);
     }
+    let output = try!(core.run(run_input_output(cmd, None)));
+    if !output.stdout.is_empty() {
+        try!(stdout.write_all(&output.stdout));
+    }
+    if !output.stderr.is_empty() {
+        try!(stderr.write_all(&output.stderr));
+    }
+    Ok(output.status.code().unwrap_or_else(|| {
+        if let Some(sig) = status_signal(output.status) {
+           println!("Compile terminated by signal {}", sig);
+        }
+        // Arbitrary.
+        2
+    }))
 }
 
 /// Send a `Compile` request to the sccache server `conn`, and handle the response.

--- a/src/server.rs
+++ b/src/server.rs
@@ -557,7 +557,8 @@ impl<C> SccacheService<C>
                                                   arguments,
                                                   cwd,
                                                   cache_control,
-                                                  self.pool.clone());
+                                                  self.pool.clone(),
+                                                  self.handle.clone());
         let me = self.clone();
         let task = result.then(move |result| {
             let mut res = ServerResponse::new();
@@ -582,6 +583,10 @@ impl<C> SccacheService<C>
                                 MissType::ForcedRecache => {
                                     stats.cache_misses += 1;
                                     stats.forced_recaches += 1;
+                                }
+                                MissType::TimedOut => {
+                                    stats.cache_misses += 1;
+                                    stats.cache_timeouts += 1;
                                 }
                             }
                             stats.cache_read_miss_duration += duration;
@@ -663,6 +668,8 @@ struct ServerStats {
     pub cache_hits: u64,
     /// The count of cache misses for handled compile requests.
     pub cache_misses: u64,
+    /// The count of cache misses because the cache took too long to respond.
+    pub cache_timeouts: u64,
     /// The count of compilations which were successful but couldn't be cached.
     pub non_cacheable_compilations: u64,
     /// The count of compilations which forcibly ignored the cache.
@@ -692,6 +699,7 @@ impl Default for ServerStats {
             cache_errors: u64::default(),
             cache_hits: u64::default(),
             cache_misses: u64::default(),
+            cache_timeouts: u64::default(),
             non_cacheable_compilations: u64::default(),
             forced_recaches: u64::default(),
             cache_write_errors: u64::default(),
@@ -734,6 +742,7 @@ impl ServerStats {
         set_stat!(stats_vec, self.requests_executed, "Compile requests executed");
         set_stat!(stats_vec, self.cache_hits, "Cache hits");
         set_stat!(stats_vec, self.cache_misses, "Cache misses");
+        set_stat!(stats_vec, self.cache_timeouts, "Cache timeouts");
         set_stat!(stats_vec, self.forced_recaches, "Forced recaches");
         set_stat!(stats_vec, self.cache_write_errors, "Cache write errors");
         set_stat!(stats_vec, self.compile_fails, "Compilation failures");


### PR DESCRIPTION
We've unfortunately been having a lot of trouble over at https://github.com/rust-lang/rust/issues/40240 with sccache causing spurious failures. A number of logs are linked from that issue and to try to diagnose these issues I've enabled sccache logging which we cat to the Travis logs on failures.

Today we got a [new failure](https://github.com/rust-lang/rust/pull/40329#issuecomment-286054302) whose [failing build](https://travis-ci.org/rust-lang/rust/jobs/210484803) pointed to:

```
error: failed to execute compile
caused by: error reading compile response from server
caused by: IoError(Error { repr: Custom(Custom { kind: Other, error: StringError("unexpected EOF") }) })
caused by: unexpected EOF
```

Upon inspection of the sccache server debug logs (at the end of the build log) I noticed the failing object was `ELFDumper.cpp.o`, we attempted to fetch this object from the cache (I think), and no other messages about `ELFDumper.cpp.o` (success or not) happened on the server. My theory for what happened looks like:

* We sent off an S3 request 
* This S3 request then takes *forever*, presumably an "infinite" amount of time
* The sccache server decided to shut down due to being idle
* sccache waited 10 seconds for the S3 connection to finish
* It didn't, so we shut down the whole server, closing active connections
* The client then receives EOF unexpectedly, causing the error

To handle this failure mode this PR makes a few modifications

* The client now handles `UnexpectedEof` the same way it handles "unhandled compilation", it just compiles the object locally. This should protect against this in the future and other spurious races like this which are generally benign.
* I've added logging to shutdown of the server just to know when it happens
* I've added a timeout to cache lookups (60s currently) which should help avoiding waiting on S3 for too long.