### PR TITLE
Replace Future::boxed with Box::new.

### DIFF
--- a/src/mock_command.rs
+++ b/src/mock_command.rs
@@ -357,7 +357,7 @@ impl CommandChild for MockChild {
     fn take_stderr(&mut self) -> Option<io::Cursor<Vec<u8>>> { self.stderr.take() }
 
     fn wait(mut self) -> Box<Future<Item = ExitStatus, Error = io::Error>> {
-        future::result(self.wait_result.take().unwrap()).boxed()
+        Box::new(future::result(self.wait_result.take().unwrap()))
     }
 
 
@@ -370,7 +370,7 @@ impl CommandChild for MockChild {
                 stderr: stderr.map(|c| c.into_inner()).unwrap_or(vec!()),
             })
         });
-        future::result(result).boxed()
+        Box::new(future::result(result))
     }
 }
 

--- a/src/simples3/credential.rs
+++ b/src/simples3/credential.rs
@@ -87,7 +87,7 @@ pub struct EnvironmentProvider;
 
 impl ProvideAwsCredentials for EnvironmentProvider {
     fn credentials(&self) -> SFuture<AwsCredentials> {
-		future::result(credentials_from_environment()).boxed()
+		Box::new(future::result(credentials_from_environment()))
     }
 }
 
@@ -189,7 +189,7 @@ impl ProvideAwsCredentials for ProfileProvider {
         let result = result.and_then(|mut profiles| {
             profiles.remove(self.profile()).ok_or("profile not found".into())
         });
-        future::result(result).boxed()
+        Box::new(future::result(result))
     }
 }
 


### PR DESCRIPTION
In futures 0.1.15, the boxed() method on Future structs was
deprecated. This returned a BoxFuture type which had to be
declared either Send or 'static while wrapping a Future
in Box::new() allows inference of the appropriate trait bounds.

We already don't use the BoxFuture trait, so just call Box::new()
directly instead to avoid the deprecation warning and make it
easier to port to future releases.

See also https://github.com/alexcrichton/futures-rs/issues/228