### PR TITLE
Upgrade ring to 13.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ openssl = { version = "0.9", optional = true }
 redis = { version = "0.8.0", optional = true }
 regex = "0.2"
 retry = "0.4.0"
-ring = "0.12.1"
+ring = "0.13.2"
 rust-crypto = { version = "0.2.36", optional = true }
 serde = "1.0"
 serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ futures-cpupool = "0.1"
 hyper = { version = "0.11", optional = true }
 hyper-tls = { version = "0.1", optional = true }
 jobserver = "0.1"
-jsonwebtoken = { version = "4.0", optional = true }
+jsonwebtoken = { version = "5.0", optional = true }
 libc = "0.2.10"
 local-encoding = "0.2.0"
 log = "0.3.6"


### PR DESCRIPTION
This fixes building sccache using MSVC 15.8, which includes Spectre mitigations which cause earlier versions of ring to fail to build.