### PR TITLE
added missing args with values on clang osx

### DIFF
--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -83,7 +83,8 @@ pub const ARGS_WITH_VALUE: &'static [&'static str] = &[
     "-iframework", "-imacros", "-imultilib", "-include",
     "-install_name", "-iprefix", "-iquote", "-isysroot",
     "-isystem", "-iwithprefix", "-iwithprefixbefore",
-    "-u", "-x", "-arch",
+    "-u", "-x", "-arch", "--serialize-diagnostics",
+    "--sysroot"
     ];
 
 

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -83,8 +83,7 @@ pub const ARGS_WITH_VALUE: &'static [&'static str] = &[
     "-iframework", "-imacros", "-imultilib", "-include",
     "-install_name", "-iprefix", "-iquote", "-isysroot",
     "-isystem", "-iwithprefix", "-iwithprefixbefore",
-    "-u", "-x", "-arch", "--serialize-diagnostics",
-    "--sysroot"
+    "-u", "-x", "-arch", "--sysroot"
     ];
 
 


### PR DESCRIPTION
when compiling on osx I had to add these two extra values to the missing args with values list. should be harmless I think.