### PR TITLE
Allow configuration of caches with a config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_script:
 
 script:
   - cargo build --verbose --features="all ${EXTRA_FEATURES}"
+  - RUST_BACKTRACE=1 cargo test --all --verbose --no-default-features --features="${EXTRA_FEATURES}"
   - RUST_BACKTRACE=1 cargo test --all --verbose --features="all ${EXTRA_FEATURES}"
 
 before_deploy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,6 +1004,7 @@ dependencies = [
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1384,6 +1385,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicase"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,6 +1723,7 @@ dependencies = [
 "checksum tokio-signal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "57c4031b97651d28c87a0a071e1c2809d70609d3120ce285b302eb7d52c96906"
 "checksum tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "772f4b04e560117fe3b0a53e490c16ddc8ba6ec437015d91fa385564996ed913"
 "checksum tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "65ae5d255ce739e8537221ed2942e0445f4b3b813daebac1c0050ddaaa3587f9"
+"checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
 "checksum unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284b6d3db520d67fbe88fd778c21510d1b0ba4a551e5d0fbb023d33405f6de8a"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ tokio-proto = "0.1"
 tokio-serde-bincode = "0.1"
 tokio-service = "0.1"
 tokio-tls = "0.1"
+toml = "0.4"
 uuid = { version = "0.6", features = ["v4"] }
 url = { version = "1.0", optional = true }
 which = "1.0"
@@ -67,6 +68,7 @@ directories = "0.8.4"
 [dev-dependencies]
 assert_cli = "0.5"
 cc = "1.0"
+chrono = "0.3"
 itertools = "0.7"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -179,10 +179,6 @@ pub fn storage_from_config(pool: &CpuPool, _handle: &Handle) -> Arc<Storage> {
                     Err(e) => warn!("Failed to create Azure cache: {:?}", e),
                 }
             },
-            CacheType::Disk(config::DiskCacheConfig { ref dir, size }) => {
-                trace!("Using DiskCache({:?}, {})", dir, size);
-                return Arc::new(DiskCache::new(dir, size, pool))
-            },
             CacheType::GCS(config::GCSCacheConfig { ref bucket, ref cred_path, rw_mode }) => {
                 debug!("Trying GCS bucket({}, {:?}, {:?})", bucket, cred_path, rw_mode);
                 #[cfg(feature = "gcs")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,350 @@
+// Copyright 2016 Mozilla Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use directories::ProjectDirs;
+use regex::Regex;
+use std::env;
+use std::io::Read;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use toml;
+
+lazy_static! {
+    pub static ref CONFIG: Config = { Config::create() };
+}
+
+const ORGANIZATION: &str = "Mozilla";
+const APP_NAME: &str = "sccache";
+const TEN_GIGS: u64 = 10 * 1024 * 1024 * 1024;
+
+pub fn default_disk_cache_dir() -> PathBuf {
+    ProjectDirs::from("", ORGANIZATION, APP_NAME)
+        .cache_dir().to_owned()
+}
+
+fn parse_size(val: &str) -> Option<u64> {
+    let re = Regex::new(r"^(\d+)([KMGT])$").unwrap();
+    re.captures(val)
+        .and_then(|caps| {
+            caps.get(1)
+                .and_then(|size| u64::from_str(size.as_str()).ok())
+                .and_then(|size| Some((size, caps.get(2))))
+        })
+        .and_then(|(size, suffix)| {
+            match suffix.map(|s| s.as_str()) {
+                Some("K") => Some(1024 * size),
+                Some("M") => Some(1024 * 1024 * size),
+                Some("G") => Some(1024 * 1024 * 1024 * size),
+                Some("T") => Some(1024 * 1024 * 1024 * 1024 * size),
+                _ => None,
+            }
+        })
+}
+
+#[derive(Debug, PartialEq)]
+#[derive(Deserialize)]
+pub struct AzureCacheConfig;
+
+#[derive(Debug, PartialEq)]
+#[derive(Deserialize)]
+pub struct DiskCacheConfig {
+    pub dir: PathBuf,
+    // TODO: use deserialize_with to allow human-readable sizes in toml
+    pub size: u64,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Deserialize)]
+pub enum GCSCacheRWMode {
+    #[serde(rename = "READ_ONLY")]
+    ReadOnly,
+    #[serde(rename = "READ_WRITE")]
+    ReadWrite,
+}
+
+#[derive(Debug, PartialEq)]
+#[derive(Deserialize)]
+pub struct GCSCacheConfig {
+    pub bucket: String,
+    pub cred_path: Option<PathBuf>,
+    pub rw_mode: GCSCacheRWMode,
+}
+
+#[derive(Debug, PartialEq)]
+#[derive(Deserialize)]
+pub struct MemcachedCacheConfig {
+    pub url: String,
+}
+
+#[derive(Debug, PartialEq)]
+#[derive(Deserialize)]
+pub struct RedisCacheConfig {
+    pub url: String,
+}
+
+#[derive(Debug, PartialEq)]
+#[derive(Deserialize)]
+pub struct S3CacheConfig {
+    pub bucket: String,
+    pub endpoint: String,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum CacheType {
+    Azure(AzureCacheConfig),
+    Disk(DiskCacheConfig),
+    GCS(GCSCacheConfig),
+    Memcached(MemcachedCacheConfig),
+    Redis(RedisCacheConfig),
+    S3(S3CacheConfig),
+}
+
+#[derive(Debug, Default)]
+#[derive(Deserialize)]
+pub struct CacheConfigs {
+    azure: Option<AzureCacheConfig>,
+    disk: Option<DiskCacheConfig>,
+    gcs: Option<GCSCacheConfig>,
+    memcached: Option<MemcachedCacheConfig>,
+    redis: Option<RedisCacheConfig>,
+    s3: Option<S3CacheConfig>,
+}
+
+impl CacheConfigs {
+    /// Return a vec of the available cache types in a specific
+    /// consistent ordering
+    fn into_vec(self) -> Vec<CacheType> {
+        let CacheConfigs {
+            azure, disk, gcs, memcached, redis, s3
+        } = self;
+
+        s3.map(CacheType::S3).into_iter()
+            .chain(redis.map(CacheType::Redis))
+            .chain(memcached.map(CacheType::Memcached))
+            .chain(gcs.map(CacheType::GCS))
+            .chain(azure.map(CacheType::Azure))
+            .chain(disk.map(CacheType::Disk))
+            .collect()
+    }
+}
+
+#[derive(Debug, Default)]
+#[derive(Deserialize)]
+pub struct FileConfig {
+    cache: CacheConfigs,
+}
+
+fn try_read_config_file(path: &Path) -> Option<FileConfig> {
+    let mut file = File::open(path)
+        .map_err(|e| debug!("Couldn't open config file: {}", e))
+        .ok()?;
+
+    let mut string = String::new();
+    file.read_to_string(&mut string)
+        .map_err(|e| warn!("Failed to read config file: {}", e))
+        .ok()?;
+
+    let toml: toml::Value = toml::from_str(&string)
+        .map_err(|e| warn!("Failed to parse config as toml: {}", e))
+        .ok()?;
+
+    toml.try_into()
+        .map_err(|e| {
+            warn!("Invalid format of config: {}", e);
+        })
+        .ok()
+}
+
+#[derive(Debug)]
+pub struct EnvConfig {
+    cache: CacheConfigs,
+}
+
+fn config_from_env() -> EnvConfig {
+    let s3 = env::var("SCCACHE_BUCKET").ok()
+        .map(|bucket| {
+            let endpoint = match env::var("SCCACHE_ENDPOINT") {
+                Ok(endpoint) => format!("{}/{}", endpoint, bucket),
+                _ => match env::var("SCCACHE_REGION") {
+                    Ok(ref region) if region != "us-east-1" =>
+                        format!("{}.s3-{}.amazonaws.com", bucket, region),
+                    _ => format!("{}.s3.amazonaws.com", bucket),
+                },
+            };
+            S3CacheConfig { bucket, endpoint }
+        });
+
+    let redis = env::var("SCCACHE_REDIS").ok()
+        .map(|url| RedisCacheConfig { url });
+
+    let memcached = env::var("SCCACHE_MEMCACHED").ok()
+        .map(|url| MemcachedCacheConfig { url });
+
+    let gcs = env::var("SCCACHE_GCS_BUCKET").ok()
+        .map(|bucket| {
+            let cred_path = env::var_os("SCCACHE_GCS_KEY_PATH")
+                .map(|p| PathBuf::from(p));
+            let rw_mode = match env::var("SCCACHE_GCS_RW_MODE")
+                                      .as_ref().map(String::as_str) {
+                Ok("READ_ONLY") => GCSCacheRWMode::ReadOnly,
+                Ok("READ_WRITE") => GCSCacheRWMode::ReadWrite,
+                // TODO: unsure if these should warn during the configuration loading
+                // or at the time when they're actually used to connect to GCS
+                Ok(_) => {
+                    warn!("Invalid SCCACHE_GCS_RW_MODE-- defaulting to READ_ONLY.");
+                    GCSCacheRWMode::ReadOnly
+                },
+                _ => {
+                    warn!("No SCCACHE_GCS_RW_MODE specified-- defaulting to READ_ONLY.");
+                    GCSCacheRWMode::ReadOnly
+                }
+            };
+            GCSCacheConfig { bucket, cred_path, rw_mode }
+        });
+
+
+    let azure = env::var("SCCACHE_AZURE_CONNECTION_STRING").ok()
+        .map(|_| AzureCacheConfig);
+
+    let disk = env::var_os("SCCACHE_DIR")
+        .map(|p| PathBuf::from(p))
+        .map(|dir| {
+            let size: u64 = env::var("SCCACHE_CACHE_SIZE")
+                .ok()
+                .and_then(|v| parse_size(&v))
+                .unwrap_or(TEN_GIGS);
+            DiskCacheConfig { dir, size }
+        });
+
+    let cache = CacheConfigs {
+        azure,
+        disk,
+        gcs,
+        memcached,
+        redis,
+        s3,
+    };
+
+    EnvConfig { cache }
+}
+
+#[derive(Debug)]
+pub struct Config {
+    pub caches: Vec<CacheType>,
+    pub fallback_cache: DiskCacheConfig,
+}
+
+impl Config {
+    pub fn create() -> Config {
+        let file_conf_path = env::var_os("SCCACHE_CONF")
+            .map(|p| PathBuf::from(p))
+            .unwrap_or_else(|| {
+                let dirs = ProjectDirs::from("", ORGANIZATION, APP_NAME);
+                dirs.config_dir().join("config")
+            });
+
+        let env_conf = config_from_env();
+
+        let file_conf = try_read_config_file(&file_conf_path)
+            .unwrap_or_default();
+
+        Config::from_env_and_file_configs(env_conf, file_conf)
+    }
+
+    fn from_env_and_file_configs(env_conf: EnvConfig, file_conf: FileConfig) -> Config {
+        let fallback_cache = DiskCacheConfig {
+            dir: default_disk_cache_dir(),
+            size: TEN_GIGS,
+        };
+
+        let mut conf = Config {
+            caches: vec![],
+            fallback_cache,
+        };
+
+        let EnvConfig { cache } = env_conf;
+        conf.caches.extend(cache.into_vec());
+
+        let FileConfig { cache } = file_conf;
+        conf.caches.extend(cache.into_vec());
+
+        // Push any DiskConfigs down to the bottom, preserving relative ordering
+        // (i.e. env disk config is still before file disk config)
+        conf.caches.sort_by(|c1, c2| {
+            use std::cmp::Ordering::*;
+            match (c1, c2) {
+                (&CacheType::Disk(_), &CacheType::Disk(_)) => Equal,
+                (&CacheType::Disk(_), _                  ) => Greater,
+                (_                  , &CacheType::Disk(_)) => Less,
+                (_                  , _                  ) => Equal,
+            }
+        });
+
+        conf
+    }
+}
+
+#[test]
+fn test_parse_size() {
+    assert_eq!(None, parse_size(""));
+    assert_eq!(None, parse_size("100"));
+    assert_eq!(Some(2048), parse_size("2K"));
+    assert_eq!(Some(10 * 1024 * 1024), parse_size("10M"));
+    assert_eq!(Some(TEN_GIGS), parse_size("10G"));
+    assert_eq!(Some(1024 * TEN_GIGS), parse_size("10T"));
+}
+
+#[test]
+fn disk_config_ordering() {
+    let env_conf = EnvConfig {
+        cache: CacheConfigs {
+            azure: Some(AzureCacheConfig),
+            disk: Some(DiskCacheConfig {
+                dir: "/env-cache".into(),
+                size: 5,
+            }),
+            ..Default::default()
+        },
+    };
+
+    let file_conf = FileConfig {
+        cache: CacheConfigs {
+            redis: Some(RedisCacheConfig {
+                url: "myredisurl".to_owned(),
+            }),
+            disk: Some(DiskCacheConfig {
+                dir: "/file-cache".into(),
+                size: 15,
+            }),
+            ..Default::default()
+        },
+    };
+
+    assert_eq!(
+        Config::from_env_and_file_configs(env_conf, file_conf).caches,
+        vec![
+            CacheType::Azure(AzureCacheConfig),
+            CacheType::Redis(RedisCacheConfig { url: "myredisurl".to_owned() }),
+            CacheType::Disk(DiskCacheConfig {
+                dir: "/env-cache".into(),
+                size: 5,
+            }),
+            CacheType::Disk(DiskCacheConfig {
+                dir: "/file-cache".into(),
+                size: 15,
+            }),
+        ]
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ extern crate tokio_process;
 extern crate tokio_proto;
 extern crate tokio_service;
 extern crate tokio_serde_bincode;
+extern crate toml;
 #[cfg(feature = "gcs")]
 extern crate url;
 extern crate uuid;
@@ -101,6 +102,7 @@ mod client;
 mod cmdline;
 mod commands;
 mod compiler;
+mod config;
 mod jobserver;
 mod mock_command;
 mod protocol;
@@ -114,6 +116,8 @@ use std::io::Write;
 
 pub fn main() {
     init_logging();
+    // Initialise config
+    let _ = config::CONFIG.caches.len();
     std::process::exit(match cmdline::parse() {
         Ok(cmd) => {
             match commands::run_command(cmd) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,7 +14,7 @@
 
 use cache::{
     Storage,
-    storage_from_environment,
+    storage_from_config,
 };
 use compiler::{
     CacheControl,
@@ -125,7 +125,7 @@ pub fn start_server(port: u16) -> Result<()> {
     let client = unsafe { Client::new() };
     let core = Core::new()?;
     let pool = CpuPool::new(20);
-    let storage = storage_from_environment(&pool, &core.handle());
+    let storage = storage_from_config(&pool, &core.handle());
     let res = SccacheServer::<ProcessCommandCreator>::new(port, pool, core, client, storage);
     let notify = env::var_os("SCCACHE_STARTUP_NOTIFY");
     match res {


### PR DESCRIPTION
Notable difference to the variant in https://github.com/vvuk/sccache is that this branch retains the behaviour of trying each cache in turn.

~It does this by trying caches configured in the environment, then caches configured in the config file, then the disk cache from the environment (if any), then the disk cache configured in the config file (if any), then finally a fallback disk cache in the default location. An alternative to falling back to the configurations on the different levels would be instead to treat them as overrides, i.e. there is only ever one S3 connection attempted, with any environment settings overriding config file settings.~

It does this by accumulating a list of all configured caches (treating the environment as overriding file-based config) and working through them.

I also fixed an issue where tests would fail with `--no-default-features`, and added the run to travis so it won't be missed in future.