### PR TITLE
Remove dependency on `named_pipe`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 cache: cargo
 
 rust:
-  - 1.13.0
+  - 1.16.0
   - stable
   - beta
   - nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-disk-cache 0.1.0",
- "named_pipe 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-named-pipes 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -480,15 +480,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "named_pipe"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1134,7 +1125,6 @@ dependencies = [
 "checksum miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3e690c5df6b2f60acd45d56378981e827ff8295562fc8d34f573deb267a59cd1"
 "checksum miow 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3a78d2605eb97302c10cf944b8d96b0a2a890c52957caf92fcd1f24f69049579"
 "checksum msdos_time 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c04b68cc63a8480fb2550343695f7be72effdec953a9d4508161c3e69041c7d8"
-"checksum named_pipe 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57495d00ae2cf44c03e8cd9246f9a00eb803e63e9664ff61b5cc288c328ca9b8"
 "checksum native-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b805ee0e8fa268f67a4e5c7f4f80adb8af1fc4428ea0ce5b0ecab1430ef17ec0"
 "checksum net2 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "1dd775c6de972a1f57a34016f3b2bdc9e086e948f870b38675d1db410a21566b"
 "checksum num 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "d2ee34a0338c16ae67afb55824aaf8852700eb0f77ccd977807ccb7606b295f6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ tokio-uds = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2.2"
-named_pipe = "0.2.2"
 winapi = "0.2"
+mio-named-pipes = "0.1"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Sccache can also be used with local storage instead of remote.
 Requirements
 ------------
 
-sccache is a [Rust](https://www.rust-lang.org/) program. Building it requires `cargo` (and thus `rustc`). sccache currently requires **Rust 1.13**.
+sccache is a [Rust](https://www.rust-lang.org/) program. Building it requires `cargo` (and thus `rustc`). sccache currently requires **Rust 1.16**.
 
 We recommend you install Rust via [Rustup](https://rustup.rs/). The generated binaries can be built so that they are very portable, see [scripts/build-release.sh](scripts/build-release.sh).
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(feature = "unstable", feature(windows_process_extensions))]
-
 extern crate app_dirs;
 extern crate chrono;
 extern crate clap;
@@ -38,7 +36,7 @@ extern crate lru_disk_cache;
 extern crate fern;
 extern crate libc;
 #[cfg(windows)]
-extern crate named_pipe;
+extern crate mio_named_pipes;
 extern crate number_prefix;
 extern crate protobuf;
 extern crate regex;

--- a/src/mock_command.rs
+++ b/src/mock_command.rs
@@ -192,7 +192,7 @@ impl RunCommand for AsyncCommand {
         self
     }
 
-    #[cfg(all(windows, feature = "unstable"))]
+    #[cfg(windows)]
     fn no_console(&mut self) -> &mut AsyncCommand {
         use std::os::windows::process::CommandExt;
         const CREATE_NO_WINDOW: u32 = 0x08000000;
@@ -200,7 +200,7 @@ impl RunCommand for AsyncCommand {
         self
     }
 
-    #[cfg(not(all(windows, feature = "unstable")))]
+    #[cfg(unix)]
     fn no_console(&mut self) -> &mut AsyncCommand {
         self
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -98,12 +98,13 @@ fn notify_server_startup(name: &Option<OsString>, success: bool) -> io::Result<(
 
 #[cfg(windows)]
 fn notify_server_startup(name: &Option<OsString>, success: bool) -> io::Result<()> {
-    use named_pipe::PipeClient;
+    use std::fs::OpenOptions;
+
     let name = match *name {
         Some(ref s) => s,
         None => return Ok(()),
     };
-    let pipe = try!(PipeClient::connect(name));
+    let pipe = try!(OpenOptions::new().write(true).read(true).open(name));
     notify_server_startup_internal(pipe, success)
 }
 


### PR DESCRIPTION
I was sporadically receiving a segfault locally when trying to debug issues on
Windows and in tracking this down I discovered blackbeam/named_pipe#3 which
leads to segfaults locally on startup.

This switches the one use case to the relevant functionality in
`mio-named-pipes` (already pulled in as part of `tokio-process`) and then
otherwise mirrors the same logic as the Unix version, just waiting for a byte
with a timeout.