### PR TITLE
Docs - README.md - tweaks (thumbnaill, separators, ToC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@ It works as a client-server. The client spawns a server if one is not running al
 
 Sccache can also be used with local storage instead of remote.
 
+---
+
+Table of Contents (ToC)
+======================
+
+* [Build Requirements](#build-requirements)
+* [Build](#build)
+* [Installation](#installation)
+* [Usage](#usage)
+* [Storage Options](#storage-options)
+* [Debugging](#debugging)
+* [Known Caveats](#known-caveats)
+
+---
 
 Build Requirements
 ------------------
@@ -26,6 +40,8 @@ We recommend you install Rust via [Rustup](https://rustup.rs/). The generated bi
 ## Installation
 
 > $ cargo install
+
+---
 
 Usage
 -----
@@ -48,6 +64,8 @@ Running `sccache --show-stats` will print a summary of cache statistics.
 
 Some notes about using `sccache` with [Jenkins](https://jenkins.io) are [here](docs/Jenkins.md).
 
+---
+
 Storage Options
 ---------------
 
@@ -63,6 +81,8 @@ By default, SCCACHE on GCS will be read-only. To change this, set `SCCACHE_GCS_R
 
 *Important:* The environment variables are only taken into account when the server starts, so only on the first run.
 
+---
+
 Debugging
 ---------
 
@@ -72,6 +92,7 @@ Alternately, you can run the server manually in foreground mode by running `SCCA
 
 You can set the `SCCACHE_ERROR_LOG` environment variable to a path to cause the server process to redirect its standard error output there, in order to capture the output of unhandled panics. (The server sets `RUST_BACKTRACE=1` internally.)
 
+---
 
 Known caveats
 -------------
@@ -82,3 +103,7 @@ Known caveats
 * It doesn't support all kinds of compiler flags, and is certainly broken with a few of them. Really only the flags used during Firefox builds have been tested.
 * It doesn't support ccache's direct mode.
 * [It doesn't support an option like `CCACHE_BASEDIR`](https://github.com/mozilla/sccache/issues/35).
+
+---
+
+<img src="https://avatars2.githubusercontent.com/u/131524?s=200&v=4" width="50"></img>


### PR DESCRIPTION
## Docs - README.md - tweaks (thumbnaill, separators, ToC)

**this PR does basically aim at:**
- *adding thumbnail logo to README.md*
- *adding separators to README.md*
- *adding ToC to README.md*

---

**main motivaton behind such:**
- *improving overall document accessebility*

---

<img src="https://avatars2.githubusercontent.com/u/131524?s=200&v=4" width="50"></img> <img src="https://avatars1.githubusercontent.com/u/7303598?s=460&v=4" width="50"></img>