### PR TITLE
Make hashes path agnostic for GCC

### DIFF
--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -325,6 +325,7 @@ pub fn preprocess<T>(creator: &T,
     let mut cmd = creator.clone().new_command_sync(executable);
     cmd.arg("-x").arg(language)
         .arg("-E")
+        .arg("-P")
         .arg(&parsed_args.input)
         .args(&parsed_args.preprocessor_args)
         .args(&parsed_args.common_args)


### PR DESCRIPTION
We now pass -P to the preprocessor, which inhibits the generation
of linemarkers. This has two positive side effects:

  1. Absolute file paths and file names are excluded from the
     preprocessor output, which makes the hash independent of
     the location of the source and build directories.

  2. The preprocessing step is slightly faster (in one case it
     was 20% faster) and the preprocessor output is smaller (in
     the aforementioned case the output was 23% smaller) which
     should translate into faster hashing too.