### PR TITLE
Replace Future::boxed with Box::new (redis, gcs)

### DIFF
--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -361,7 +361,7 @@ impl Storage for GCSCache {
         let start = time::Instant::now();
         let data = match entry.finish() {
             Ok(data) => data,
-            Err(e) => return future::err(e.into()).boxed(),
+            Err(e) => return Box::new(future::err(e.into())),
         };
         let bucket = self.bucket.clone();
         let response = bucket.put(&key, data, &self.credential_provider).chain_err(|| {


### PR DESCRIPTION
This follows up on commit 0.2.2~5 which replaced deprecated use of
Future::boxed everywhere except the redis and gcs modules.