### PR TITLE
Re-enable s3 by default, build with --features=all in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ rust:
   - nightly
 
 before_script:
-  - if [[ "${TRAVIS_RUST_VERSION}" = "nightly" ]]; then export FEATURES="--features=unstable" export CARGO_TEST_EXTRA="--all"; fi
+  - if [[ "${TRAVIS_RUST_VERSION}" = "nightly" ]]; then export EXTRA_FEATURES=unstable export CARGO_TEST_EXTRA="--all"; fi
 
 script:
-  - cargo build --verbose ${FEATURES}
-  - RUST_BACKTRACE=1 cargo test --verbose ${FEATURES} ${CARGO_TEST_EXTRA}
+  - cargo build --verbose --features="all ${EXTRA_FEATURES}"
+  - RUST_BACKTRACE=1 cargo test --verbose --features="all ${EXTRA_FEATURES}" ${CARGO_TEST_EXTRA}
 
 os:
   - linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ winapi = "0.2"
 mio-named-pipes = "0.1"
 
 [features]
-default = []
+default = ["s3"]
 all = ["redis", "s3"]
 s3 = ["chrono", "hyper", "hyper-tls", "rust-crypto", "serde_json", "simple-s3"]
 simple-s3 = []

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,15 +5,13 @@ environment:
   # Stable 64-bit MSVC
     - channel: stable
       target: x86_64-pc-windows-msvc
-      FEATURES: --features=all
   # Beta 64-bit MSVC
     - channel: beta
       target: x86_64-pc-windows-msvc
-      FEATURES: --features=all
   # Nightly 64-bit MSVC
     - channel: nightly
       target: x86_64-pc-windows-msvc
-      FEATURES: --features="all unstable"
+      EXTRA_FEATURES: unstable
       CARGO_TEST_EXTRA: --all
 
 ### GNU Toolchains ###
@@ -45,10 +43,10 @@ install:
 - ps: .\appveyor_rust_install.ps1
 
 build_script:
-- cmd: cargo build --verbose %FEATURES%
+- cmd: cargo build --verbose --features="all %EXTRA_FEATURES%"
 
 test_script:
-- cmd: cargo test --verbose %FEATURES% %CARGO_TEST_EXTRA%
+- cmd: cargo test --verbose --features="all %EXTRA_FEATURES%" %CARGO_TEST_EXTRA%
 
 branches:
   only:


### PR DESCRIPTION
I think I missed this when the redis storage patch landed. Opening a PR to make sure the CI builds are OK before I land this.