### PR TITLE
Fix compatibility with `clang-cl.exe`

### DIFF
--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -142,16 +142,19 @@ pub fn detect_showincludes_prefix<T>(creator: &T,
         let stdout = from_local_codepage(&stdout_bytes)
             .chain_err(|| "Failed to convert compiler stdout while detecting showIncludes prefix")?;
         for line in stdout.lines() {
-            if line.ends_with("test.h") {
-                for (i, c) in line.char_indices().rev() {
-                    if c == ' ' {
-                        // See if the rest of this line is a full pathname.
-                        if Path::new(&line[i+1..]).exists() {
-                            // Everything from the beginning of the line
-                            // to this index is the prefix.
-                            return Ok(line[..i+1].to_owned());
-                        }
-                    }
+            if !line.ends_with("test.h") {
+                continue
+            }
+            for (i, c) in line.char_indices().rev() {
+                if c != ' ' {
+                    continue
+                }
+                let path = tempdir.path().join(&line[i + 1..]);
+                // See if the rest of this line is a full pathname.
+                if path.exists() {
+                    // Everything from the beginning of the line
+                    // to this index is the prefix.
+                    return Ok(line[..i+1].to_owned());
                 }
             }
         }


### PR DESCRIPTION
I've been giving clang-cl a spin lately to test a few things and I've noticed
that it's not currently cached by sccache. Looks like it's a pretty minor fix
though thankfully!

It looks like MSVC may print out absolute paths to included header files but
clang-cl prints out relative ones, so when testing the compiler look up the
relative paths rather than the absolute ones.