### PR TITLE
Get rid of Storage::start_put and rename finish_put

### DIFF
--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -154,14 +154,11 @@ pub trait Storage {
     /// return a `Cache::Hit`.
     fn get(&self, key: &str) -> SFuture<Cache>;
 
-    /// Get a cache entry for `key` that can be filled with data.
-    fn start_put(&self, key: &str) -> Result<CacheWrite>;
-
     /// Put `entry` in the cache under `key`.
     ///
     /// Returns a `Future` that will provide the result or error when the put is
     /// finished.
-    fn finish_put(&self, key: &str, entry: CacheWrite) -> SFuture<Duration>;
+    fn put(&self, key: &str, entry: CacheWrite) -> SFuture<Duration>;
 
     /// Get the storage location.
     fn location(&self) -> String;

--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -81,12 +81,7 @@ impl Storage for DiskCache {
         }).boxed()
     }
 
-    fn start_put(&self, key: &str) -> Result<CacheWrite> {
-        trace!("DiskCache::start_put({})", key);
-        Ok(CacheWrite::new())
-    }
-
-    fn finish_put(&self, key: &str, entry: CacheWrite) -> SFuture<Duration> {
+    fn put(&self, key: &str, entry: CacheWrite) -> SFuture<Duration> {
         // We should probably do this on a background thread if we're going to buffer
         // everything in memory...
         trace!("DiskCache::finish_put({})", key);

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -83,14 +83,8 @@ impl Storage for RedisCache {
         }).boxed()
     }
 
-    /// Initiate a cache write. There is nothing special needed
-    /// for the Redis cache.
-    fn start_put(&self, _key: &str) -> Result<CacheWrite> {
-        Ok(CacheWrite::new())
-    }
-
-    /// Open a connecxtion and store a object in the cache.
-    fn finish_put(&self, key: &str, entry: CacheWrite) -> SFuture<Duration> {
+    /// Open a connection and store a object in the cache.
+    fn put(&self, key: &str, entry: CacheWrite) -> SFuture<Duration> {
         let key = key.to_owned();
         let me = self.clone();
         self.pool.spawn_fn(move || {

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -85,12 +85,7 @@ impl Storage for S3Cache {
         }))
     }
 
-    fn start_put(&self, _key: &str) -> Result<CacheWrite> {
-        // Just hand back an in-memory buffer.
-        Ok(CacheWrite::new())
-    }
-
-    fn finish_put(&self, key: &str, entry: CacheWrite) -> SFuture<Duration> {
+    fn put(&self, key: &str, entry: CacheWrite) -> SFuture<Duration> {
         let key = normalize_key(&key);
         let start = Instant::now();
         let data = match entry.finish() {

--- a/src/test/mock_storage.rs
+++ b/src/test/mock_storage.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use cache::{Cache,CacheWrite,Storage};
+use cache::{Cache, CacheWrite, Storage};
 use errors::*;
 use std::cell::RefCell;
 use std::time::Duration;
@@ -20,7 +20,6 @@ use std::time::Duration;
 /// A mock `Storage` implementation.
 pub struct MockStorage {
     gets: RefCell<Vec<SFuture<Cache>>>,
-    puts: RefCell<Vec<Result<CacheWrite>>>,
 }
 
 impl MockStorage {
@@ -28,18 +27,12 @@ impl MockStorage {
     pub fn new() -> MockStorage {
         MockStorage {
             gets: RefCell::new(vec![]),
-            puts: RefCell::new(vec![]),
         }
     }
 
     /// Queue up `res` to be returned as the next result from `Storage::get`.
     pub fn next_get(&self, res: SFuture<Cache>) {
         self.gets.borrow_mut().push(res)
-    }
-
-    /// Queue up `res` to be returned as the next result from `Storage::start_put`.
-    pub fn next_put(&self, res: Result<CacheWrite>) {
-        self.puts.borrow_mut().push(res)
     }
 }
 
@@ -49,12 +42,7 @@ impl Storage for MockStorage {
         assert!(g.len() > 0, "MockStorage get called, but no get results available");
         g.remove(0)
     }
-    fn start_put(&self, _key: &str) -> Result<CacheWrite> {
-        let mut p = self.puts.borrow_mut();
-        assert!(p.len() > 0, "MockStorage start_put called, but no put results available");
-        p.remove(0)
-    }
-    fn finish_put(&self, _key: &str, _entry: CacheWrite) -> SFuture<Duration> {
+    fn put(&self, _key: &str, _entry: CacheWrite) -> SFuture<Duration> {
         f_ok(Duration::from_secs(0))
     }
     fn location(&self) -> String { "Mock Storage".to_string() }


### PR DESCRIPTION
This patch removes the start_put function from the `Storage` trait. The `finish_put` function is renamed
to `put` get a nice `get`/`put` pair in `Storage.

This fixes #71.