### PR TITLE
Always request color output from rustc. Fixes #99

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,6 +965,7 @@ version = "0.2.6-alpha.0"
 dependencies = [
  "app_dirs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cli 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1002,6 +1003,7 @@ dependencies = [
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strip-ansi-escapes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1177,6 +1179,14 @@ dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "vte 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1462,6 +1472,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "utf8parse"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "uuid"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,6 +1503,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vte"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "utf8parse 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "walkdir"
@@ -1697,6 +1720,7 @@ dependencies = [
 "checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
 "checksum socket2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a76b792959eba82f021c9028c8ecb6396f085268d6d46af2ed96a829cc758d7c"
+"checksum strip-ansi-escapes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d63676e2abafa709460982ddc02a3bb586b6d15a49b75c212e06edd3933acee"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
@@ -1727,11 +1751,13 @@ dependencies = [
 "checksum untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f392d7819dbe58833e26872f5f6f0d68b7bbbe90fc3667e98731c4a15ad9a7ae"
 "checksum url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa35e768d4daf1d85733418a49fb42e10d7f633e394fccab4ab7aba897053fe2"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum utf8parse 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a15ea87f3194a3a454c78d79082b4f5e85f6956ddb6cb86bbfbe4892aa3c0323"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum vte 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a01634c75db59478405de08d8567c40c578bba80c565217ee709934b551720d8"
 "checksum walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"
 "checksum which 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4be6cfa54dab45266e98b5d7be2f8ce959ddd49abd141a05d52dce4b07f803bb"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ rust-crypto = { version = "0.2.36", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+strip-ansi-escapes = "0.1"
 tempdir = "0.3.4"
 tempfile = "2.1.5"
 time = "0.1.35"
@@ -61,6 +62,7 @@ url = { version = "1.0", optional = true }
 which = "1.0"
 zip = { version = "=0.2.3", default-features = false }
 lazy_static = "1.0.0"
+atty = "0.2.6"
 
 [dev-dependencies]
 assert_cli = "0.5"

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use compiler::{Cacheable, Compiler, CompilerArguments, CompilerHasher, CompilerKind, Compilation, HashResult};
+use compiler::{Cacheable, ColorMode, Compiler, CompilerArguments, CompilerHasher, CompilerKind,
+               Compilation, HashResult};
 use futures::Future;
 use futures_cpupool::CpuPool;
 use mock_command::CommandCreatorSync;
@@ -251,6 +252,11 @@ impl<T, I> CompilerHasher<T> for CCompilerHasher<I>
                 }),
             })
         }))
+    }
+
+    fn color_mode(&self) -> ColorMode {
+        //TODO: actually implement this for C compilers
+        ColorMode::Auto
     }
 
     fn output_pretty(&self) -> Cow<str>

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -94,6 +94,10 @@ pub trait CompilerHasher<T>: fmt::Debug + Send + 'static
                          env_vars: &[(OsString, OsString)],
                          pool: &CpuPool)
                          -> SFuture<HashResult<T>>;
+
+    /// Return the state of any `--color` option passed to the compiler.
+    fn color_mode(&self) -> ColorMode;
+
     /// Look up a cached compile result in `storage`. If not found, run the
     /// compile and store the result.
     fn get_cached_or_compile(self: Box<Self>,
@@ -358,6 +362,18 @@ pub enum CompileResult {
     NotCacheable,
     /// Not in cache, but compilation failed.
     CompileFailed,
+}
+
+/// The state of `--color` options passed to a compiler.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ColorMode {
+    Off,
+    On,
+    Auto,
+}
+
+impl Default for ColorMode {
+    fn default() -> ColorMode { ColorMode::Auto }
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@
 #![recursion_limit="128"]
 
 extern crate app_dirs;
+extern crate atty;
 extern crate base64;
 extern crate bincode;
 extern crate byteorder;
@@ -67,6 +68,7 @@ extern crate retry;
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
+extern crate strip_ansi_escapes;
 extern crate tempdir;
 extern crate tempfile;
 extern crate time;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,3 +1,4 @@
+use compiler::ColorMode;
 use std::ffi::OsString;
 use server::ServerInfo;
 
@@ -47,6 +48,8 @@ pub struct CompileFinished {
     pub stdout: Vec<u8>,
     /// The compiler's stderr.
     pub stderr: Vec<u8>,
+    /// The state of any compiler options passed to control color output.
+    pub color_mode: ColorMode,
 }
 
 /// The contents of a compile request from a client.

--- a/src/server.rs
+++ b/src/server.rs
@@ -549,6 +549,7 @@ impl<C> SccacheService<C>
             CacheControl::Default
         };
         let out_pretty = hasher.output_pretty().into_owned();
+        let color_mode = hasher.color_mode();
         let result = hasher.get_cached_or_compile(self.creator.clone(),
                                                   self.storage.clone(),
                                                   arguments,
@@ -562,6 +563,7 @@ impl<C> SccacheService<C>
             let mut cache_write = None;
             let mut stats = me.stats.borrow_mut();
             let mut res = CompileFinished::default();
+            res.color_mode = color_mode;
             match result {
                 Ok((compiled, out)) => {
                     match compiled {

--- a/tests/sccache_cargo.rs
+++ b/tests/sccache_cargo.rs
@@ -88,7 +88,8 @@ fn test_rust_cargo() {
     a.unwrap();
     // Now build the crate with cargo.
     let a = Assert::command(&[&cargo])
-        .with_args(&["build"]).with_env(&env).current_dir(&crate_dir).succeeds();
+        .with_args(&["build", "--color=never"]).with_env(&env).current_dir(&crate_dir)
+        .stderr().doesnt_contain("\x1b[").succeeds();
     trace!("cargo build: {:?}", a);
     a.unwrap();
     // Clean it so we can build it again.
@@ -97,7 +98,8 @@ fn test_rust_cargo() {
     trace!("cargo clean: {:?}", a);
     a.unwrap();
     let a = Assert::command(&[&cargo])
-        .with_args(&["build"]).with_env(&env).current_dir(&crate_dir).succeeds();
+        .with_args(&["build", "--color=always"]).with_env(&env).current_dir(&crate_dir)
+        .stderr().contains("\x1b[").succeeds();
     trace!("cargo build: {:?}", a);
     a.unwrap();
     // Now get the stats and ensure that we had a cache hit for the second build.

--- a/tests/test-crate/src/lib.rs
+++ b/tests/test-crate/src/lib.rs
@@ -1,3 +1,5 @@
+fn unused() {}
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
This change makes sccache run rustc with `--color=always`, removing any other
--color option from the compiler options so that it's not included in the
cache key.

A `color_mode` method is added to the `CompilerHasher` trait, and the value
is sent back to the client in the `CompileFinished` method, so the client can
determine whether specific --color options were passed without having to
do its own commandline parsing.

The client uses the new `strip-ansi-escapes` crate to remove escape codes
from the compiler output in situations where color output is not desired:
* When `--color=never` was passed on the compiler commandline.
* When `--color=auto` is in effect (the default) but the output is not
  a terminal.

The existing cargo tests were lightly modified to run compile once with
`--color=never` and once with `--color=always` to validate that cache hits
are not affected by color options.