### PR TITLE
Additional s3 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Storage Options
 
 sccache defaults to using local disk storage. You can set the `SCCACHE_DIR` environment variable to change the disk cache location. By default it will use a sensible location for the current platform: `~/.cache/sccache` on Linux, `%LOCALAPPDATA%\Mozilla\sccache` on Windows, `~/Library/Caches/sccache` on OS X.
 
-If you want to use S3 storage for the sccache cache, you need to set the `SCCACHE_BUCKET` environment variable to the name of the S3 bucket to use.
+If you want to use S3 storage for the sccache cache, you need to set the `SCCACHE_BUCKET` environment variable to the name of the S3 bucket to use. You can use `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to set the S3 credentials and if you need to override the default endpoint you can set `SCCACHE_ENDPOINT`. To connect to a minio storage for example you can set `SCCACHE_ENDPOINT=<ip>:<port>`.
 
 Set `SCCACHE_REDIS` to a [Redis](https://redis.io/) url in format `redis://[:<passwd>@]<hostname>[:port][/<db>]` to store the cache in a Redis instance.
 

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -83,7 +83,8 @@ pub const ARGS_WITH_VALUE: &'static [&'static str] = &[
     "-iframework", "-imacros", "-imultilib", "-include",
     "-install_name", "-iprefix", "-iquote", "-isysroot",
     "-isystem", "-iwithprefix", "-iwithprefixbefore",
-    "-u", "-x", "-arch",
+    "-u", "-x", "-arch", "--serialize-diagnostics",
+    "--sysroot"
     ];
 
 

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -83,8 +83,7 @@ pub const ARGS_WITH_VALUE: &'static [&'static str] = &[
     "-iframework", "-imacros", "-imultilib", "-include",
     "-install_name", "-iprefix", "-iquote", "-isysroot",
     "-isystem", "-iwithprefix", "-iwithprefixbefore",
-    "-u", "-x", "-arch", "--serialize-diagnostics",
-    "--sysroot"
+    "-u", "-x", "-arch",
     ];
 
 


### PR DESCRIPTION
minor addition for undocumented s3 env variables needed to use a private s3 compatible object store like minio. 