### PR TITLE
Use base64 instead of rustc-serialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "sccache"
 version = "0.1.1-pre"
 dependencies = [
  "app_dirs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -30,7 +31,6 @@ dependencies = [
  "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/mozilla/sccache/"
 
 [dependencies]
 app_dirs = "1.1.1"
+base64 = "0.5.2"
 bincode = "0.8"
 byteorder = "1.0"
 chrono = { version = "0.3", optional = true }
@@ -31,7 +32,6 @@ regex = "0.2"
 retry = "0.4.0"
 ring = "0.9.0"
 rust-crypto = { version = "0.2.36", optional = true }
-rustc-serialize = "0.3"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", optional = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 extern crate app_dirs;
+extern crate base64;
 extern crate bincode;
 extern crate byteorder;
 #[cfg(feature = "chrono")]
@@ -52,7 +53,6 @@ extern crate ring;
 extern crate redis;
 extern crate regex;
 extern crate retry;
-extern crate rustc_serialize;
 #[cfg(feature = "serde_json")]
 extern crate serde_json;
 #[macro_use]

--- a/src/simples3/s3.rs
+++ b/src/simples3/s3.rs
@@ -4,6 +4,7 @@
 use std::ascii::AsciiExt;
 use std::fmt;
 
+use base64;
 use crypto::digest::Digest;
 use crypto::hmac::Hmac;
 use crypto::mac::Mac;
@@ -13,7 +14,6 @@ use hyper::{self, header};
 use hyper::Method;
 use hyper::client::{Client, Request};
 use hyper_tls::HttpsConnector;
-use rustc_serialize::base64::{ToBase64, STANDARD};
 use simples3::credential::*;
 use time;
 use tokio_core::reactor::Handle;
@@ -46,7 +46,8 @@ fn hmac<D: Digest>(d: D, key: &[u8], data: &[u8]) -> Vec<u8> {
 }
 
 fn signature(string_to_sign: &str, signing_key: &str) -> String {
-    hmac(Sha1::new(), signing_key.as_bytes(), string_to_sign.as_bytes()).to_base64(STANDARD)
+    let s = hmac(Sha1::new(), signing_key.as_bytes(), string_to_sign.as_bytes());
+    base64::encode_config::<Vec<u8>>(&s, base64::STANDARD)
 }
 
 /// An S3 bucket.


### PR DESCRIPTION
[rustc-serialize has been deprecated](https://github.com/rust-lang-deprecated/rustc-serialize).
Instead, this pull request switchs to [base64](https://crates.io/crates/base64)