### PR TITLE
Add a link to the Jenkins notes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ You can run `sccache --stop-server` to terminate the server. It will terminate a
 
 Running `sccache --show-stats` will print a summary of cache statistics.
 
+Some notes about using `sccache` with [Jenkins](https://jenkins.io) are [here](docs/Jenkins.md).
+
 Storage Options
 ---------------
 


### PR DESCRIPTION
This add a link to the Jenkins nodes in the README as requested bu @luser. Definitely a good idea ;-).