### PR TITLE
Leverage OsString much more deeply througout

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -404,11 +404,9 @@ fn request_compile<W, X, Y>(conn: &mut ServerConnection, exe: W, args: &Vec<X>, 
           Y: AsRef<Path>,
 {
     let req = Request::Compile(Compile {
-        exe: exe.as_ref().to_str().ok_or("bad exe")?.to_owned(),
-        cwd: cwd.as_ref().to_str().ok_or("bad cwd")?.to_owned(),
-        args: args.iter().map(|a| {
-            a.as_ref().to_str().ok_or("bad arg".into()).map(|s| s.to_owned())
-        }).collect::<Result<_>>()?,
+        exe: exe.as_ref().to_owned().into(),
+        cwd: cwd.as_ref().to_owned().into(),
+        args: args.iter().map(|a| a.as_ref().to_owned()).collect(),
         env_vars: env_vars,
     });
     trace!("request_compile: {:?}", req);

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -21,9 +21,10 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::fmt;
-use std::path::Path;
+use std::hash::Hash;
+use std::path::{Path, PathBuf};
 use std::process;
-use util::{os_str_bytes, sha1_digest};
+use util::{HashToSha1, sha1_digest};
 
 use errors::*;
 
@@ -32,7 +33,7 @@ use errors::*;
 pub struct CCompiler<I>
     where I: CCompilerImpl,
 {
-    executable: String,
+    executable: PathBuf,
     executable_digest: String,
     compiler: I,
 }
@@ -43,7 +44,7 @@ pub struct CCompilerHasher<I>
     where I: CCompilerImpl,
 {
     parsed_args: ParsedArguments,
-    executable: String,
+    executable: PathBuf,
     executable_digest: String,
     compiler: I,
 }
@@ -53,31 +54,34 @@ pub struct CCompilerHasher<I>
 #[derive(Debug, PartialEq, Clone)]
 pub struct ParsedArguments {
     /// The input source file.
-    pub input: String,
+    pub input: PathBuf,
     /// The file extension of the input source file.
     pub extension: String,
     /// The file in which to generate dependencies.
-    pub depfile: Option<String>,
+    pub depfile: Option<PathBuf>,
     /// Output files, keyed by a simple name, like "obj".
-    pub outputs: HashMap<&'static str, String>,
+    pub outputs: HashMap<&'static str, PathBuf>,
     /// Commandline arguments for the preprocessor.
-    pub preprocessor_args: Vec<String>,
+    pub preprocessor_args: Vec<OsString>,
     /// Commandline arguments for the preprocessor or the compiler.
-    pub common_args: Vec<String>,
+    pub common_args: Vec<OsString>,
     /// Whether or not the `-showIncludes` argument is passed on MSVC
     pub msvc_show_includes: bool,
 }
 
 impl ParsedArguments {
-    pub fn output_file(&self) -> Cow<str> {
-        self.outputs.get("obj").and_then(|o| Path::new(o).file_name().map(|f| f.to_string_lossy())).unwrap_or(Cow::Borrowed("Unknown filename"))
+    pub fn output_pretty(&self) -> Cow<str> {
+        self.outputs.get("obj")
+            .and_then(|o| o.file_name())
+            .map(|s| s.to_string_lossy())
+            .unwrap_or(Cow::Borrowed("Unknown filename"))
     }
 }
 
 /// A generic implementation of the `Compilation` trait for C/C++ compilers.
 struct CCompilation<I: CCompilerImpl> {
     parsed_args: ParsedArguments,
-    executable: String,
+    executable: PathBuf,
     /// The output from running the preprocessor.
     preprocessor_result: process::Output,
     compiler: I,
@@ -100,14 +104,14 @@ pub trait CCompilerImpl: Clone + fmt::Debug + Send + 'static {
     fn kind(&self) -> CCompilerKind;
     /// Determine whether `arguments` are supported by this compiler.
     fn parse_arguments(&self,
-                       arguments: &[String],
+                       arguments: &[OsString],
                        cwd: &Path) -> CompilerArguments<ParsedArguments>;
     /// Run the C preprocessor with the specified set of arguments.
     fn preprocess<T>(&self,
                      creator: &T,
-                     executable: &str,
+                     executable: &Path,
                      parsed_args: &ParsedArguments,
-                     cwd: &str,
+                     cwd: &Path,
                      env_vars: &[(OsString, OsString)],
                      pool: &CpuPool)
                      -> SFuture<process::Output> where T: CommandCreatorSync;
@@ -115,10 +119,10 @@ pub trait CCompilerImpl: Clone + fmt::Debug + Send + 'static {
     /// previously-generated `preprocessor_output` as input if possible.
     fn compile<T>(&self,
                   creator: &T,
-                  executable: &str,
+                  executable: &Path,
                   preprocessor_result: process::Output,
                   parsed_args: &ParsedArguments,
-                  cwd: &str,
+                  cwd: &Path,
                   env_vars: &[(OsString, OsString)],
                   pool: &CpuPool)
                   -> SFuture<(Cacheable, process::Output)>
@@ -128,7 +132,7 @@ pub trait CCompilerImpl: Clone + fmt::Debug + Send + 'static {
 impl <I> CCompiler<I>
     where I: CCompilerImpl,
 {
-    pub fn new(compiler: I, executable: String, pool: &CpuPool) -> SFuture<CCompiler<I>>
+    pub fn new(compiler: I, executable: PathBuf, pool: &CpuPool) -> SFuture<CCompiler<I>>
     {
         Box::new(sha1_digest(executable.clone(), &pool).map(move |digest| {
             CCompiler {
@@ -143,7 +147,7 @@ impl <I> CCompiler<I>
 impl<T: CommandCreatorSync, I: CCompilerImpl> Compiler<T> for CCompiler<I> {
     fn kind(&self) -> CompilerKind { CompilerKind::C(self.compiler.kind()) }
     fn parse_arguments(&self,
-                       arguments: &[String],
+                       arguments: &[OsString],
                        cwd: &Path) -> CompilerArguments<Box<CompilerHasher<T> + 'static>> {
         match self.compiler.parse_arguments(arguments, cwd) {
             CompilerArguments::Ok(args) => {
@@ -170,7 +174,7 @@ impl<T, I> CompilerHasher<T> for CCompilerHasher<I>
 {
     fn generate_hash_key(self: Box<Self>,
                          creator: &T,
-                         cwd: &str,
+                         cwd: &Path,
                          env_vars: &[(OsString, OsString)],
                          pool: &CpuPool)
                          -> SFuture<HashResult<T>>
@@ -178,18 +182,18 @@ impl<T, I> CompilerHasher<T> for CCompilerHasher<I>
         let me = *self;
         let CCompilerHasher { parsed_args, executable, executable_digest, compiler } = me;
         let result = compiler.preprocess(creator, &executable, &parsed_args, cwd, env_vars, pool);
-        let out_file = parsed_args.output_file().into_owned();
+        let out_pretty = parsed_args.output_pretty().into_owned();
         let env_vars = env_vars.to_vec();
         let result = result.map_err(move |e| {
-            debug!("[{}]: preprocessor failed: {:?}", out_file, e);
+            debug!("[{}]: preprocessor failed: {:?}", out_pretty, e);
             e
         });
-        let out_file = parsed_args.output_file().into_owned();
+        let out_pretty = parsed_args.output_pretty().into_owned();
         Box::new(result.or_else(move |err| {
             match err {
                 Error(ErrorKind::ProcessError(output), _) => {
                     debug!("[{}]: preprocessor returned error status {:?}",
-                           out_file,
+                           out_pretty,
                            output.status.code());
                     // Drop the stdout since it's the preprocessor output, just hand back stderr and
                     // the exit status.
@@ -202,17 +206,14 @@ impl<T, I> CompilerHasher<T> for CCompilerHasher<I>
             }
         }).and_then(move |preprocessor_result| {
             trace!("[{}]: Preprocessor output is {} bytes",
-                   parsed_args.output_file(),
+                   parsed_args.output_pretty(),
                    preprocessor_result.stdout.len());
 
-            // Remove object file from arguments before hash calculation
             let key = {
-                let out_file = parsed_args.output_file();
-                let arguments = parsed_args.common_args.iter()
-                    .filter(|a| **a != out_file)
-                    .map(|a| a.as_str())
-                    .collect::<String>();
-                hash_key(&executable_digest, &arguments, &env_vars, &preprocessor_result.stdout)
+                hash_key(&executable_digest,
+                         &parsed_args.common_args,
+                         &env_vars,
+                         &preprocessor_result.stdout)
             };
             Ok(HashResult {
                 key: key,
@@ -226,9 +227,9 @@ impl<T, I> CompilerHasher<T> for CCompilerHasher<I>
         }))
     }
 
-    fn output_file(&self) -> Cow<str>
+    fn output_pretty(&self) -> Cow<str>
     {
-        self.parsed_args.output_file()
+        self.parsed_args.output_pretty()
     }
 
     fn box_clone(&self) -> Box<CompilerHasher<T>>
@@ -240,7 +241,7 @@ impl<T, I> CompilerHasher<T> for CCompilerHasher<I>
 impl<T: CommandCreatorSync, I: CCompilerImpl> Compilation<T> for CCompilation<I> {
     fn compile(self: Box<Self>,
                creator: &T,
-               cwd: &str,
+               cwd: &Path,
                env_vars: &[(OsString, OsString)],
                pool: &CpuPool)
                -> SFuture<(Cacheable, process::Output)>
@@ -251,14 +252,14 @@ impl<T: CommandCreatorSync, I: CCompilerImpl> Compilation<T> for CCompilation<I>
                          pool)
     }
 
-    fn outputs<'a>(&'a self) -> Box<Iterator<Item=(&'a str, &'a String)> + 'a>
+    fn outputs<'a>(&'a self) -> Box<Iterator<Item=(&'a str, &'a Path)> + 'a>
     {
-        Box::new(self.parsed_args.outputs.iter().map(|(k, v)| (*k, v)))
+        Box::new(self.parsed_args.outputs.iter().map(|(k, v)| (*k, &**v)))
     }
 }
 
 /// The cache is versioned by the inputs to `hash_key`.
-pub const CACHE_VERSION : &'static [u8] = b"3";
+pub const CACHE_VERSION : &'static [u8] = b"4";
 
 /// Environment variables that are factored into the cache key.
 pub const CACHED_ENV_VARS : &'static [&'static str] = &[
@@ -267,21 +268,25 @@ pub const CACHED_ENV_VARS : &'static [&'static str] = &[
 ];
 
 /// Compute the hash key of `compiler` compiling `preprocessor_output` with `args`.
-pub fn hash_key(compiler_digest: &str, arguments: &str, env_vars: &[(OsString, OsString)],
+pub fn hash_key(compiler_digest: &str,
+                arguments: &[OsString],
+                env_vars: &[(OsString, OsString)],
                 preprocessor_output: &[u8]) -> String
 {
     // If you change any of the inputs to the hash, you should change `CACHE_VERSION`.
     let mut m = sha1::Sha1::new();
     m.update(compiler_digest.as_bytes());
     m.update(CACHE_VERSION);
-    m.update(arguments.as_bytes());
+    for arg in arguments {
+        arg.hash(&mut HashToSha1 { sha: &mut m });
+    }
     //TODO: use lazy_static.
     let cached_env_vars: HashSet<OsString> = CACHED_ENV_VARS.iter().map(|v| OsStr::new(v).to_os_string()).collect();
     for &(ref var, ref val) in env_vars.iter() {
         if cached_env_vars.contains(var) {
-            m.update(os_str_bytes(var));
+            var.hash(&mut HashToSha1 { sha: &mut m });
             m.update(&b"="[..]);
-            m.update(os_str_bytes(val));
+            val.hash(&mut HashToSha1 { sha: &mut m });
         }
     }
     m.update(preprocessor_output);
@@ -294,36 +299,40 @@ mod test {
 
     #[test]
     fn test_hash_key_executable_contents_differs() {
-        let args = "a b c";
+        let args = ovec!["a", "b", "c"];
         const PREPROCESSED : &'static [u8] = b"hello world";
-        assert_neq!(hash_key("abcd", &args, &[], &PREPROCESSED),
-                    hash_key("wxyz", &args, &[], &PREPROCESSED));
+        assert_neq!(hash_key("abcd",&args, &[], &PREPROCESSED),
+                    hash_key("wxyz",&args, &[], &PREPROCESSED));
     }
 
     #[test]
     fn test_hash_key_args_differs() {
         let digest = "abcd";
+        let abc = ovec!["a", "b", "c"];
+        let xyz = ovec!["x", "y", "z"];
+        let ab = ovec!["a", "b"];
+        let a = ovec!["a"];
         const PREPROCESSED: &'static [u8] = b"hello world";
-        assert_neq!(hash_key(digest, "a b c", &[], &PREPROCESSED),
-                    hash_key(digest, "x y z", &[], &PREPROCESSED));
+        assert_neq!(hash_key(digest, &abc, &[], &PREPROCESSED),
+                    hash_key(digest, &xyz, &[], &PREPROCESSED));
 
-        assert_neq!(hash_key(digest, "a b c", &[], &PREPROCESSED),
-                    hash_key(digest, "a b", &[], &PREPROCESSED));
+        assert_neq!(hash_key(digest, &abc, &[], &PREPROCESSED),
+                    hash_key(digest, &ab, &[], &PREPROCESSED));
 
-        assert_neq!(hash_key(digest, "a b c", &[], &PREPROCESSED),
-                    hash_key(digest, "a", &[], &PREPROCESSED));
+        assert_neq!(hash_key(digest, &abc, &[], &PREPROCESSED),
+                    hash_key(digest, &a, &[], &PREPROCESSED));
     }
 
     #[test]
     fn test_hash_key_preprocessed_content_differs() {
-        let args = "a b c";
+        let args = ovec!["a", "b", "c"];
         assert_neq!(hash_key("abcd", &args, &[], &b"hello world"[..]),
                     hash_key("abcd", &args, &[], &b"goodbye"[..]));
     }
 
     #[test]
     fn test_hash_key_env_var_differs() {
-        let args = "a b c";
+        let args = ovec!["a", "b", "c"];
         let digest = "abcd";
         const PREPROCESSED: &'static [u8] = b"hello world";
         for var in CACHED_ENV_VARS.iter() {

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -24,14 +24,16 @@ use std::collections::{HashMap, HashSet};
 use std::env::consts::DLL_EXTENSION;
 use std::ffi::OsString;
 use std::fs::{self, File};
+use std::hash::Hash;
 use std::io::Read;
-use std::iter::FromIterator;
+use std::iter::{self, FromIterator};
 use std::path::{Path, PathBuf};
 use std::process::{self, Stdio};
 use std::slice;
 use std::time::Instant;
 use tempdir::TempDir;
-use util::{fmt_duration_as_secs, os_str_bytes, run_input_output, sha1_digest};
+use util::{fmt_duration_as_secs, run_input_output, sha1_digest};
+use util::HashToSha1;
 
 use errors::*;
 
@@ -47,7 +49,7 @@ const LIBS_DIR: &'static str = "bin";
 #[derive(Debug, Clone)]
 pub struct Rust {
     /// The path to the rustc executable.
-    executable: String,
+    executable: PathBuf,
     /// The SHA-1 digests of all the shared libraries in rustc's $sysroot/lib (or /bin on Windows).
     compiler_shlibs_digests: Vec<String>,
 }
@@ -56,7 +58,7 @@ pub struct Rust {
 #[derive(Debug, Clone)]
 pub struct RustHasher {
     /// The path to the rustc executable.
-    executable: String,
+    executable: PathBuf,
     /// The SHA-1 digests of all the shared libraries in rustc's $sysroot/lib (or /bin on Windows).
     compiler_shlibs_digests: Vec<String>,
     parsed_args: ParsedArguments,
@@ -65,26 +67,26 @@ pub struct RustHasher {
 #[derive(Debug, Clone)]
 pub struct ParsedArguments {
     /// The full commandline, with arguments and their values as pairs.
-    arguments: Vec<(String, Option<String>)>,
+    arguments: Vec<(OsString, Option<OsString>)>,
     /// The location of compiler outputs.
-    output_dir: String,
+    output_dir: PathBuf,
     /// Paths to extern crates used in the compile.
-    externs: Vec<String>,
+    externs: Vec<PathBuf>,
     /// The crate name passed to --crate-name.
     crate_name: String,
     /// If dependency info is being emitted, the name of the dep info file.
-    dep_info: Option<String>,
+    dep_info: Option<PathBuf>,
 }
 
 /// A struct on which to hang a `Compilation` impl.
 #[derive(Debug, Clone)]
 pub struct RustCompilation {
     /// The path to the rustc executable.
-    executable: String,
+    executable: PathBuf,
     /// The full commandline.
-    arguments: Vec<String>,
+    arguments: Vec<OsString>,
     /// The compiler outputs.
-    outputs: HashMap<String, String>,
+    outputs: HashMap<String, PathBuf>,
     /// The crate name being compiled.
     crate_name: String,
 }
@@ -122,7 +124,7 @@ const ARGS_WITH_VALUE: &'static [&'static str] = &[
 const ALLOWED_EMIT: &'static [&'static str] = &["link", "dep-info"];
 
 /// Version number for cache key.
-const CACHE_VERSION: &'static [u8] = b"1";
+const CACHE_VERSION: &'static [u8] = b"2";
 
 /// Return true if `arg` is in the set of arguments `set`.
 fn arg_in(arg: &str, set: &HashSet<&str>) -> bool
@@ -145,8 +147,13 @@ fn hash_all(files: Vec<String>, pool: &CpuPool) -> SFuture<Vec<String>>
 }
 
 /// Calculate SHA-1 digests for all source files listed in rustc's dep-info output.
-fn hash_source_files<T>(creator: &T, crate_name: &str, executable: &str, arguments: &[String],
-                        cwd: &str, env_vars: &[(OsString, OsString)], pool: &CpuPool)
+fn hash_source_files<T>(creator: &T,
+                        crate_name: &str,
+                        executable: &Path,
+                        arguments: &[OsString],
+                        cwd: &Path,
+                        env_vars: &[(OsString, OsString)],
+                        pool: &CpuPool)
                         -> SFuture<Vec<String>>
     where T: CommandCreatorSync,
 {
@@ -224,7 +231,10 @@ fn parse_dep_info<T>(dep_info: &str, cwd: T) -> Vec<String>
 }
 
 /// Run `rustc --print file-names` to get the outputs of compilation.
-fn get_compiler_outputs<T>(creator: &T, executable: &str, arguments: &[String], cwd: &str,
+fn get_compiler_outputs<T>(creator: &T,
+                           executable: &Path,
+                           arguments: &[OsString],
+                           cwd: &Path,
                            env_vars: &[(OsString, OsString)]) -> SFuture<Vec<String>>
     where T: CommandCreatorSync,
 {
@@ -247,7 +257,7 @@ fn get_compiler_outputs<T>(creator: &T, executable: &str, arguments: &[String], 
 impl Rust {
     /// Create a new Rust compiler instance, calculating the hashes of
     /// all the shared libraries in its sysroot.
-    pub fn new<T>(mut creator: T, executable: String, pool: CpuPool) -> SFuture<Rust>
+    pub fn new<T>(mut creator: T, executable: PathBuf, pool: CpuPool) -> SFuture<Rust>
         where T: CommandCreatorSync,
     {
         let mut cmd = creator.new_command_sync(&executable);
@@ -300,7 +310,7 @@ impl<T> Compiler<T> for Rust
     /// * We require `--out-dir`.
     /// * We don't support `-o file`.
     fn parse_arguments(&self,
-                       arguments: &[String],
+                       arguments: &[OsString],
                        cwd: &Path) -> CompilerArguments<Box<CompilerHasher<T> + 'static>>
     {
         match parse_arguments(arguments, cwd) {
@@ -323,13 +333,13 @@ impl<T> Compiler<T> for Rust
 }
 
 /// An iterator over (argument, argument value) pairs.
-struct ArgsIter<'a> {
-    arguments: slice::Iter<'a, String>,
+struct ArgsIter<'a, 'b: 'a> {
+    arguments: slice::Iter<'a, &'b str>,
     args_with_val: &'a HashSet<&'static str>,
 }
 
-impl<'a> ArgsIter<'a> {
-    fn new(arguments: &'a [String], args_with_val: &'a HashSet<&'static str>) -> ArgsIter<'a> {
+impl<'a, 'b> ArgsIter<'a, 'b> {
+    fn new(arguments: &'a [&'b str], args_with_val: &'a HashSet<&'static str>) -> ArgsIter<'a, 'b> {
         ArgsIter {
             arguments: arguments.iter(),
             args_with_val: args_with_val,
@@ -337,7 +347,7 @@ impl<'a> ArgsIter<'a> {
     }
 }
 
-impl<'a> Iterator for ArgsIter<'a> {
+impl<'a, 'b> Iterator for ArgsIter<'a, 'b> {
     type Item = (&'a str, Option<&'a str>);
 
     fn next(&mut self) -> Option<(&'a str, Option<&'a str>)> {
@@ -346,7 +356,7 @@ impl<'a> Iterator for ArgsIter<'a> {
                 if let Some(i) = arg.find('=') {
                     Some((&arg[..i], Some(&arg[i+1..])))
                 } else {
-                    Some((arg, self.arguments.next().map(|v| v.as_str())))
+                    Some((arg, self.arguments.next().map(|v| *v)))
                 }
             } else {
                 Some((arg, None))
@@ -357,8 +367,20 @@ impl<'a> Iterator for ArgsIter<'a> {
     }
 }
 
-fn parse_arguments(arguments: &[String], _cwd: &Path) -> CompilerArguments<ParsedArguments>
+fn parse_arguments(arguments: &[OsString], _cwd: &Path) -> CompilerArguments<ParsedArguments>
 {
+    // While we could go the extra mile here and handle non-utf8 `OsString`
+    // instances the rustc compiler certainly does not. With that knowledge
+    // we just validate that everything's utf-8 and ship everything else
+    // to the compiler as "not cacheable".
+    let mut args = Vec::with_capacity(arguments.len());
+    for arg in arguments {
+        match arg.to_str() {
+            Some(s) => args.push(s),
+            None => return CompilerArguments::CannotCache("not utf-8"),
+        }
+    }
+
     //TODO: use lazy_static for this.
     let args_with_val: HashSet<&'static str> = HashSet::from_iter(ARGS_WITH_VALUE.iter().map(|v| *v));
     let mut emit: Option<HashSet<&str>> = None;
@@ -368,7 +390,7 @@ fn parse_arguments(arguments: &[String], _cwd: &Path) -> CompilerArguments<Parse
     let mut extra_filename = None;
     let mut externs = vec![];
 
-    let it = ArgsIter::new(arguments, &args_with_val);
+    let it = ArgsIter::new(&args, &args_with_val);
     for (arg, val) in it {
         match arg {
             // Various non-compilation options.
@@ -396,7 +418,7 @@ fn parse_arguments(arguments: &[String], _cwd: &Path) -> CompilerArguments<Parse
             "--extern" => {
                 if let Some(val) = val {
                     if let Some(crate_file) = val.splitn(2, "=").nth(1) {
-                        externs.push(crate_file.to_owned());
+                        externs.push(PathBuf::from(crate_file));
                     }
                 }
             }
@@ -464,17 +486,17 @@ fn parse_arguments(arguments: &[String], _cwd: &Path) -> CompilerArguments<Parse
     } else {
         None
     };
-    let arguments = ArgsIter::new(arguments, &args_with_val)
-        .map(|(arg, val)| (arg.to_owned(), val.map(|v| v.to_owned())))
+    let arguments = ArgsIter::new(&args, &args_with_val)
+        .map(|(arg, val)| (arg.into(), val.map(|v| v.into())))
         .collect::<Vec<_>>();
     // We'll figure out the source files and outputs later in
     // `generate_hash_key` where we can run rustc.
     CompilerArguments::Ok(ParsedArguments {
         arguments: arguments,
-        output_dir: output_dir.to_owned(),
+        output_dir: output_dir.into(),
         externs: externs,
         crate_name: crate_name.to_string(),
-        dep_info: dep_info,
+        dep_info: dep_info.map(|s| s.into()),
     })
 }
 
@@ -483,7 +505,7 @@ impl<T> CompilerHasher<T> for RustHasher
 {
     fn generate_hash_key(self: Box<Self>,
                          creator: &T,
-                         cwd: &str,
+                         cwd: &Path,
                          env_vars: &[(OsString, OsString)],
                          pool: &CpuPool)
                          -> SFuture<HashResult<T>>
@@ -533,14 +555,19 @@ impl<T> CompilerHasher<T> for RustHasher
             // and append them to the rest of the arguments.
             let args = {
                 let (mut sortables, rest): (Vec<_>, Vec<_>) = arguments.iter()
-                    .partition(|&&(ref arg, ref _v)| arg == "--extern" || arg == "-L" || arg == "--cfg");
+                    .partition(|&&(ref arg, _)| arg == "--extern" || arg == "-L" || arg == "--cfg");
                 sortables.sort();
                 rest.into_iter()
                     .chain(sortables)
-                    .flat_map(|&(ref arg, ref val)| Some(arg).into_iter().chain(val))
-                    .map(|s| s.as_str()).collect::<String>()
+                    .flat_map(|&(ref arg, ref val)| {
+                        iter::once(arg).chain(val.as_ref())
+                    })
+                    .fold(OsString::new(), |mut a, b| {
+                        a.push(b);
+                        a
+                    })
             };
-            m.update(args.as_bytes());
+            args.hash(&mut HashToSha1 { sha: &mut m });
             // 4. The sha-1 digests of all source files (this includes src file from cmdline).
             // 5. The sha-1 digests of all files listed on the commandline (self.externs)
             for h in source_hashes.into_iter().chain(extern_hashes) {
@@ -556,9 +583,9 @@ impl<T> CompilerHasher<T> for RustHasher
             env_vars.sort();
             for &(ref var, ref val) in env_vars.iter() {
                 if var.to_str().map(|s| s.starts_with("CARGO_")).unwrap_or(false) {
-                    m.update(os_str_bytes(var));
+                    var.hash(&mut HashToSha1 { sha: &mut m });
                     m.update(b"=");
-                    m.update(os_str_bytes(val));
+                    val.hash(&mut HashToSha1 { sha: &mut m });
                 }
             }
             // 7. TODO: native libraries being linked.
@@ -572,13 +599,13 @@ impl<T> CompilerHasher<T> for RustHasher
                 // Convert output files into a map of basename -> full path.
                 let mut outputs = outputs.into_iter()
                     .map(|o| {
-                        let p = output_dir.join(&o).to_string_lossy().into_owned();
+                        let p = output_dir.join(&o);
                         (o, p)
                     })
                     .collect::<HashMap<_, _>>();
                 if let Some(dep_info) = dep_info {
-                    let p = output_dir.join(&dep_info).to_string_lossy().into_owned();
-                    outputs.insert(dep_info, p);
+                    let p = output_dir.join(&dep_info);
+                    outputs.insert(dep_info.to_string_lossy().into_owned(), p);
                 }
                 HashResult {
                     key: m.digest().to_string(),
@@ -593,7 +620,7 @@ impl<T> CompilerHasher<T> for RustHasher
         }))
     }
 
-    fn output_file(&self) -> Cow<str> {
+    fn output_pretty(&self) -> Cow<str> {
         Cow::Borrowed(&self.parsed_args.crate_name)
     }
 
@@ -607,7 +634,7 @@ impl<T> Compilation<T> for RustCompilation
 {
     fn compile(self: Box<Self>,
                creator: &T,
-               cwd: &str,
+               cwd: &Path,
                env_vars: &[(OsString, OsString)],
                _pool: &CpuPool)
                -> SFuture<(Cacheable, process::Output)>
@@ -626,8 +653,8 @@ impl<T> Compilation<T> for RustCompilation
         }))
     }
 
-    fn outputs<'a>(&'a self) -> Box<Iterator<Item=(&'a str, &'a String)> + 'a> {
-        Box::new(self.outputs.iter().map(|(k, v)| (k.as_str(), v)))
+    fn outputs<'a>(&'a self) -> Box<Iterator<Item=(&'a str, &'a Path)> + 'a> {
+        Box::new(self.outputs.iter().map(|(k, v)| (k.as_str(), &**v)))
     }
 }
 
@@ -639,6 +666,7 @@ mod test {
     use itertools::Itertools;
     use mock_command::*;
     use sha1;
+    use std::ffi::OsStr;
     use std::fs::File;
     use std::io::Write;
     use std::sync::{Arc,Mutex};
@@ -646,7 +674,8 @@ mod test {
 
     fn _parse_arguments(arguments: &[String]) -> CompilerArguments<ParsedArguments>
     {
-        parse_arguments(arguments, ".".as_ref())
+        let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
+        parse_arguments(&arguments, ".".as_ref())
     }
 
     macro_rules! parses {
@@ -671,19 +700,19 @@ mod test {
     #[test]
     fn test_parse_arguments_simple() {
         let h = parses!("--emit", "link", "foo.rs", "--out-dir", "out", "--crate-name", "foo");
-        assert_eq!(h.output_dir, "out");
+        assert_eq!(h.output_dir.to_str(), Some("out"));
         assert!(h.dep_info.is_none());
         assert!(h.externs.is_empty());
         let h = parses!("--emit=link", "foo.rs", "--out-dir", "out", "--crate-name=foo");
-        assert_eq!(h.output_dir, "out");
+        assert_eq!(h.output_dir.to_str(), Some("out"));
         assert!(h.dep_info.is_none());
         let h = parses!("--emit", "link", "foo.rs", "--out-dir=out", "--crate-name=foo");
-        assert_eq!(h.output_dir, "out");
+        assert_eq!(h.output_dir.to_str(), Some("out"));
         let h = parses!("--emit", "link,dep-info", "foo.rs", "--out-dir", "out",
                         "--crate-name", "my_crate",
                         "-C", "extra-filename=-abcxyz");
-        assert_eq!(h.output_dir, "out");
-        assert_eq!(h.dep_info.unwrap(), "my_crate-abcxyz.d");
+        assert_eq!(h.output_dir.to_str(), Some("out"));
+        assert_eq!(h.dep_info.unwrap().to_str().unwrap(), "my_crate-abcxyz.d");
         fails!("--emit", "link", "--out-dir", "out", "--crate-name=foo");
         fails!("--emit", "link", "foo.rs", "--crate-name=foo");
         fails!("--emit", "asm", "foo.rs", "--out-dir", "out", "--crate-name=foo");
@@ -699,10 +728,11 @@ mod test {
                         "-L", "dependency=/foo/target/debug/deps",
                         "--extern", "libc=/foo/target/debug/deps/liblibc-89a24418d48d484a.rlib",
                         "--extern", "log=/foo/target/debug/deps/liblog-2f7366be74992849.rlib");
-        assert_eq!(h.output_dir, "/foo/target/debug/deps");
+        assert_eq!(h.output_dir.to_str(), Some("/foo/target/debug/deps"));
         assert_eq!(h.crate_name, "foo");
-        assert_eq!(h.dep_info.unwrap(), "foo-d6ae26f5bcfb7733.d");
-        assert_eq!(h.externs, &["/foo/target/debug/deps/liblibc-89a24418d48d484a.rlib", "/foo/target/debug/deps/liblog-2f7366be74992849.rlib"]);
+        assert_eq!(h.dep_info.unwrap().to_str().unwrap(),
+                   "foo-d6ae26f5bcfb7733.d");
+        assert_eq!(h.externs, ovec!["/foo/target/debug/deps/liblibc-89a24418d48d484a.rlib", "/foo/target/debug/deps/liblog-2f7366be74992849.rlib"]);
     }
 
     #[test]
@@ -710,7 +740,7 @@ mod test {
         let h = parses!("--crate-name", "foo", "src/lib.rs",
                         "--emit=dep-info,link",
                         "--out-dir", "/out");
-        assert_eq!(h.dep_info, Some("foo.d".to_string()));
+        assert_eq!(h.dep_info, Some("foo.d".into()));
     }
 
     #[test]
@@ -725,8 +755,8 @@ mod test {
         let args_with_val: HashSet<&'static str> = HashSet::from_iter(ARGS_WITH_VALUE.iter().map(|v| *v));
         macro_rules! t {
             ( [ $( $s:expr ),* ], [ $( $t:expr ),* ] ) => {
-                let v = vec!( $( $s.to_string(), )* );
-                let it = ArgsIter::new(&v, &args_with_val);
+                let v = &[ $( $s, )* ];
+                let it = ArgsIter::new(v, &args_with_val);
                 assert_eq!(it.collect::<Vec<_>>(),
                            vec!( $( $t, )* ));
             }
@@ -756,7 +786,11 @@ mod test {
     fn test_get_compiler_outputs() {
         let creator = new_creator();
         next_command(&creator, Ok(MockChild::new(exit_status(0), "foo\nbar\nbaz", "")));
-        let outputs = get_compiler_outputs(&creator, "rustc", &stringvec!("a", "b"), "cwd", &[]).wait().unwrap();
+        let outputs = get_compiler_outputs(&creator,
+                                           "rustc".as_ref(),
+                                           &ovec!("a", "b"),
+                                           "cwd".as_ref(),
+                                           &[]).wait().unwrap();
         assert_eq!(outputs, &["foo", "bar", "baz"]);
     }
 
@@ -764,7 +798,11 @@ mod test {
     fn test_get_compiler_outputs_fail() {
         let creator = new_creator();
         next_command(&creator, Ok(MockChild::new(exit_status(1), "", "error")));
-        assert!(get_compiler_outputs(&creator, "rustc", &stringvec!("a", "b"), "cwd", &[]).wait().is_err());
+        assert!(get_compiler_outputs(&creator,
+                                     "rustc".as_ref(),
+                                     &ovec!("a", "b"),
+                                     "cwd".as_ref(),
+                                     &[]).wait().is_err());
     }
 
     #[test]
@@ -889,17 +927,17 @@ c:/foo/bar.rs:
             f.touch(s).unwrap();
         }
         let hasher = Box::new(RustHasher {
-            executable: "rustc".to_owned(),
+            executable: "rustc".into(),
             compiler_shlibs_digests: vec![FAKE_DIGEST.to_owned()],
             parsed_args: ParsedArguments {
-                arguments: vec![("a".to_string(), None),
-                                ("--extern".to_string(), Some("xyz".to_string())),
-                                ("b".to_string(), None),
-                                ("--extern".to_string(), Some("abc".to_string())),
+                arguments: vec![("a".into(), None),
+                                ("--extern".into(), Some("xyz".into())),
+                                ("b".into(), None),
+                                ("--extern".into(), Some("abc".into())),
                                 ],
-                output_dir: "foo/".to_string(),
-                externs: stringvec!["bar.rlib"],
-                crate_name: "foo".to_string(),
+                output_dir: "foo/".into(),
+                externs: vec!["bar.rlib".into()],
+                crate_name: "foo".into(),
                 dep_info: None,
             }
         });
@@ -908,7 +946,7 @@ c:/foo/bar.rs:
         mock_file_names(&creator, &["foo.rlib", "foo.a"]);
         let pool = CpuPool::new(1);
         let res = hasher.generate_hash_key(&creator,
-                                           &f.tempdir.path().to_string_lossy(),
+                                           f.tempdir.path(),
                                            &[(OsString::from("CARGO_PKG_NAME"), OsString::from("foo")),
                                              (OsString::from("FOO"), OsString::from("bar")),
                                              (OsString::from("CARGO_BLAH"), OsString::from("abc"))],
@@ -919,7 +957,7 @@ c:/foo/bar.rs:
         // sysroot shlibs digests.
         m.update(FAKE_DIGEST.as_bytes());
         // Arguments, with externs sorted at the end.
-        m.update(b"ab--externabc--externxyz");
+        OsStr::new("ab--externabc--externxyz").hash(&mut HashToSha1 { sha: &mut m });
         // bar.rs (source file, from dep-info)
         m.update(EMPTY_DIGEST.as_bytes());
         // foo.rs (source file, from dep-info)
@@ -927,8 +965,12 @@ c:/foo/bar.rs:
         // bar.rlib (extern crate, from externs)
         m.update(EMPTY_DIGEST.as_bytes());
         // Env vars
-        m.update(b"CARGO_BLAH=abc");
-        m.update(b"CARGO_PKG_NAME=foo");
+        OsStr::new("CARGO_BLAH").hash(&mut HashToSha1 { sha: &mut m });
+        m.update(b"=");
+        OsStr::new("abc").hash(&mut HashToSha1 { sha: &mut m });
+        OsStr::new("CARGO_PKG_NAME").hash(&mut HashToSha1 { sha: &mut m });
+        m.update(b"=");
+        OsStr::new("foo").hash(&mut HashToSha1 { sha: &mut m });
         let digest = m.digest().to_string();
         assert_eq!(res.key, digest);
         let mut out = res.compilation.outputs().map(|(k, _)| k.to_owned()).collect::<Vec<_>>();
@@ -936,7 +978,7 @@ c:/foo/bar.rs:
         assert_eq!(out, vec!["foo.a", "foo.rlib"]);
     }
 
-    fn hash_key(args: &[String], env_vars: &[(OsString, OsString)]) -> String {
+    fn hash_key(args: &[OsString], env_vars: &[(OsString, OsString)]) -> String {
         let f = TestFixture::new();
         let parsed_args = match parse_arguments(args, &f.tempdir.path()) {
             CompilerArguments::Ok(parsed_args) => parsed_args,
@@ -949,11 +991,11 @@ c:/foo/bar.rs:
         }
         // as well as externs
         for e in parsed_args.externs.iter() {
-            let s = format!("Failed to create {}", e);
-            f.touch(e).expect(&s);
+            let s = format!("Failed to create {:?}", e);
+            f.touch(e.to_str().unwrap()).expect(&s);
         }
         let hasher = Box::new(RustHasher {
-            executable: "rustc".to_string(),
+            executable: "rustc".into(),
             compiler_shlibs_digests: vec![],
             parsed_args: parsed_args,
         });
@@ -962,24 +1004,24 @@ c:/foo/bar.rs:
         let pool = CpuPool::new(1);
         mock_dep_info(&creator, &["foo.rs"]);
         mock_file_names(&creator, &["foo.rlib"]);
-        hasher.generate_hash_key(&creator, &f.tempdir.path().to_string_lossy(), env_vars, &pool).wait().unwrap().key
+        hasher.generate_hash_key(&creator, f.tempdir.path(), env_vars, &pool).wait().unwrap().key
     }
 
     #[test]
     fn test_equal_hashes_externs() {
-        assert_eq!(hash_key(&stringvec!["--emit", "link", "foo.rs", "--extern", "a=a.rlib", "--out-dir", "out", "--crate-name", "foo", "--extern", "b=b.rlib"], &vec![]),
-                   hash_key(&stringvec!["--extern", "b=b.rlib", "--emit", "link", "--extern", "a=a.rlib", "foo.rs", "--out-dir", "out", "--crate-name", "foo"], &vec![]));
+        assert_eq!(hash_key(&ovec!["--emit", "link", "foo.rs", "--extern", "a=a.rlib", "--out-dir", "out", "--crate-name", "foo", "--extern", "b=b.rlib"], &vec![]),
+                   hash_key(&ovec!["--extern", "b=b.rlib", "--emit", "link", "--extern", "a=a.rlib", "foo.rs", "--out-dir", "out", "--crate-name", "foo"], &vec![]));
     }
 
     #[test]
     fn test_equal_hashes_link_paths() {
-        assert_eq!(hash_key(&stringvec!["--emit", "link", "-L", "x=x", "foo.rs", "--out-dir", "out", "--crate-name", "foo", "-L", "y=y"], &vec![]),
-                   hash_key(&stringvec!["-L", "y=y", "--emit", "link", "-L", "x=x", "foo.rs", "--out-dir", "out", "--crate-name", "foo"], &vec![]));
+        assert_eq!(hash_key(&ovec!["--emit", "link", "-L", "x=x", "foo.rs", "--out-dir", "out", "--crate-name", "foo", "-L", "y=y"], &vec![]),
+                   hash_key(&ovec!["-L", "y=y", "--emit", "link", "-L", "x=x", "foo.rs", "--out-dir", "out", "--crate-name", "foo"], &vec![]));
     }
 
     #[test]
     fn test_equal_hashes_cfg_features() {
-        assert_eq!(hash_key(&stringvec!["--emit", "link", "--cfg", "feature=a", "foo.rs", "--out-dir", "out", "--crate-name", "foo", "--cfg", "feature=b"], &vec![]),
-                   hash_key(&stringvec!["--cfg", "feature=b", "--emit", "link", "--cfg", "feature=a", "foo.rs", "--out-dir", "out", "--crate-name", "foo"], &vec![]));
+        assert_eq!(hash_key(&ovec!["--emit", "link", "--cfg", "feature=a", "foo.rs", "--out-dir", "out", "--crate-name", "foo", "--cfg", "feature=b"], &vec![]),
+                   hash_key(&ovec!["--cfg", "feature=b", "--emit", "link", "--cfg", "feature=a", "foo.rs", "--out-dir", "out", "--crate-name", "foo"], &vec![]));
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -53,11 +53,11 @@ pub struct CompileFinished {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Compile {
     /// The full path to the compiler executable.
-    pub exe: String,
+    pub exe: OsString,
     /// The current working directory in which to execute the compile.
-    pub cwd: String,
+    pub cwd: OsString,
     /// The commandline arguments passed to the compiler.
-    pub args: Vec<String>,
+    pub args: Vec<OsString>,
     /// The environment variables present when the compiler was executed, as (var, val).
     pub env_vars: Vec<(OsString, OsString)>,
 }

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -34,6 +34,13 @@ macro_rules! stringvec {
     };
 }
 
+/// Return a `Vec` with each listed entry converted to an owned `OsString`.
+macro_rules! ovec {
+    ( $( $x:expr ),* ) => {
+        vec!($( ::std::ffi::OsString::from($x), )*)
+    };
+}
+
 /// Assert that `left != right`.
 macro_rules! assert_neq {
     ($left:expr , $right:expr) => ({

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::future;
 use futures::Future;
+use futures::future;
 use futures_cpupool::CpuPool;
 use mock_command::{CommandChild, RunCommand};
 use sha1;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fs::File;
-use std::io::prelude::*;
+use std::hash::Hasher;
 use std::io::BufReader;
+use std::io::prelude::*;
 use std::path::PathBuf;
 use std::process::{self,Stdio};
 use std::time::Duration;
@@ -53,21 +54,6 @@ pub fn sha1_digest<T>(path: T, pool: &CpuPool) -> SFuture<String>
 pub fn fmt_duration_as_secs(duration: &Duration) -> String
 {
     format!("{}.{:03} s", duration.as_secs(), duration.subsec_nanos() / 1000_000)
-}
-
-
-#[cfg(unix)]
-pub fn os_str_bytes(s: &OsStr) -> &[u8]
-{
-    use std::os::unix::ffi::OsStrExt;
-    s.as_bytes()
-}
-
-#[cfg(windows)]
-pub fn os_str_bytes(s: &OsStr) -> &[u8]
-{
-    use std::mem;
-    unsafe { mem::transmute(s) }
 }
 
 /// If `input`, write it to `child`'s stdin while also reading `child`'s stdout and stderr, then wait on `child` and return its status and output.
@@ -134,10 +120,151 @@ pub fn run_input_output<C>(mut command: C, input: Option<Vec<u8>>)
              }))
 }
 
-#[test]
-fn test_os_str_bytes() {
-    // Just very basic sanity checks in case anyone changes the underlying
-    // representation of OsStr on Windows.
-    assert_eq!(os_str_bytes(OsStr::new("hello")), b"hello");
-    assert_eq!(os_str_bytes(OsStr::new("你好")), "你好".as_bytes());
+pub trait OsStrExt {
+    fn starts_with(&self, s: &str) -> bool;
+    fn split_prefix(&self, s: &str) -> Option<OsString>;
+}
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt as _OsStrExt;
+
+#[cfg(unix)]
+impl OsStrExt for OsStr {
+    fn starts_with(&self, s: &str) -> bool {
+        self.as_bytes().starts_with(s.as_bytes())
+    }
+
+    fn split_prefix(&self, s: &str) -> Option<OsString> {
+        let bytes = self.as_bytes();
+        if bytes.starts_with(s.as_bytes()) {
+            Some(OsStr::from_bytes(&bytes[s.len()..]).to_owned())
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(windows)]
+use std::os::windows::ffi::{OsStrExt as _OsStrExt, OsStringExt};
+
+#[cfg(windows)]
+impl OsStrExt for OsStr {
+    fn starts_with(&self, s: &str) -> bool {
+        // Attempt to interpret this OsStr as utf-16. This is a pretty "poor
+        // man's" implementation, however, as it only handles a subset of
+        // unicode characters in `s`. Currently that's sufficient, though, as
+        // we're only calling `starts_with` with ascii string literals.
+        let mut u16s = self.encode_wide();
+        let mut utf8 = s.chars();
+
+        while let Some(codepoint) = u16s.next() {
+            let to_match = match utf8.next() {
+                Some(ch) => ch,
+                None => return true,
+            };
+
+            let to_match = to_match as u32;
+            let codepoint = codepoint as u32;
+
+            // UTF-16 encodes codepoints < 0xd7ff as just the raw value as a
+            // u16, and that's all we're matching against. If the codepoint in
+            // `s` is *over* this value then just assume it's not in `self`.
+            //
+            // If `to_match` is the same as the `codepoint` coming out of our
+            // u16 iterator we keep going, otherwise we've found a mismatch.
+            if to_match < 0xd7ff {
+                if to_match != codepoint {
+                    return false
+                }
+            } else {
+                return false
+            }
+        }
+
+        // If we ran out of characters to match, then the strings should be
+        // equal, otherwise we've got more data to match in `s` so we didn't
+        // start with `s`
+        utf8.next().is_none()
+    }
+
+    fn split_prefix(&self, s: &str) -> Option<OsString> {
+        // See comments in the above implementation for what's going on here
+        let mut u16s = self.encode_wide().peekable();
+        let mut utf8 = s.chars();
+
+        while let Some(&codepoint) = u16s.peek() {
+            let to_match = match utf8.next() {
+                Some(ch) => ch,
+                None => {
+                    let codepoints = u16s.collect::<Vec<_>>();
+                    return Some(OsString::from_wide(&codepoints))
+                }
+            };
+
+            let to_match = to_match as u32;
+            let codepoint = codepoint as u32;
+
+            if to_match < 0xd7ff {
+                if to_match != codepoint {
+                    return None
+                }
+            } else {
+                return None
+            }
+            u16s.next();
+        }
+
+        if utf8.next().is_none() {
+            Some(OsString::new())
+        } else {
+            None
+        }
+    }
+}
+
+pub struct HashToSha1<'a> {
+    pub sha: &'a mut sha1::Sha1,
+}
+
+impl<'a> Hasher for HashToSha1<'a> {
+    fn write(&mut self, bytes: &[u8]) {
+        self.sha.update(bytes)
+    }
+
+    fn finish(&self) -> u64 {
+        panic!("not supposed to be called");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::{OsStr, OsString};
+    use super::OsStrExt;
+
+    #[test]
+    fn simple_starts_with() {
+        let a: &OsStr = "foo".as_ref();
+        assert!(a.starts_with(""));
+        assert!(a.starts_with("f"));
+        assert!(a.starts_with("fo"));
+        assert!(a.starts_with("foo"));
+        assert!(!a.starts_with("foo2"));
+        assert!(!a.starts_with("b"));
+        assert!(!a.starts_with("b"));
+
+        let a: &OsStr = "".as_ref();
+        assert!(!a.starts_with("a"))
+    }
+
+    #[test]
+    fn simple_strip_prefix() {
+        let a: &OsStr = "foo".as_ref();
+
+        assert_eq!(a.split_prefix(""), Some(OsString::from("foo")));
+        assert_eq!(a.split_prefix("f"), Some(OsString::from("oo")));
+        assert_eq!(a.split_prefix("fo"), Some(OsString::from("o")));
+        assert_eq!(a.split_prefix("foo"), Some(OsString::from("")));
+        assert_eq!(a.split_prefix("foo2"), None);
+        assert_eq!(a.split_prefix("b"), None);
+    }
 }


### PR DESCRIPTION
This initially started out tackling #93 and ended up plumbing the `OsStr` type
basically everywhere! This knocked out a TODO or two along the way and should
remove some pesky unwraps and/or error handling around handling of arguments and
paths that may not be unicode.

Some notable other points are:

* A few utilities were added to `src/util.rs` to assist with handling os strings
* The Rust implementation doesn't deal with os strings in argument parsing at
  all, but otherwise internally stores os strings for maximal compatibility
  (more comments in the code).
* Some unsafe transmutes were removed in util in favor of a more stable
  implementation.
* The `output_file` function was renamed to `output_pretty` as it turns out it's
  not actually the actual output file but rather just a pretty description of it
  (for logging and such).

Closes #93