### PR TITLE
Remove line break in release script

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -24,8 +24,7 @@ case $system in
     Linux)
         # Build using rust-musl-builder
         rm -rf target/x86_64-unknown-linux-musl/release
-        docker run --rm -it -v "$(pwd)":/home/rust/src -v ~/.cargo/git:/home/rust/.cargo/git -v
-        ~/.cargo/registry:/home/rust/.cargo/registry luser/rust-musl-builder sh -c "cargo build --release --features=all && cargo test --features=all --release"
+        docker run --rm -it -v "$(pwd)":/home/rust/src -v ~/.cargo/git:/home/rust/.cargo/git -v ~/.cargo/registry:/home/rust/.cargo/registry luser/rust-musl-builder sh -c "cargo build --release --features=all && cargo test --features=all --release"
         cp target/x86_64-unknown-linux-musl/release/sccache "$stagedir"
         strip "$stagedir/sccache"
         compress=xz


### PR DESCRIPTION
With `2349791` a line break in the release script is introduced that breaks
it. This patch removes that one. I noticed that when rereading the patch yesterday.