### PR TITLE
Support MSVC response files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,63 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-simpchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "env_logger"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +1030,7 @@ dependencies = [
  "chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "daemonize 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1620,6 +1678,13 @@ dependencies = [
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
+"checksum encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+"checksum encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+"checksum encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+"checksum encoding-index-simpchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+"checksum encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+"checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+"checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum environment 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4b14e20978669064c33b4c1e0fb4083412e40fe56cbea2eae80fd7591503ee"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ bincode = "0.9"
 byteorder = "1.0"
 chrono = { version = "0.3", optional = true }
 clap = "2.23.0"
+encoding = "0.2"
 env_logger = "0.4"
 error-chain = { version = "0.11", default-features = false }
 filetime = "0.1"

--- a/docs/MSBuild.md
+++ b/docs/MSBuild.md
@@ -1,0 +1,46 @@
+**Note**: Using `sccache` with `msbuild` is not fully supported yet. Supporting
+multiple inputs on one command line is the last remaining issue. See
+https://github.com/mozilla/sccache/issues/107 for more information.
+
+Instruct `msbuild` to use our own `cl.exe`:
+
+    msbuild blah.sln /p:CLToolExe=cl.exe /p:CLToolPath=C:\tools
+
+Where `C:\tools` contains `cl.exe`, the renamed `sccache.exe`.
+
+Since there is no way to tell `msbuild` to run `sccache cl [args...]`, `sccache`
+must determine which compiler to immitate based upon the name of the executable
+alone. Thus, the `sccache` executable must be renamed to `cl.exe`.
+
+## Debugging
+
+If you want to see what the `sccache` server is doing, start it up manually
+within a Visual Studio command prompt (`cl.exe` will not find the DLLs it needs
+otherwise):
+
+    set SCCACHE_LOG_LEVEL=info
+    set SCCACHE_START_SERVER=1
+    set SCCACHE_NO_DAEMON=1
+    sccache
+
+## Cache Misses
+
+Common causes of cache misses are detailed in this section.
+
+### Multiple source files per command line
+
+`msbuild` calls `cl.exe` with multiple source files. This feature is not yet
+supported by `sccache` due to its internal architecture and is the last
+remaining hurdle for full support.
+
+### PDB output
+
+Invididual compilations are not allowed to output to a shared PDB. This is the
+default behavior when `/Zi` (Program Databse) or `/ZI` (Program Database for
+Edit and Continue) is specified.
+
+Instead, you must use `/Z7` where the debug information is embedded in the
+object file itself. The main trade off is that you cannot use Minimal Rebuild
+(`/Gm`) or Edit and Continue.
+
+See also: https://docs.microsoft.com/en-us/cpp/build/reference/z7-zi-zi-debug-information-format

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -608,6 +608,12 @@ impl<'a> Iterator for SplitArgs<'a> {
             };
         }
 
+        // Flush any backslashes at the end of the string.
+        while backslashes > 0 {
+            arg.push('\\');
+            backslashes -= 1;
+        }
+
         // Slide the window over.
         self.s = chars.as_str();
 
@@ -1056,5 +1062,9 @@ mod test {
         // toggles the "in quotes" mode.
         assert!(test_split(r#"prog \\\\"in quotes\\\\""#,
                            &["prog", r"\\in quotes\\"]));
+
+        // Trailing backslashes
+        assert!(test_split(r"prog \\\\", &["prog", r"\\\\"]));
+        assert!(test_split(r"prog foo\\\\", &["prog", r"foo\\\\"]));
     }
 }

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -199,7 +199,7 @@ enum MSVCArgAttribute {
 use self::MSVCArgAttribute::*;
 
 static ARGS: [(ArgInfo, MSVCArgAttribute); 20] = [
-    take_arg!("-D", String, Concatenated, PreprocessorArgument),
+    take_arg!("-D", String, CanBeSeparated, PreprocessorArgument),
     take_arg!("-FA", String, Concatenated, TooHard),
     take_arg!("-FI", Path, CanBeSeparated, PreprocessorArgument),
     take_arg!("-FR", Path, Concatenated, TooHard),

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ extern crate clap;
 extern crate crypto;
 #[cfg(unix)]
 extern crate daemonize;
+extern crate encoding;
 extern crate env_logger;
 #[macro_use]
 extern crate error_chain;


### PR DESCRIPTION
Adds support for `@`-files appearing on the MSVC command line.

The response file is expanded in-place on the command line, but not recursively like in the gcc implementation in order to conform to the spec. I also implemented a Windows command line parser for this instead of relying on [`CommandLineToArgvW`](https://msdn.microsoft.com/en-us/library/windows/desktop/bb776391(v=vs.85).aspx) just in case people somehow use the MSVC compiler on non-Windows platforms.

This was one of the blockers for MSBuild support as mentioned in https://github.com/mozilla/sccache/issues/107#issuecomment-337343925. After this is merged, I'll look into adding support for handling multiple source files on one command line.

Please rip it apart in a code review. :feelsgood: 