### PR TITLE
Change size and capacity types to u64 to support 32-bit Windows

### DIFF
--- a/lru-disk-cache/src/lib.rs
+++ b/lru-disk-cache/src/lib.rs
@@ -128,7 +128,7 @@ impl LruDiskCache {
     ///
     /// The cache is not observant of changes to files under `path` from external sources, it
     /// expects to have sole maintence of the contents.
-    pub fn new<T>(path: T, size: usize) -> Result<Self>
+    pub fn new<T>(path: T, size: u64) -> Result<Self>
         where PathBuf: From<T>
     {
         LruDiskCache {
@@ -138,10 +138,10 @@ impl LruDiskCache {
     }
 
     /// Return the current size of all the files in the cache.
-    pub fn size(&self) -> usize { self.lru.size() }
+    pub fn size(&self) -> u64 { self.lru.size() }
 
     /// Return the maximum size of the cache.
-    pub fn capacity(&self) -> usize { self.lru.capacity() }
+    pub fn capacity(&self) -> u64 { self.lru.capacity() }
 
     /// Return the path in which the cache is stored.
     pub fn path(&self) -> &Path { self.root.as_path() }

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -54,7 +54,7 @@ const APP_INFO: AppInfo = AppInfo {
     author: "Mozilla",
 };
 
-const TEN_GIGS: usize = 10 * 1024 * 1024 * 1024;
+const TEN_GIGS: u64 = 10 * 1024 * 1024 * 1024;
 
 /// Result of a cache lookup.
 pub enum Cache {
@@ -170,18 +170,18 @@ pub trait Storage {
     fn location(&self) -> String;
 
     /// Get the current storage usage, if applicable.
-    fn current_size(&self) -> Option<usize>;
+    fn current_size(&self) -> Option<u64>;
 
     /// Get the maximum storage size, if applicable.
-    fn max_size(&self) -> Option<usize>;
+    fn max_size(&self) -> Option<u64>;
 }
 
-fn parse_size(val: &str) -> Option<usize> {
+fn parse_size(val: &str) -> Option<u64> {
     let re = Regex::new(r"^(\d+)([KMGT])$").unwrap();
     re.captures(val)
         .and_then(|caps| {
             caps.get(1)
-                .and_then(|size| usize::from_str(size.as_str()).ok())
+                .and_then(|size| u64::from_str(size.as_str()).ok())
                 .and_then(|size| Some((size, caps.get(2))))
         })
         .and_then(|(size, suffix)| {
@@ -300,7 +300,7 @@ pub fn storage_from_environment(pool: &CpuPool, _handle: &Handle) -> Arc<Storage
         // Fall back to something, even if it's not very good.
         .unwrap_or(env::temp_dir().join("sccache_cache"));
     trace!("Using DiskCache({:?})", d);
-    let cache_size = env::var("SCCACHE_CACHE_SIZE")
+    let cache_size: u64 = env::var("SCCACHE_CACHE_SIZE")
         .ok()
         .and_then(|v| parse_size(&v))
         .unwrap_or(TEN_GIGS);

--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -40,7 +40,7 @@ pub struct DiskCache {
 impl DiskCache {
     /// Create a new `DiskCache` rooted at `root`, with `max_size` as the maximum cache size on-disk, in bytes.
     pub fn new<T: AsRef<OsStr>>(root: &T,
-                                max_size: usize,
+                                max_size: u64,
                                 pool: &CpuPool) -> DiskCache {
         DiskCache {
             //TODO: change this function to return a Result
@@ -98,6 +98,6 @@ impl Storage for DiskCache {
         format!("Local disk: {:?}", self.lru.lock().unwrap().path())
     }
 
-    fn current_size(&self) -> Option<usize> { Some(self.lru.lock().unwrap().size()) }
-    fn max_size(&self) -> Option<usize> { Some(self.lru.lock().unwrap().capacity()) }
+    fn current_size(&self) -> Option<u64> { Some(self.lru.lock().unwrap().size()) }
+    fn max_size(&self) -> Option<u64> { Some(self.lru.lock().unwrap().capacity()) }
 }

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -102,7 +102,7 @@ impl Storage for RedisCache {
 
     /// Returns the current cache size. This value is aquired via
     /// the Redis INFO command (used_memory).
-    fn current_size(&self) -> Option<usize> {
+    fn current_size(&self) -> Option<u64> {
         self.connect().ok()
             .and_then(|c| cmd("INFO").query(&c).ok())
             .and_then(|i: InfoDict| i.get("used_memory"))
@@ -111,13 +111,13 @@ impl Storage for RedisCache {
     /// Returns the maximum cache size. This value is read via
     /// the Redis CONFIG command (maxmemory). If the server has no
     /// configured limit, the result is None.
-    fn max_size(&self) -> Option<usize> {
+    fn max_size(&self) -> Option<u64> {
         self.connect().ok()
             .and_then(|c| cmd("CONFIG").arg("GET").arg("maxmemory").query(&c).ok())
             .and_then(|h: HashMap<String, usize>| h.get("maxmemory").map(|s| *s))
             .and_then(|s| {
                 if s != 0 {
-                    Some(s)
+                    Some(s as u64)
                 } else {
                     None
                 }

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -110,6 +110,6 @@ impl Storage for S3Cache {
         format!("S3, bucket: {}", self.bucket)
     }
 
-    fn current_size(&self) -> Option<usize> { None }
-    fn max_size(&self) -> Option<usize> { None }
+    fn current_size(&self) -> Option<u64> { None }
+    fn max_size(&self) -> Option<u64> { None }
 }

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -602,7 +602,7 @@ mod test {
     use std::io::Write;
     use std::sync::Arc;
     use std::time::Duration;
-    use std::usize;
+    use std::u64;
     use test::mock_storage::MockStorage;
     use test::utils::*;
     use tokio_core::reactor::Core;
@@ -707,7 +707,7 @@ mod test {
         let core = Core::new().unwrap();
         let handle = core.handle();
         let storage = DiskCache::new(&f.tempdir.path().join("cache"),
-                                     usize::MAX,
+                                     u64::MAX,
                                      &pool);
         let storage: Arc<Storage> = Arc::new(storage);
         // Pretend to be GCC.
@@ -788,7 +788,7 @@ mod test {
         let core = Core::new().unwrap();
         let handle = core.handle();
         let storage = DiskCache::new(&f.tempdir.path().join("cache"),
-                                     usize::MAX,
+                                     u64::MAX,
                                      &pool);
         let storage: Arc<Storage> = Arc::new(storage);
         // Pretend to be GCC.
@@ -934,7 +934,7 @@ mod test {
         let core = Core::new().unwrap();
         let handle = core.handle();
         let storage = DiskCache::new(&f.tempdir.path().join("cache"),
-                                     usize::MAX,
+                                     u64::MAX,
                                      &pool);
         let storage: Arc<Storage> = Arc::new(storage);
         // Pretend to be GCC.
@@ -1022,7 +1022,7 @@ mod test {
         let core = Core::new().unwrap();
         let handle = core.handle();
         let storage = DiskCache::new(&f.tempdir.path().join("cache"),
-                                     usize::MAX,
+                                     u64::MAX,
                                      &pool);
         let storage: Arc<Storage> = Arc::new(storage);
         // Pretend to be GCC.

--- a/src/server.rs
+++ b/src/server.rs
@@ -698,8 +698,8 @@ pub struct ServerStats {
 pub struct ServerInfo {
     pub stats: ServerStats,
     pub cache_location: String,
-    pub cache_size: Option<usize>,
-    pub max_cache_size: Option<usize>,
+    pub cache_size: Option<u64>,
+    pub max_cache_size: Option<u64>,
 }
 
 impl Default for ServerStats {

--- a/src/test/mock_storage.rs
+++ b/src/test/mock_storage.rs
@@ -46,6 +46,6 @@ impl Storage for MockStorage {
         f_ok(Duration::from_secs(0))
     }
     fn location(&self) -> String { "Mock Storage".to_string() }
-    fn current_size(&self) -> Option<usize> { None }
-    fn max_size(&self) -> Option<usize> { None }
+    fn current_size(&self) -> Option<u64> { None }
+    fn max_size(&self) -> Option<u64> { None }
 }

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -40,7 +40,7 @@ use std::process::Command;
 use std::sync::{Arc,Mutex,mpsc};
 use std::thread;
 use std::time::Duration;
-use std::usize;
+use std::u64;
 use test::utils::*;
 use tokio_core::reactor::Core;
 
@@ -50,7 +50,7 @@ struct ServerOptions {
     /// The server's idle shutdown timeout.
     idle_timeout: Option<u64>,
     /// The maximum size of the disk cache.
-    cache_size: Option<usize>,
+    cache_size: Option<u64>,
 }
 
 /// Run a server on a background thread, and return a tuple of useful things.
@@ -71,7 +71,7 @@ fn run_server_thread<T>(cache_dir: &Path, options: T)
     let cache_size = options.as_ref()
                             .and_then(|o| o.cache_size.as_ref())
                             .map(|s| *s)
-                            .unwrap_or(usize::MAX);
+                            .unwrap_or(u64::MAX);
     let pool = CpuPool::new(1);
     let storage = Arc::new(DiskCache::new(&cache_dir, cache_size, &pool));
 


### PR DESCRIPTION
Currently compiling for 32-bit Windows (`--target=i686-pc-windows-msvc`) errors on the following line:

```
error[E0080]: constant evaluation error
  --> src\cache\cache.rs:57:25
   |
57 | const TEN_GIGS: usize = 10 * 1024 * 1024 * 1024;
   |                         ^^^^^^^^^^^^^^^^^^^^^^^ attempt to multiply with overflow

error: aborting due to previous error

error: Could not compile `sccache`.
```

These changes convert size and capacity to u64 instead of usize to support 32-bit targets.