### PR TITLE
Add clang arguments to the list of arguments that take values.

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -82,10 +82,10 @@ impl CCompilerImpl for Clang {
 
 /// Arguments that take a value that aren't in `gcc::ARGS_WITH_VALUE`.
 const ARGS_WITH_VALUE: &'static [&'static str] = &[
-    "-arch",
     "-B",
     "-target",
     "-Xclang",
+    "--serialize-diagnostics",
 ];
 
 /// Return true if `arg` is a clang commandline argument that takes a value.

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -83,7 +83,7 @@ pub const ARGS_WITH_VALUE: &'static [&'static str] = &[
     "-iframework", "-imacros", "-imultilib", "-include",
     "-install_name", "-iprefix", "-iquote", "-isysroot",
     "-isystem", "-iwithprefix", "-iwithprefixbefore",
-    "-u", "-x", "-arch", "--serialize-diagnostics",
+    "-u", "-x", "-arch",
     ];
 
 

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -83,7 +83,7 @@ pub const ARGS_WITH_VALUE: &'static [&'static str] = &[
     "-iframework", "-imacros", "-imultilib", "-include",
     "-install_name", "-iprefix", "-iquote", "-isysroot",
     "-isystem", "-iwithprefix", "-iwithprefixbefore",
-    "-u",
+    "-u", "-x", "-arch", "--serialize-diagnostics",
     ];
 
 


### PR DESCRIPTION
These arguments are passed by xcode during normal builds, so should be supported by sccache.