### PR TITLE
Fix non-GMT time stamp in HTTP Date header

### DIFF
--- a/src/simples3/s3.rs
+++ b/src/simples3/s3.rs
@@ -102,7 +102,7 @@ impl Bucket {
         let mut request = Request::new(Method::Put, url.parse().unwrap());
 
         let content_type = "application/octet-stream";
-        let date = time::now().rfc822z().to_string();
+        let date = time::now_utc().rfc822().to_string();
         let mut canonical_headers = String::new();
         let token = creds.token().as_ref().map(|s| s.as_str());
         // Keep the list of header values sorted!


### PR DESCRIPTION
HTTP/1.1 [requires](https://tools.ietf.org/html/rfc2616#section-3.3.1) that all time stamps created be in GMT. Posts to S3 were using local time with a numerical offset instead.  Ceph's radosgw is [picky](http://tracker.ceph.com/issues/3973) enough to care, so this was preventing sccache from POSTing to ceph's S3 interface.