### PR TITLE
Send environment variables from client, hash CARGO_ env vars in Rust

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -43,6 +43,8 @@ pub enum Command {
         cmdline: Vec<OsString>,
         /// The directory in which to execute the command.
         cwd: PathBuf,
+        /// The environment variables to use for execution.
+        env_vars: Vec<(OsString, OsString)>,
     },
 }
 
@@ -146,6 +148,7 @@ pub fn parse() -> Result<Command> {
                 exe: exe.to_owned(),
                 cmdline: cmdline,
                 cwd: cwd,
+                env_vars: env::vars_os().collect(),
             })
         } else {
             bail!("No compile command");

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,16 +1,28 @@
+use std::ffi::OsString;
+
+/// A client request.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Request {
+    /// Zero the server's statistics.
     ZeroStats,
+    /// Get server statistics.
     GetStats,
+    /// Shut the server down gracefully.
     Shutdown,
+    /// Execute a compile or fetch a cached compilation result.
     Compile(Compile),
 }
 
+/// A server response.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Response {
+    /// Response for `Request::Compile`.
     Compile(CompileResponse),
+    /// Response for `Request::GetStats`, containing server statistics.
     Stats(CacheStats),
+    /// Response for `Request::Shutdown`, containing server statistics.
     ShuttingDown(CacheStats),
+    /// Second response for `Request::Compile`, containing the results of the compilation.
     CompileFinished(CompileFinished),
 }
 
@@ -23,35 +35,55 @@ pub enum CompileResponse {
     UnhandledCompile,
 }
 
+/// Server statistics.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CacheStats {
+    /// A `Vec` of individual statistics.
     pub stats: Vec<CacheStatistic>,
 }
 
+/// A single server statistic.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CacheStatistic {
+    /// Stat name.
     pub name: String,
+    /// Stat value.
     pub value: CacheStat,
 }
 
+/// A statistic value.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub enum CacheStat {
+    /// A count of occurrences.
     Count(u64),
+    /// An opaque string, such as a name.
     String(String),
+    /// A size in bytes.
     Size(u64),
 }
 
+/// Information about a finished compile, either from cache or executed locally.
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct CompileFinished {
+    /// The return code of the compile process, if available.
     pub retcode: Option<i32>,
+    /// The signal that terminated the compile process, if available.
     pub signal: Option<i32>,
+    /// The compiler's stdout.
     pub stdout: Vec<u8>,
+    /// The compiler's stderr.
     pub stderr: Vec<u8>,
 }
 
+/// The contents of a compile request from a client.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Compile {
+    /// The full path to the compiler executable.
     pub exe: String,
+    /// The current working directory in which to execute the compile.
     pub cwd: String,
+    /// The commandline arguments passed to the compiler.
     pub args: Vec<String>,
+    /// The environment variables present when the compiler was executed, as (var, val).
+    pub env_vars: Vec<(OsString, OsString)>,
 }

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -166,7 +166,7 @@ fn test_server_unsupported_compiler() {
     let mut stderr = Cursor::new(Vec::new());
     let path = Some(f.paths);
     let mut core = Core::new().unwrap();
-    assert_eq!(0, do_compile(client_creator.clone(), &mut core, conn, exe, cmdline, cwd, path, &mut stdout, &mut stderr).unwrap());
+    assert_eq!(0, do_compile(client_creator.clone(), &mut core, conn, exe, cmdline, cwd, path, vec![], &mut stdout, &mut stderr).unwrap());
     // Make sure we ran the mock processes.
     assert_eq!(0, server_creator.lock().unwrap().children.len());
     assert_eq!(0, client_creator.lock().unwrap().children.len());
@@ -222,7 +222,7 @@ fn test_server_compile() {
     let mut stderr = Cursor::new(Vec::new());
     let path = Some(f.paths);
     let mut core = Core::new().unwrap();
-    assert_eq!(0, do_compile(client_creator.clone(), &mut core, conn, exe, cmdline, cwd, path, &mut stdout, &mut stderr).unwrap());
+    assert_eq!(0, do_compile(client_creator.clone(), &mut core, conn, exe, cmdline, cwd, path, vec![], &mut stdout, &mut stderr).unwrap());
     // Make sure we ran the mock processes.
     assert_eq!(0, server_creator.lock().unwrap().children.len());
     assert_eq!(STDOUT, stdout.into_inner().as_slice());

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,6 +14,7 @@
 
 use futures_cpupool::CpuPool;
 use sha1;
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
@@ -48,4 +49,27 @@ pub fn sha1_digest<T>(path: T, pool: &CpuPool) -> SFuture<String>
 pub fn fmt_duration_as_secs(duration: &Duration) -> String
 {
     format!("{}.{:03}s", duration.as_secs(), duration.subsec_nanos() / 1000_000)
+}
+
+
+#[cfg(unix)]
+pub fn os_str_bytes(s: &OsStr) -> &[u8]
+{
+    use std::os::unix::ffi::OsStrExt;
+    s.as_bytes()
+}
+
+#[cfg(windows)]
+pub fn os_str_bytes(s: &OsStr) -> &[u8]
+{
+    use std::mem;
+    unsafe { mem::transmute(s) }
+}
+
+#[test]
+fn test_os_str_bytes() {
+    // Just very basic sanity checks in case anyone changes the underlying
+    // representation of OsStr on Windows.
+    assert_eq!(os_str_bytes(OsStr::new("hello")), b"hello");
+    assert_eq!(os_str_bytes(OsStr::new("你好")), "你好".as_bytes());
 }


### PR DESCRIPTION
This fixes a longstanding issue about not using the client's environment for compilation, and then uses that fix to include CARGO_ env vars in Rust hash generation.