### PR TITLE
Two-tier caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ To use Azure Blob Storage, you'll need your Azure connection string and an _exis
 environment variable to your connection string, and `SCCACHE_AZURE_BLOB_CONTAINER` to the name of the container to use.  Note that sccache will not create
 the container for you - you'll need to do that yourself.
 
+Set `SCCACHE_TWO_TIER` if you want to use a two tier storage system, where cache can be read from any of the remote options
+above but is only ever written to a local disk.  Remote cache items that are read will also be written locally.  This can
+be used to give CI machines read / write to your cache and developers read access to the cache they generate.
+
 *Important:* The environment variables are only taken into account when the server starts, so only on the first run.
 
 ---

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ Set `SCCACHE_TWO_TIER` if you want to use a two tier storage system, where cache
 above but is only ever written to a local disk.  Remote cache items that are read will also be written locally.  This can
 be used to give CI machines read / write to your cache and developers read access to the cache they generate.
 
+Sometimes path are used in the hashing of built artifacts, in order to avoid getting cache misses across different machines you could set
+`SCCACHE_STRIP_DIRS` to a `":"` separated list of directories to ignore from the hashing.  E.g. `SCCACHE_STRIP_DIRS=/projects/thing:/projects/dep`
+
 *Important:* The environment variables are only taken into account when the server starts, so only on the first run.
 
 ---

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -108,6 +108,18 @@ impl CacheRead {
         io::copy(&mut file, to)?;
         Ok(file.unix_mode())
     }
+
+    pub fn to_write(&mut self) -> CacheWrite {
+        let mut write = CacheWrite::new();
+        for i in 0..self.zip.len() {
+            // Mutable borrows mean we have to unwrap twice
+            let mut file = self.zip.by_index(i).unwrap();
+            let file_name = String::from(file.name());
+            let mode = file.unix_mode();
+            write.put_object(&file_name, &mut file, mode);
+        }
+        write
+    }
 }
 
 /// Data to be stored in the compiler cache.

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -16,14 +16,13 @@
 pub mod azure;
 pub mod cache;
 pub mod disk;
+pub mod two_tier_disk;
 #[cfg(feature = "memcached")]
 pub mod memcached;
 #[cfg(feature = "redis")]
 pub mod redis;
 #[cfg(feature = "s3")]
 pub mod s3;
-#[cfg(feature = "s3")]
-pub mod s3disk;
 #[cfg(feature = "gcs")]
 pub mod gcs;
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -22,6 +22,8 @@ pub mod memcached;
 pub mod redis;
 #[cfg(feature = "s3")]
 pub mod s3;
+#[cfg(feature = "s3")]
+pub mod s3disk;
 #[cfg(feature = "gcs")]
 pub mod gcs;
 

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -65,7 +65,11 @@ impl S3Cache {
 }
 
 fn normalize_key(key: &str) -> String {
-    format!("{}/{}/{}/{}", &key[0..1], &key[1..2], &key[2..3], &key)
+    let normalized = format!("{}/{}/{}/{}", &key[0..1], &key[1..2], &key[2..3], &key);
+    if let Ok(s3_prefix) = env::var("SCCACHE_BUCKET_PREFIX") {
+        return format!("{}/{}", s3_prefix, normalized);
+    }
+    normalized
 }
 
 impl Storage for S3Cache {

--- a/src/cache/s3disk.rs
+++ b/src/cache/s3disk.rs
@@ -1,0 +1,78 @@
+// Copyright 2016 Mozilla Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cache::{
+    Cache,
+    CacheWrite,
+    Storage,
+};
+use cache::disk::DiskCache;
+use cache::s3::S3Cache;
+use futures;
+use futures::future::Future;
+use std::time::{Duration};
+
+use errors::*;
+
+/// A cache that stores entries on disk but can fetch from Amazon S3 or disk.
+pub struct S3DiskCache {
+    /// S3 Cache
+    s3: S3Cache,
+    /// Disk cache
+    disk: DiskCache
+}
+
+impl S3DiskCache {
+    /// Create a new `S3Cache` storing data in `bucket`.
+    pub fn new(s3_cache: S3Cache, disk_cache: DiskCache) -> S3DiskCache {
+        S3DiskCache {
+            s3: s3_cache,
+            disk: disk_cache,
+        }
+    }
+}
+
+impl Storage for S3DiskCache {
+    fn get(&self, key: &str) -> SFuture<Cache> {
+        let disk_lookup = Box::new(self.disk.get(&key).then(|disk_result| {
+            match disk_result {
+                Ok(data) => {
+                    match data {
+                        Cache::Hit(_) => Ok(data),
+                        _ => Ok(Cache::Miss),
+                    }
+                }
+                Err(e) => {
+                    warn!("Got s3disk error: {:?}", e);
+                     Ok(Cache::Miss)
+                }
+            }
+        })).wait();
+        match disk_lookup {
+            Ok(Cache::Hit(_)) => Box::new(futures::done(disk_lookup)),
+            _ => Box::new(self.s3.get(&key))
+        }
+    }
+
+    fn put(&self, key: &str, entry: CacheWrite) -> SFuture<Duration> {
+        self.disk.put(key, entry)
+    }
+
+    fn location(&self) -> String {
+        format!("Local: {} - S3, bucket: {}", self.disk.location(), self.s3.location())
+    }
+
+    fn current_size(&self) -> Option<u64> { self.disk.current_size() }
+    fn max_size(&self) -> Option<u64> { self.disk.max_size() }
+}

--- a/src/cache/two_tier_disk.rs
+++ b/src/cache/two_tier_disk.rs
@@ -16,7 +16,6 @@ use cache::{
     Cache,
     CacheWrite,
     Storage,
-    CacheRead,
 };
 use cache::disk::DiskCache;
 use futures;
@@ -73,9 +72,7 @@ impl TwoTierDiskCache {
                                 Ok(Cache::Hit(mut entry)) => {
                                     {
                                         trace!("cache hit but need to push back into primary cache");
-                                        // We really don't care if this succeeds or not
-                                        // we just need to try it
-                                        disk.put(&key, entry.to_write());
+                                        disk.put(&key, entry.to_write()).wait();
                                         Ok(Cache::Hit(entry))
                                     }
                                 }

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -328,7 +328,6 @@ pub fn hash_key(compiler_digest: &str,
 
     if let Ok(strip_dirs) = env::var("SCCACHE_STRIP_DIRS") {
         trace!("Attempting to strip dirs from preprocessor output");
-        m.update(strip_dirs.as_bytes());
         let output_result = str::from_utf8(preprocessor_output);
 
         if output_result.is_ok() {


### PR DESCRIPTION
Fixes #30 `SCCACHE_TWO_TIER`
Fixes #1 `SCCACHE_BUCKET_PREFIX`
Fixes #35 (maybe) `SCCACHE_STRIP_DIRS`

Please note ~this is a work in progress~ (and being real I haven't really touched rust before 😆 ).  Started work on this before I saw #30 so I'm going to genericize the `S3Disk` storage implementation to allow any storage implementation backed by disk 👍 

* [x] Arbitrary remote cache
* [x] Store remote cache hits in local disk cache

_please hold while I learn rust_

This adds support for three new environment variables that will make `sccache` usable by local developers (at least in the example of Electron).

* `SCCACHE_TWO_TIER` tells sccache to use disk as primary and the configured remote storage source as a secondary.  Reads will be done as `primary -> secondary -> fail` and writes will only be done `primary -> fail`.
* `SCCACHE_BUCKET_PREFIX` tells sccache's S3 storage method to prefix all keys with the given value.  Useful for reusing an existing bucket
* `SCCACHE_STRIP_DIRS` tells scacche's hashing mechanism to strip all references to any of the directories in that value from the input to the hasher.  Looks like `SCCACHE_STRIP_DIRS=/path/to/project1:/path/to/project2`