### PR TITLE
Add jobserver support to sccache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "hyper 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jobserver 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonwebtoken 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -27,6 +28,7 @@ dependencies = [
  "lru-disk-cache 0.1.0",
  "mio-named-pipes 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -413,6 +415,15 @@ dependencies = [
 name = "itoa"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "jobserver"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "jsonwebtoken"
@@ -1385,6 +1396,7 @@ dependencies = [
 "checksum iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"
 "checksum itertools 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "772a0928a97246167d59a2a4729df5871f1327ab8b36fd24c4224b229cb47b99"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
+"checksum jobserver 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "443ae8bc0af6c106e6e8b77e04684faecc1a5ce94e058f4c2b0a037b0ea1b133"
 "checksum jsonwebtoken 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded1c69eb0de78a0abce9f7987dc832613abb168029868271e8cba843f45a3b3"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,14 @@ futures = "0.1.11"
 futures-cpupool = "0.1"
 hyper = { version = "0.11", optional = true }
 hyper-tls = { version = "0.1", optional = true }
+jobserver = "0.1"
 jsonwebtoken = { version = "2.0", optional = true }
 libc = "0.2.10"
 local-encoding = "0.2.0"
 log = "0.3.6"
 lru-disk-cache = { path = "lru-disk-cache", version = "0.1.0" }
 native-tls = "0.1"
+num_cpus = "1.0"
 number_prefix = "0.2.5"
 openssl = { version = "0.9", optional = true }
 redis = { version = "0.8.0", optional = true }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -18,6 +18,7 @@ use client::{
     ServerConnection,
 };
 use cmdline::{Command, StatsFormat};
+use jobserver::Client;
 use log::LogLevel::Trace;
 use mock_command::{
     CommandCreatorSync,
@@ -601,9 +602,10 @@ pub fn run_command(cmd: Command) -> Result<i32> {
         }
         Command::Compile { exe, cmdline, cwd, env_vars } => {
             trace!("Command::Compile {{ {:?}, {:?}, {:?} }}", exe, cmdline, cwd);
+            let jobserver = unsafe { Client::new() };
             let conn = connect_or_start_server(get_port())?;
             let mut core = Core::new()?;
-            let res = do_compile(ProcessCommandCreator::new(&core.handle()),
+            let res = do_compile(ProcessCommandCreator::new(&core.handle(), &jobserver),
                                  &mut core,
                                  conn,
                                  exe.as_ref(),

--- a/src/jobserver.rs
+++ b/src/jobserver.rs
@@ -1,0 +1,71 @@
+extern crate jobserver;
+
+use std::io;
+use std::process::Command;
+use std::sync::Arc;
+
+use futures::prelude::*;
+use futures::sync::mpsc;
+use futures::sync::oneshot;
+use num_cpus;
+
+use errors::*;
+
+pub use self::jobserver::Acquired;
+
+#[derive(Clone)]
+pub struct Client {
+    helper: Arc<jobserver::HelperThread>,
+    inner: jobserver::Client,
+    tx: mpsc::UnboundedSender<oneshot::Sender<io::Result<Acquired>>>
+}
+
+impl Client {
+    // unsafe because `from_env` is unsafe (can use the wrong fds)
+    pub unsafe fn new() -> Client {
+        match jobserver::Client::from_env() {
+            Some(c) => Client::_new(c),
+            None => Client::new_num(num_cpus::get()),
+        }
+    }
+
+    pub fn new_num(num: usize) -> Client {
+        let inner = jobserver::Client::new(num)
+                .expect("failed to create jobserver");
+        Client::_new(inner)
+    }
+
+    fn _new(inner: jobserver::Client) -> Client {
+        let (tx, rx) = mpsc::unbounded::<oneshot::Sender<_>>();
+        let mut rx = rx.wait();
+        let helper = inner.clone().into_helper_thread(move |token| {
+            if let Some(Ok(sender)) = rx.next() {
+                drop(sender.send(token));
+            }
+        }).expect("failed to spawn helper thread");
+
+        Client {
+            inner: inner,
+            helper: Arc::new(helper),
+            tx: tx,
+        }
+    }
+
+    /// Configures this jobserver to be inherited by the specified command
+    pub fn configure(&self, cmd: &mut Command) {
+        self.inner.configure(cmd)
+    }
+
+    /// Returns a future that represents an acquired jobserver token.
+    ///
+    /// This should be invoked before any "work" is spawend (for whatever the
+    /// defnition of "work" is) to ensure that the system is properly
+    /// rate-limiting itself.
+    pub fn acquire(&self) -> SFuture<Acquired> {
+        let (tx, rx) = oneshot::channel();
+        self.helper.request_token();
+        self.tx.unbounded_send(tx).unwrap();
+        Box::new(rx.chain_err(|| "jobserver helper panicked")
+                   .and_then(|t| t.chain_err(|| "failed to acquire jobserver token")))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ extern crate libc;
 #[cfg(windows)]
 extern crate mio_named_pipes;
 extern crate native_tls;
+extern crate num_cpus;
 extern crate number_prefix;
 #[cfg(feature = "openssl")]
 extern crate openssl;
@@ -93,6 +94,7 @@ mod client;
 mod cmdline;
 mod commands;
 mod compiler;
+mod jobserver;
 mod mock_command;
 mod protocol;
 mod server;

--- a/src/simples3/credential.rs
+++ b/src/simples3/credential.rs
@@ -87,7 +87,7 @@ pub struct EnvironmentProvider;
 
 impl ProvideAwsCredentials for EnvironmentProvider {
     fn credentials(&self) -> SFuture<AwsCredentials> {
-		future::result(credentials_from_environment()).boxed()
+		Box::new(future::result(credentials_from_environment()))
     }
 }
 
@@ -189,7 +189,7 @@ impl ProvideAwsCredentials for ProfileProvider {
         let result = result.and_then(|mut profiles| {
             profiles.remove(self.profile()).ok_or("profile not found".into())
         });
-        future::result(result).boxed()
+        Box::new(future::result(result))
     }
 }
 

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -202,11 +202,9 @@ fn test_server_compile() {
         let obj = f.tempdir.path().join("file.o");
         c.next_command_calls(move |_| {
             // Pretend to compile something.
-            match File::create(&obj)
-                .and_then(|mut f| f.write_all(b"file contents")) {
-                    Ok(_) => Ok(MockChild::new(exit_status(0), STDOUT, STDERR)),
-                    Err(e) => Err(e),
-                }
+            let mut f = File::create(&obj)?;
+            f.write_all(b"file contents")?;
+            Ok(MockChild::new(exit_status(0), STDOUT, STDERR))
         });
     }
     // Ask the server to compile something.

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use futures::Future;
-use futures::future;
 use futures_cpupool::CpuPool;
 use mock_command::{CommandChild, RunCommand};
 use ring::digest::{SHA512, Context};
@@ -139,10 +138,9 @@ pub fn run_input_output<C>(mut command: C, input: Option<Vec<u8>>)
         .stdin(if input.is_some() { Stdio::piped() } else { Stdio::inherit() })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .spawn()
-        .chain_err(|| "failed to spawn child");
+        .spawn();
 
-    Box::new(future::result(child)
+    Box::new(child
              .and_then(|child| {
                  wait_with_input_output(child, input).and_then(|output| {
                      if output.status.success() {


### PR DESCRIPTION
This commit alters the main sccache server to operate and orchestrate its own
GNU make style jobserver. This is primarily intended for interoperation with
rustc itself.

The Rust compiler currently has a multithreaded mode where it will execute code
generation and optimization on the LLVM side of things in parallel. This
parallelism, however, can overload a machine quickly if not properly accounted
for (e.g. if 10 rustcs all spawn 10 threads...). The usage of a GNU make style
jobserver is intended to arbitrate and rate limit all these rustc instances to
ensure that one build's maximal parallelism never exceeds a particular amount.

Currently for Rust Cargo is the primary driver for setting up a jobserver. Cargo
will create this and manage this per compilation, ensuring that any one `cargo
build` invocation never exceeds a maximal parallelism. When sccache enters the
picture, however, the story gets slightly more odd.

The jobserver implementation on Unix relies on inheritance of file descriptors
in spawned processes. With sccache, however, there's no inheritance as the
actual rustc invocation is spawned by the server, not the client. In this case
the env vars used to configure the jobsever are usually incorrect.

To handle this problem this commit bakes a jobserver directly into sccache
itself. The jobserver then overrides whatever jobserver the client has
configured in its own env vars to ensure correct operation. The settings of each
jobserver may be misconfigured (there's no way to configure sccache's jobserver
right now), but hopefully that's not too much of a problem for the forseeable
future.

The implementation here was to provide a thin wrapper around the `jobserver`
crate with a futures-based interface. This interface was then hooked into the
mock command infrastructure to automatically acquire a jobserver token when
spawning a process and automatically drop the token when the process exits.
Additionally, all spawned processes will now automatically receive a configured
jobserver.

cc rust-lang/rust#42867, the original motivation for this commit