### PR TITLE
Don't cache Rust compiles with incremental compilation. Fixes #257

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - os: osx
 
     # rustc version compat
-    - rust: 1.22.0 # oldest supported version, keep in sync with README.md
+    - rust: 1.27.0 # oldest supported version, keep in sync with README.md
     - rust: beta
     - rust: nightly
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Table of Contents (ToC)
 Build Requirements
 ------------------
 
-Sccache is a [Rust](https://www.rust-lang.org/) program. Building it requires `cargo` (and thus `rustc`). sccache currently requires **Rust 1.22**.
+Sccache is a [Rust](https://www.rust-lang.org/) program. Building it requires `cargo` (and thus `rustc`). sccache currently requires **Rust 1.27**.
 
 We recommend you install Rust via [Rustup](https://rustup.rs/). The generated binaries can be built so that they are very [portable](#building-portable-binaries). By default `sccache` supports a local disk cache. To build `sccache` with support for `S3` and/or `Redis` cache backends, add `--features=all` or select a specific feature by passing `s3`, `gcs`, and/or `redis`. Refer the [Cargo Documentation](http://doc.crates.io/manifest.html#the-features-section) for details.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ for:
         target: x86_64-pc-windows-msvc
       - channel: nightly
         target: x86_64-pc-windows-msvc
-      - channel: 1.22.0 # Oldest supported version. Keep in sync with README.md.
+      - channel: 1.27.0 # Oldest supported version. Keep in sync with README.md.
         target: x86_64-pc-windows-msvc
         # Build a release build on master to make sure it builds.
       - channel: stable

--- a/tests/sccache_cargo.rs
+++ b/tests/sccache_cargo.rs
@@ -103,6 +103,9 @@ fn test_rust_cargo() {
     trace!("cargo build: {:?}", a);
     a.unwrap();
     // Now get the stats and ensure that we had a cache hit for the second build.
+    // Ideally we'd check the stats more usefully here--the test crate has one dependency (itoa)
+    // so there are two separate compilations, but cargo will build the test crate with
+    // incremental compilation enabled, so sccache will not cache it.
     trace!("sccache --show-stats");
     Assert::command(&[&sccache.to_string_lossy()])
         .with_args(&["--show-stats", "--stats-format=json"])

--- a/tests/test-crate/Cargo.lock
+++ b/tests/test-crate/Cargo.lock
@@ -1,4 +1,14 @@
 [[package]]
+name = "itoa"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "test-crate"
 version = "0.1.0"
+dependencies = [
+ "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
+[metadata]
+"checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"

--- a/tests/test-crate/Cargo.toml
+++ b/tests/test-crate/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 
 [dependencies]
+# Arbitrary crate dependency that doesn't pull in any transitive dependencies.
+itoa = "0.3.4"


### PR DESCRIPTION
rustc's incremental compilation mode isn't well-handled by sccache currently
because we don't cache the separate artifacts it creates. Additionally,
if there are existing incremental artifacts it's likely that rustc will do
a better job than sccache anyway, so don't bother trying to cache Rust
compilation when incremental compilation is enabled for now.

Longer-term we would like to make sccache and rustc incremental work
together nicely: https://github.com/mozilla/sccache/issues/236