### PR TITLE
Handle storage get failure

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -548,18 +548,18 @@ impl<C> SccacheService<C>
                         },
                         CompileResult::CacheMiss(miss_type, duration, future) => {
                             match miss_type {
-                                MissType::Normal => {
-                                    stats.cache_misses += 1;
-                                }
+                                MissType::Normal => {}
                                 MissType::ForcedRecache => {
-                                    stats.cache_misses += 1;
                                     stats.forced_recaches += 1;
                                 }
                                 MissType::TimedOut => {
-                                    stats.cache_misses += 1;
                                     stats.cache_timeouts += 1;
                                 }
+                                MissType::CacheReadError => {
+                                    stats.cache_errors += 1;
+                                }
                             }
+                            stats.cache_misses += 1;
                             stats.cache_read_miss_duration += duration;
                             cache_write = Some(future);
                         }
@@ -656,6 +656,8 @@ pub struct ServerStats {
     pub cache_misses: u64,
     /// The count of cache misses because the cache took too long to respond.
     pub cache_timeouts: u64,
+    /// The count of errors reading cache entries.
+    pub cache_read_errors: u64,
     /// The count of compilations which were successful but couldn't be cached.
     pub non_cacheable_compilations: u64,
     /// The count of compilations which forcibly ignored the cache.
@@ -695,6 +697,7 @@ impl Default for ServerStats {
             cache_hits: u64::default(),
             cache_misses: u64::default(),
             cache_timeouts: u64::default(),
+            cache_read_errors: u64::default(),
             non_cacheable_compilations: u64::default(),
             forced_recaches: u64::default(),
             cache_write_errors: u64::default(),
@@ -738,6 +741,7 @@ impl ServerStats {
         set_stat!(stats_vec, self.cache_hits, "Cache hits");
         set_stat!(stats_vec, self.cache_misses, "Cache misses");
         set_stat!(stats_vec, self.cache_timeouts, "Cache timeouts");
+        set_stat!(stats_vec, self.cache_read_errors, "Cache read errors");
         set_stat!(stats_vec, self.forced_recaches, "Forced recaches");
         set_stat!(stats_vec, self.cache_write_errors, "Cache write errors");
         set_stat!(stats_vec, self.compile_fails, "Compilation failures");

--- a/src/test/mock_storage.rs
+++ b/src/test/mock_storage.rs
@@ -1,0 +1,63 @@
+// Copyright 2017 Mozilla Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cache::{Cache,CacheWrite,Storage};
+use errors::*;
+use std::cell::RefCell;
+use std::time::Duration;
+
+/// A mock `Storage` implementation.
+pub struct MockStorage {
+    gets: RefCell<Vec<SFuture<Cache>>>,
+    puts: RefCell<Vec<Result<CacheWrite>>>,
+}
+
+impl MockStorage {
+    /// Create a new `MockStorage`.
+    pub fn new() -> MockStorage {
+        MockStorage {
+            gets: RefCell::new(vec![]),
+            puts: RefCell::new(vec![]),
+        }
+    }
+
+    /// Queue up `res` to be returned as the next result from `Storage::get`.
+    pub fn next_get(&self, res: SFuture<Cache>) {
+        self.gets.borrow_mut().push(res)
+    }
+
+    /// Queue up `res` to be returned as the next result from `Storage::start_put`.
+    pub fn next_put(&self, res: Result<CacheWrite>) {
+        self.puts.borrow_mut().push(res)
+    }
+}
+
+impl Storage for MockStorage {
+    fn get(&self, _key: &str) -> SFuture<Cache> {
+        let mut g = self.gets.borrow_mut();
+        assert!(g.len() > 0, "MockStorage get called, but no get results available");
+        g.remove(0)
+    }
+    fn start_put(&self, _key: &str) -> Result<CacheWrite> {
+        let mut p = self.puts.borrow_mut();
+        assert!(p.len() > 0, "MockStorage start_put called, but no put results available");
+        p.remove(0)
+    }
+    fn finish_put(&self, _key: &str, _entry: CacheWrite) -> SFuture<Duration> {
+        f_ok(Duration::from_secs(0))
+    }
+    fn location(&self) -> String { "Mock Storage".to_string() }
+    fn current_size(&self) -> Option<usize> { None }
+    fn max_size(&self) -> Option<usize> { None }
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod mock_storage;
 #[macro_use]
 pub mod utils;
 mod tests;


### PR DESCRIPTION
We're seeing failures reading cache entries in Firefox CI. I'm not sure if we're getting a truncated response from S3 or what, but it's failing to parse the zip file. This change makes storage failures like that non-fatal, they're just handled as cache misses. I believe this was the original behavior of sccache and it got changed during the tokio refactor.

I've also added another change to check that the response body matches the `Content-Length` header for S3 requests, and a diagnostic log for the response body in all cases.