### PR TITLE
Add support for --coverage

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -75,7 +75,7 @@ pub struct ParsedArguments {
     pub common_args: Vec<OsString>,
     /// Whether or not the `-showIncludes` argument is passed on MSVC
     pub msvc_show_includes: bool,
-    /// Whether the compilation is generating profiling data.
+    /// Whether the compilation is generating profiling or coverage data.
     pub profile_generate: bool,
 }
 

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -311,6 +311,7 @@ where
     if outputs_gcno {
         let gcno = output.with_extension("gcno");
         outputs.insert("gcno", gcno);
+        profile_generate = true;
     }
     if need_explicit_dep_target {
         preprocessor_args.push("-MT".into());
@@ -623,7 +624,7 @@ mod test {
         assert!(preprocessor_args.is_empty());
         assert_eq!(ovec!["-ftest-coverage"], common_args);
         assert!(!msvc_show_includes);
-        assert!(!profile_generate);
+        assert!(profile_generate);
     }
 
     #[test]


### PR DESCRIPTION
closes #258

This initial implementation is following [this comment](https://github.com/mozilla/sccache/issues/258#issuecomment-402265866).

Here's a problem: `-fprofile-generate` on its own does not generate `.gcno` files, but this patch behaves like it did.

I think we need to split the `ProfileGenerate` flag into `ProfileArcs` and `TestCoverage`, with `ProfileArcs` having the meaning of `ProfileGenerate` and `TestCoverage` meaning we'll find a `.gcno` file in the outputs. But that would mean `--coverage` needs to be flagged with both of these. Can the `flag!` macro take two flags?

