### PR TITLE
Make the client error on unsupported compilers. Fixes #261

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -519,6 +519,10 @@ fn handle_compile_response<T>(mut creator: T,
                 }),
             }
         }
+        CompileResponse::UnsupportedCompiler => {
+            debug!("Server sent UnsupportedCompiler");
+            bail!("Compiler not supported");
+        }
         CompileResponse::UnhandledCompile => {
             debug!("Server sent UnhandledCompile");
         }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -35,6 +35,8 @@ pub enum CompileResponse {
     CompileStarted,
     /// The server could not handle this compilation request.
     UnhandledCompile,
+    /// The compiler was not supported.
+    UnsupportedCompiler,
 }
 
 /// Information about a finished compile, either from cache or executed locally.

--- a/src/server.rs
+++ b/src/server.rs
@@ -500,6 +500,9 @@ impl<C> SccacheService<C>
             None => {
                 debug!("check_compiler: Unsupported compiler");
                 stats.requests_unsupported_compiler += 1;
+                return Message::WithoutBody(
+                    Response::Compile(CompileResponse::UnsupportedCompiler)
+                        );
             }
             Some(c) => {
                 debug!("check_compiler: Supported compiler");


### PR DESCRIPTION
Previously when an unsupported compiler was detected the server would report
this as an UnhandledCompile and the client would run the command locally.
Trying to run a compile with an unsupported compiler is a fairly unusual
situation and so it should produce errors to make the situation clear instead
of silently not caching any compilation.

We encountered this situation in Firefox CI when switching to clang-cl and
it went unnoticed for several weeks.