### PR TITLE
Ship all log messages to the client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,6 @@ dependencies = [
  "daemonize 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fern 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -31,6 +30,7 @@ dependencies = [
  "ring 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -229,14 +229,6 @@ dependencies = [
 name = "error-chain"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "fern"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "filetime"
@@ -1268,7 +1260,6 @@ dependencies = [
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "82dcb9ceed3868a03b335657b85a159736c961900f7e7747d3b0b97b9ccb5ccb"
 "checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
-"checksum fern 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4d2f58d053ad7791bfaad58a3f3541fe2d2aecc564dd82aee7f92fa402c054b2"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
 "checksum flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "3eeb481e957304178d2e782f2da1257f1434dfecbae883bafb61ada2a9fea3bb"
 "checksum futures 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8e51e7f9c150ba7fd4cee9df8bf6ea3dea5b63b68955ddad19ccd35b71dcfb4d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ chrono = { version = "0.2.25", optional = true }
 clap = "~2.23.0"
 env_logger = "0.3.3"
 error-chain = { version = "0.7.2", default-features = false }
-fern = "0.3.5"
 filetime = "0.1"
 futures = "0.1.11"
 futures-cpupool = "0.1"
@@ -32,6 +31,7 @@ retry = "0.4.0"
 ring = "0.9.0"
 rust-crypto = { version = "0.2.36", optional = true }
 rustc-serialize = "0.3"
+scoped-tls = "0.1"
 serde = "0.9"
 serde_derive = "0.9"
 serde_json = { version = "0.9.0", optional = true }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -31,9 +31,15 @@ pub enum Response {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum CompileResponse {
     /// The compilation was started.
-    CompileStarted,
+    CompileStarted {
+        /// Log messages produced by the server
+        logs: Vec<String>,
+    },
     /// The server could not handle this compilation request.
-    UnhandledCompile,
+    UnhandledCompile {
+        /// Log messages produced by the server
+        logs: Vec<String>,
+    },
 }
 
 /// Information about a finished compile, either from cache or executed locally.
@@ -47,6 +53,8 @@ pub struct CompileFinished {
     pub stdout: Vec<u8>,
     /// The compiler's stderr.
     pub stderr: Vec<u8>,
+    /// Log messages produced by the server
+    pub logs: Vec<String>,
 }
 
 /// The contents of a compile request from a client.


### PR DESCRIPTION
This commit updates the sccache server to capture all log messages and ship them
to the client. Captured log messages are then printed out by the client. The
intention of this is to assist with debugging sccache by setting the `RUST_LOG`
env var on the client and having it propagate to the server and back.

With this PR you'd start up the server with a maximum log level set, e.g. with

    RUST_LOG=foo=debug

and then all clients would use their own `RUST_LOG` env var when executing to
get logs message shipped back. Note that log messages show up on the server by
default as well, but log messages are typically cast into the void as
stdout/stderr are closed.