### PR TITLE
Add snapcraft packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ target
 *.log
 .cargo
 *.pyc
+
+# snapcraft artifacts
+/parts
+/prime
+/snap/.snapcraft
+/stage
+/*.snap

--- a/snap/bin/sccache.wrapper
+++ b/snap/bin/sccache.wrapper
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# read environment from the config file
+. $SNAP_DATA/config
+
+$SNAP/bin/sccache "$@"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -xe
+
+CONFIG_FILE=$SNAP_DATA/config
+
+declare -A OPTIONS DEFAULTS VALUES
+OPTIONS[port]=SCCACHE_PORT
+OPTIONS[log-level]=SCCACHE_LOG_LEVEL
+OPTIONS[cache-dir]=SCCACHE_DIR
+OPTIONS[s3.bucket]=SCCACHE_BUCKET
+OPTIONS[s3.endpoint]=SCCACHE_ENDPOINT
+OPTIONS[s3.key-id]=AWS_ACCESS_KEY_ID
+OPTIONS[s3.secret]=AWS_SECRET_ACCESS_KEY
+OPTIONS[redis.url]=SCCACHE_REDIS
+OPTIONS[gcs.bucket]=SCCACHE_GCS_BUCKET
+OPTIONS[gcs.key-path]=SCCACHE_GCS_KEY_PATH
+OPTIONS[gcs.rw-mode]=SCCACHE_GCS_RW_MODE
+
+DEFAULTS[port]=4226
+DEFAULTS[cache-dir]=$SNAP_COMMON/cache
+DEFAULTS[log-level]=info
+DEFAULTS[gcs.rw-mode]=false
+
+VALUES[gcs.rw-mode-true]=READ_WRITE
+VALUES[gcs.rw-mode-false]=READ_ONLY
+
+# Iterate through the config options array
+for opt in ${!OPTIONS[@]}; do
+    # Get environment variable name
+    var=${OPTIONS[$opt]}
+
+    # Use snapctl to get the value registered by the snap set command
+    value="$(snapctl get $opt)"
+
+    # Fall back to the default value
+    [ -n "$value" ] || value="${DEFAULTS[$opt]}"
+
+    # Set the resulting value back to snapctl to populate all keys and defaults
+    snapctl set $opt="$value"
+
+    # Map the value using the VALUES map
+    value="${VALUES[$opt-$value]-$value}"
+
+    # Write out non-empty variable exports to the config file, preserving
+    # calling environment values
+    [ -n "$value" ] && echo "export $var=\"\${$var-$value}\"" >> $CONFIG_FILE.new
+done
+
+# Move the new config file
+mv -f ${CONFIG_FILE}.new $CONFIG_FILE || /bin/true
+
+# Restart the server to pick up new values
+systemctl restart snap.sccache.sccache-server.service

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,32 @@
+name: sccache
+version: '0.2.2'
+version-script: |
+    git describe --tags
+
+summary: sccache is ccache with cloud storage
+description: |
+    sccache is a ccache-like tool. It is used as a compiler wrapper and avoids
+    compilation when possible, storing a cache in a remote storage using the
+    Amazon Simple Cloud Storage Service (S3) API, the Google Cloud Storage (GCS)
+    API, or Redis.
+
+grade: stable
+confinement: classic
+
+apps:
+    sccache:
+        command: bin/sccache
+
+parts:
+    sccache:
+        plugin: rust
+        source: .
+        source-type: git
+        build-packages:
+        - libssl-dev
+        - make
+        - pkg-config
+        rust-features:
+        - gcs
+        - redis
+        - s3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,15 @@ confinement: classic
 
 apps:
     sccache:
-        command: bin/sccache
+        command: bin/sccache.wrapper
+
+    sccache-server:
+        environment:
+            SCCACHE_START_SERVER: 1
+            SCCACHE_NO_DAEMON: 1
+            SCCACHE_IDLE_TIMEOUT: 0
+        command: bin/sccache.wrapper
+        daemon: simple
 
 parts:
     sccache:
@@ -30,3 +38,8 @@ parts:
         - gcs
         - redis
         - s3
+
+    wrapper:
+        plugin: dump
+        source: snap
+        prime: [bin]


### PR DESCRIPTION
[Snaps](https://snapcraft.io/) are portable cross-distro packages available on more and more systems.

sccache is a perfect candidate for this, and having it readily available on travis-ci, for example feels like an ideal use case.

https://build.snapcraft.io/ is a build service that can build and publish the built snaps in an automated way.

I now published an "edge" version based on master and a "candidate" based on the latest 0.2.2 release. I'd love to transfer the "sccache" name to you, snaps could become the easiest way for people to install sccache :)

```
$ snap info sccache                    
name:      sccache
summary:   sccache is ccache with cloud storage
publisher: saviq
contact:   https://github.com/mozilla/sccache
description: |
  sccache is a ccache-like tool. It is used as a compiler wrapper and avoids
  compilation when possible, storing a cache in a remote storage using the
  Amazon Simple Cloud Storage Service (S3) API, the Google Cloud Storage (GCS)
  API, or Redis.
snap-id: ZuPGnwd83RCPQbRI9tkO178o6PA849OE
commands:
  - sccache
services:
  sccache.sccache-server: simple, enabled, inactive
tracking:                 edge
installed:                0.2.2-6-gc96439b (2) 9MB classic
refreshed:                2017-10-27 20:03:35 +0200 CEST
channels:                                      
  stable:                 –                        
  candidate:              0.2.2-2-g63a2232 (3) 9MB classic
  beta:                   ↑                        
  edge:                   0.2.2-6-gc96439b (2) 9MB classic
```