### PR TITLE
Actually support -showIncludes on MSVC

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -509,9 +509,9 @@ gcc
     cmd.stdout(Stdio::piped())
        .stderr(Stdio::null());
     let output = write.and_then(move |(tempdir, src)| {
-        let args = vec!(OsString::from("-E"), OsString::from(&src));
+        cmd.arg("-E").arg(src);
         trace!("compiler {:?}", cmd);
-        let child = cmd.args(&args).spawn().chain_err(|| {
+        let child = cmd.spawn().chain_err(|| {
             format!("failed to execute {:?}", cmd)
         });
         child.into_future().and_then(|child| {
@@ -551,6 +551,7 @@ gcc
                 }))
             }
         }
+        debug!("nothing useful in detection output {:?}", stdout);
         f_ok(None)
     }))
 }


### PR DESCRIPTION
Various problems locally meant that I wasn't able to thoroughly test before
pushing up a patch, but now I've fixed those issues and this is tested locally!
Namely:

* Pass `-showIncludes` to the preprocessor even if there's no dep file output
  requested.
* When a dep file is requested and `-showIncludes` is passed then ship all
  output of dep files to the compiler's stdout.