### PR TITLE
Fix build with --no-default-features --features=redis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ ring = "0.9.0"
 rust-crypto = { version = "0.2.36", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
-serde_json = { version = "1.0", optional = true }
+serde_json = "1.0"
 tempdir = "0.3.4"
 tempfile = "2.1.5"
 time = "0.1.35"
@@ -71,7 +71,7 @@ mio-named-pipes = "0.1"
 [features]
 default = ["s3"]
 all = ["redis", "s3"]
-s3 = ["chrono", "hyper", "hyper-tls", "rust-crypto", "serde_json", "simple-s3"]
+s3 = ["chrono", "hyper", "hyper-tls", "rust-crypto", "simple-s3"]
 simple-s3 = []
 # Enable features that require unstable features of Nightly Rust.
 unstable = []

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,7 +23,6 @@ use futures::future;
 #[cfg(feature = "hyper")]
 use hyper;
 use lru_disk_cache;
-#[cfg(feature = "serde_json")]
 use serde_json;
 #[cfg(feature = "redis")]
 use redis;
@@ -34,7 +33,7 @@ error_chain! {
         Hyper(hyper::Error) #[cfg(feature = "hyper")];
         Io(io::Error);
         Lru(lru_disk_cache::Error);
-        Json(serde_json::Error) #[cfg(feature = "serde_json")];
+        Json(serde_json::Error);
         Bincode(bincode::Error);
         Redis(redis::RedisError) #[cfg(feature = "redis")];
         TempfilePersist(tempfile::PersistError);

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,6 @@ extern crate ring;
 extern crate redis;
 extern crate regex;
 extern crate retry;
-#[cfg(feature = "serde_json")]
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
The `serde_json` crate is always needed by `src/commands.rs` even when building only with support for Redis, but `serde_json` would be left out when the S3 feature is disabled. This make it possible to build `sccache` only with Redis support.

Building with S3 disabled trims down a stripped release build from 5.1 MiB down to 4.4 MiB on x86_64.