### PR TITLE
Treat -include as a preprocessor flag

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -173,8 +173,8 @@ mod test {
         assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
         //TODO: fix assert_map_contains to assert no extra keys!
         assert_eq!(1, a.outputs.len());
-        assert!(a.preprocessor_args.is_empty());
-        assert_eq!(ovec!["-arch", "xyz", "-fabc", "-I", "include", "-include", "file"], a.common_args);
+        assert_eq!(ovec!["-include", "file"], a.preprocessor_args);
+        assert_eq!(ovec!["-arch", "xyz", "-fabc", "-I", "include"], a.common_args);
     }
 
     #[test]

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -144,9 +144,14 @@ fn _parse_arguments(arguments: &[OsString],
                 // -MF and -MQ are in this set but are handled separately
                 // because they are also preprocessor options.
                 a if argument_takes_value(a) => {
-                    common_args.push(arg.clone());
+                    let args = if a == "-include" {
+                        &mut preprocessor_args
+                    } else {
+                        &mut common_args
+                    };
+                    args.push(arg.clone());
                     if let Some(arg_val) = it.next() {
-                        common_args.push(arg_val);
+                        args.push(arg_val);
                     }
                 },
                 "-MF" |
@@ -557,8 +562,8 @@ mod test {
         assert_map_contains!(outputs, ("obj", PathBuf::from("foo.o")));
         //TODO: fix assert_map_contains to assert no extra keys!
         assert_eq!(1, outputs.len());
-        assert!(preprocessor_args.is_empty());
-        assert_eq!(ovec!["-fabc", "-I", "include", "-include", "file"], common_args);
+        assert_eq!(ovec!["-include", "file"], preprocessor_args);
+        assert_eq!(ovec!["-fabc", "-I", "include"], common_args);
         assert!(!msvc_show_includes);
     }
 


### PR DESCRIPTION
When the original compiler invocation contains -include, passing the
flag to the compiler invocation for the preprocessed source can lead to
errors because it will cause another pass of the preprocessor (although
arguably, with -x cpp-output, it shouldn't).

Ideally, other flags like -I, -idirafter, etc. should be handled the
same, but there are other issues that should be addressed for those
(as well as -include, but this addresses the most immediate issue)
See https://github.com/mozilla/sccache/issues/117#issuecomment-315569559

Fixes #117