### PR TITLE
Revert "Move from openssl to pem-parser for PEM to DER conversion for GCS"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
  "mio-named-pipes 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "pem-parser 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -662,15 +662,6 @@ dependencies = [
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pem-parser"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1378,7 +1369,6 @@ dependencies = [
 "checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
 "checksum openssl 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b34cd77cf91301fff3123fbd46b065c3b728b17a392835de34c397315dce5586"
 "checksum openssl-sys 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e035022a50faa380bd7ccdbd184d946ce539ebdb0a358780de92a995882af97a"
-"checksum pem-parser 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "443598a432c1c2dc0ad1b98e160b51caa94380894f09f932de45845527bd7ad0"
 "checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum podio 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e5422a1ee1bc57cc47ae717b0137314258138f38fd5f3cea083f43a9725383a0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.3.6"
 lru-disk-cache = { path = "lru-disk-cache", version = "0.1.0" }
 native-tls = "0.1"
 number_prefix = "0.2.5"
-pem-parser= { version = "0.1.1", optional = true }
+openssl = { version = "0.9", optional = true }
 redis = { version = "0.8.0", optional = true }
 regex = "0.2"
 retry = "0.4.0"
@@ -77,7 +77,7 @@ default = ["s3"]
 all = ["redis", "s3"]
 s3 = ["chrono", "hyper", "hyper-tls", "rust-crypto", "simple-s3"]
 simple-s3 = []
-gcs = ["chrono", "hyper", "hyper-tls", "jsonwebtoken", "pem-parser", "url"]
+gcs = ["chrono", "hyper", "hyper-tls", "jsonwebtoken", "openssl", "url"]
 # Enable features that require unstable features of Nightly Rust.
 unstable = []
 

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -34,7 +34,7 @@ use hyper::Method;
 use hyper::client::{Client, HttpConnector, Request};
 use hyper_tls::HttpsConnector;
 use jwt;
-use pem_parser;
+use openssl;
 use serde_json;
 use tokio_core::reactor::Handle;
 use url::form_urlencoded;
@@ -229,7 +229,9 @@ impl GCSCredentialProvider {
             issued_at: chrono::UTC::now().timestamp(),
         };
 
-        let binary_key = pem_parser::pem_to_der(&self.sa_key.private_key);
+        let binary_key = openssl::rsa::Rsa::private_key_from_pem(
+            self.sa_key.private_key.as_bytes()
+        )?.private_key_to_der()?;
 
         let auth_request_jwt = jwt::encode(
             &jwt::Header::new(jwt::Algorithm::RS256),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,6 +26,8 @@ use hyper;
 use jwt;
 use lru_disk_cache;
 use native_tls;
+#[cfg(feature = "openssl")]
+use openssl;
 use serde_json;
 #[cfg(feature = "redis")]
 use redis;
@@ -38,6 +40,7 @@ error_chain! {
         Lru(lru_disk_cache::Error);
         Json(serde_json::Error);
         Jwt(jwt::errors::Error) #[cfg(feature = "jsonwebtoken")];
+        Openssl(openssl::error::ErrorStack) #[cfg(feature = "openssl")];
         Bincode(bincode::Error);
         Redis(redis::RedisError) #[cfg(feature = "redis")];
         StrFromUtf8(::std::string::FromUtf8Error) #[cfg(feature = "gcs")];

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,8 +53,8 @@ extern crate libc;
 extern crate mio_named_pipes;
 extern crate native_tls;
 extern crate number_prefix;
-#[cfg(feature = "pem-parser")]
-extern crate pem_parser;
+#[cfg(feature = "openssl")]
+extern crate openssl;
 extern crate ring;
 #[cfg(feature = "redis")]
 extern crate redis;


### PR DESCRIPTION
This reverts commit 39fdfd83a84ccf1f1a8df58588c33953bebe702d.

See #157. This commit broke GCS authentication. While it's unfortunate to bring in OpenSSL as a dependency, it seems like pem-parser doesn't work for some reason, and I don't know of an alternative crate.

cc @luser