### PR TITLE
Don't pass flags to `wide_char_to_multi_byte`.

### DIFF
--- a/src/test/system.rs
+++ b/src/test/system.rs
@@ -25,11 +25,8 @@ use std::collections::HashMap;
 use std::env;
 use std::ffi::{OsStr,OsString};
 use std::fmt;
-use std::fs;
-use std::io::{
-    self,
-    Write,
-};
+use std::fs::{self, File};
+use std::io::{self, Read, Write};
 use std::path::{Path,PathBuf};
 use std::process::{
     Command,
@@ -138,16 +135,16 @@ fn run_sccache_command_test(sccache: &Path, compiler: Compiler, tempdir: &Path) 
             .success());
     trace!("run_sccache_command_test: {}", name);
     // Compile a source file.
-    let original_source_file = Path::new(file!()).parent().unwrap().join("test.c");
+    const INPUT: &'static str = "test.c";
+    const OUTPUT: &'static str = "test.o";
+    let original_source_file = Path::new(file!()).parent().unwrap().join(INPUT);
     // Copy the source file into the tempdir so we can compile with relative paths, since the commandline winds up in the hash key.
-    let source_file = tempdir.join("test.c");
+    let source_file = tempdir.join(INPUT);
     trace!("fs::copy({:?}, {:?})", original_source_file, source_file);
     fs::copy(&original_source_file, &source_file).unwrap();
     let out_file = tempdir.join("test.o");
-    let input = source_file.file_name().unwrap().to_str().unwrap();
-    let output = out_file.file_name().unwrap().to_str().unwrap();
     trace!("compile");
-    assert_eq!(true, run(sccache, &compile_cmdline(name, &exe, &input, &output), tempdir, &env_vars));
+    assert_eq!(true, run(sccache, &compile_cmdline(name, &exe, INPUT, OUTPUT), tempdir, &env_vars));
     assert_eq!(true, fs::metadata(&out_file).and_then(|m| Ok(m.len() > 0)).unwrap());
     trace!("request stats");
     let info = get_stats(sccache, tempdir);
@@ -157,7 +154,7 @@ fn run_sccache_command_test(sccache: &Path, compiler: Compiler, tempdir: &Path) 
     assert_eq!(1, info.stats.cache_misses);
     trace!("compile");
     fs::remove_file(&out_file).unwrap();
-    assert_eq!(true, run(sccache, &compile_cmdline(name, &exe, &input, &output), tempdir, &env_vars));
+    assert_eq!(true, run(sccache, &compile_cmdline(name, &exe, INPUT, OUTPUT), tempdir, &env_vars));
     assert_eq!(true, fs::metadata(&out_file).and_then(|m| Ok(m.len() > 0)).unwrap());
     trace!("request stats");
     let info = get_stats(sccache, tempdir);
@@ -165,6 +162,23 @@ fn run_sccache_command_test(sccache: &Path, compiler: Compiler, tempdir: &Path) 
     assert_eq!(2, info.stats.requests_executed);
     assert_eq!(1, info.stats.cache_hits);
     assert_eq!(1, info.stats.cache_misses);
+    if name == "cl.exe" {
+        // Check that -deps works.
+        trace!("compile with -deps");
+        let mut args = compile_cmdline(name, &exe, INPUT, OUTPUT);
+        args.push("-depstest.d".into());
+        assert_eq!(true, run(sccache, &args, tempdir, &env_vars));
+        // Check the contents
+        let mut f = File::open(tempdir.join("test.d")).expect("Failed to open dep file");
+        let mut buf = String::new();
+        // read_to_string should be safe because we're supplying all the filenames here,
+        // and there are no absolute paths.
+        f.read_to_string(&mut buf).expect("Failed to read dep file");
+        let lines: Vec<_> = buf.lines().map(|l| l.trim_right()).collect();
+        let expected = format!("{output}: {input}\n{input}:\n", output=OUTPUT, input=INPUT);
+        let expected_lines: Vec<_> = expected.lines().collect();
+        assert_eq!(lines, expected_lines);
+    }
     trace!("stop server");
     assert_eq!(true, run(sccache, &["--stop-server"], tempdir, &[]));
 }


### PR DESCRIPTION
The MSDN docs for WideCharToMultiByte say:
"WC_ERR_INVALID_CHARS - ... Note that this flag only applies when CodePage is
specified as CP_UTF8 or 54936 (for Windows Vista and later). It cannot be used
with other code page values."
https://msdn.microsoft.com/en-us/library/windows/desktop/dd374130(v=vs.85).aspx

We're currently getting ERROR_INVALID_FLAGS here. I've also added a test
that -deps works for MSVC which catches this error.