### PR TITLE
Richer argument handling for compilers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ascii"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,15 +47,6 @@ dependencies = [
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "base64"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -590,10 +586,10 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1291,6 +1287,7 @@ dependencies = [
 name = "sccache"
 version = "0.2.8-alpha.0"
 dependencies = [
+ "arraydeque 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cmd 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1314,7 +1311,7 @@ dependencies = [
  "hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "jobserver 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonwebtoken 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonwebtoken 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1330,6 +1327,7 @@ dependencies = [
  "number_prefix 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates 0.5.2 (git+https://github.com/luser/predicates-rs?branch=function-unsized)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2001,10 +1999,10 @@ dependencies = [
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum arraydeque 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc059aa8598b9f4fb1dd532a061edc8e4efe0ccc55ba05358aba2a80b7b01f11"
 "checksum ascii 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "97be891acc47ca214468e09425d02cef3af2c94d0d82081cd02061f996802f14"
 "checksum assert_cmd 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11d61ba2f519654febb9a504d172cfc21c667c9889e707b9860d78dd5e2b69b3"
 "checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
-"checksum base64 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c4a342b450b268e1be8036311e2c613d7f8a7ed31214dff1cc3b60852a3168d"
 "checksum base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "229d032f1a99302697f10b27167ae6d03d49d032e6a8e2550e8d3fc13356d2b4"
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
 "checksum bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9a6301db0b49fb63551bc15b5ae348147101cdf323242b93ec7546d5002ff1af"
@@ -2073,7 +2071,7 @@ dependencies = [
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
 "checksum jobserver 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "60af5f849e1981434e4a31d3d782c4774ae9b434ce55b101a96ecfd09147e8be"
-"checksum jsonwebtoken 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50ff506fbf25106dea8f97be2f9b43d67b7f02a4b5ced6b1ff3543dd08cecee0"
+"checksum jsonwebtoken 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88f52f9cabcc5a04929df00f52fbec4812f89039d0e71cfd15fe6eb58097c7d8"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ name = "sccache-dist"
 required-features = ["dist-server"]
 
 [dependencies]
+arraydeque = { version = "0.4", optional = true }
 base64 = "0.9.0"
 bincode = "0.9" # TODO: update to 1.0
 boxfnonce = "0.1"
@@ -36,7 +37,7 @@ futures-cpupool = "0.1"
 hyper = { version = "0.11", optional = true }
 hyper-tls = { version = "0.1", optional = true }
 jobserver = "0.1"
-jsonwebtoken = { version = "4.0", optional = true }
+jsonwebtoken = "4.0.1"
 libc = "0.2.10"
 local-encoding = "0.2.0"
 log = "0.3.6"
@@ -46,6 +47,7 @@ native-tls = "0.1"
 num_cpus = "1.0"
 number_prefix = "0.2.5"
 openssl = { version = "0.9", optional = true }
+rand = "0.4.2"
 redis = { version = "0.8.0", optional = true }
 regex = "0.2"
 # Since we use the unstable async API
@@ -109,14 +111,14 @@ all-windows = ["redis", "s3", "memcached", "azure"]
 azure = ["chrono", "hyper", "hyper-tls", "rust-crypto"]
 s3 = ["chrono", "hyper", "hyper-tls", "rust-crypto", "simple-s3"]
 simple-s3 = []
-gcs = ["chrono", "hyper", "hyper-tls", "jsonwebtoken", "openssl", "url"]
+gcs = ["chrono", "hyper", "hyper-tls", "openssl", "url"]
 memcached = ["memcached-rs"]
 # Enable features that require unstable features of Nightly Rust.
 unstable = []
 # Enables distributed support in the sccache client
 dist = []
 # Enables the sccache-dist binary
-dist-server = ["crossbeam-utils", "flate2", "libmount", "nix"]
+dist-server = ["arraydeque", "crossbeam-utils", "flate2", "libmount", "nix"]
 
 [workspace]
 exclude = ["tests/test-crate"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ futures-cpupool = "0.1"
 hyper = { version = "0.11", optional = true }
 hyper-tls = { version = "0.1", optional = true }
 jobserver = "0.1"
-jsonwebtoken = "4.0.1"
+jsonwebtoken = { version = "4.0.1", optional = true }
 libc = "0.2.10"
 local-encoding = "0.2.0"
 log = "0.3.6"
@@ -50,13 +50,13 @@ openssl = { version = "0.9", optional = true }
 rand = "0.4.2"
 redis = { version = "0.8.0", optional = true }
 regex = "0.2"
-# Since we use the unstable async API
-reqwest = { version = "=0.8.6", features = ["unstable"] }
+# Exact dependency since we use the unstable async API
+reqwest = { version = "=0.8.6", features = ["unstable"], optional = true }
 retry = "0.4.0"
 ring = "0.12.1"
 # Need https://github.com/tomaka/rouille/pull/185
 #rouille = "2.1"
-rouille = { git = "https://github.com/tomaka/rouille.git", rev = "7b6b2eb" }
+rouille = { git = "https://github.com/tomaka/rouille.git", rev = "7b6b2eb", optional = true }
 rust-crypto = { version = "0.2.36", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
@@ -111,14 +111,14 @@ all-windows = ["redis", "s3", "memcached", "azure"]
 azure = ["chrono", "hyper", "hyper-tls", "rust-crypto"]
 s3 = ["chrono", "hyper", "hyper-tls", "rust-crypto", "simple-s3"]
 simple-s3 = []
-gcs = ["chrono", "hyper", "hyper-tls", "openssl", "url"]
+gcs = ["chrono", "hyper", "hyper-tls", "jsonwebtoken", "openssl", "url"]
 memcached = ["memcached-rs"]
 # Enable features that require unstable features of Nightly Rust.
 unstable = []
 # Enables distributed support in the sccache client
-dist = []
+dist-client = ["reqwest"]
 # Enables the sccache-dist binary
-dist-server = ["arraydeque", "crossbeam-utils", "flate2", "libmount", "nix"]
+dist-server = ["arraydeque", "crossbeam-utils", "jsonwebtoken", "flate2", "libmount", "nix", "reqwest", "rouille"]
 
 [workspace]
 exclude = ["tests/test-crate"]

--- a/docs/Distributed.md
+++ b/docs/Distributed.md
@@ -1,4 +1,4 @@
-= Distributed sccache
+# Distributed sccache
 
 Background:
 
@@ -15,7 +15,7 @@ Background:
    tokens), be aware that a lack of entropy is possible in cloud or
    virtualized environments in some scenarios.
 
-== Overview
+## Overview
 
 Distributed sccache consists of three parts:
 
@@ -31,7 +31,7 @@ compilation from Linux, Windows or OSX. Linux compilations will attempt to
 automatically package the compiler in use, while Windows and OSX users will
 need to specify a toolchain for cross-compilation ahead of time.
 
-== Communication
+## Communication
 
 The HTTP implementation of sccache has the following API:
 
@@ -60,7 +60,7 @@ There are two axes of security in this setup:
 1. Can the scheduler trust the servers?
 2. Is the client permitted to submit and run jobs?
 
-=== Server Trust
+### Server Trust
 
 If a server is malicious, they can return malicious compilation output to a user.
 To protect against this, servers must be authenticated. You have three means for
@@ -69,7 +69,7 @@ doing this, and the scheduler and all servers must use the same mechanism.
 Once a server has registered itself using the selected authentication, the scheduler
 will trust the registered server address and use it for builds.
 
-==== JWT HS256 (preferred)
+#### JWT HS256 (preferred)
 
 This method uses secret key to create a per-IP-and-port token for each server.
 Acquiring a token will only allow participation as a server if the attacker can
@@ -105,7 +105,7 @@ scheduler_auth = { type = "jwt_token", token = "YOUR_TOKEN_HERE" }
 
 Done!
 
-==== Token
+#### Token
 
 This method simply shares a token between the scheduler and all servers. A token
 leak from anywhere allows any attacker to participate as a server.
@@ -128,7 +128,7 @@ scheduler_auth = { type = "token", token = "YOUR_TOKEN_HERE" }
 
 Done!
 
-==== Insecure (bad idea)
+#### Insecure (bad idea)
 
 *This route is not recommended*
 
@@ -151,7 +151,7 @@ scheduler_auth = { type = "DANGEROUSLY_INSECURE" }
 
 Done!
 
-=== Client Trust
+### Client Trust
 
 If a client is malicious, they can cause a DoS of distributed sccache servers or
 explore ways to escape the build sandbox. To protect against this, clients must
@@ -168,7 +168,7 @@ the scheduler during registration. This means that the server can verify users
 without either a) adding client authentication to every server or b) needing
 secret transfer between scheduler and server on every job allocation.
 
-==== Token
+#### Token
 
 This method simply shares a token between the scheduler and all clients. A token
 leak from anywhere allows any attacker to participate as a client.
@@ -191,7 +191,7 @@ auth = { type = "token", token = "YOUR_TOKEN_HERE" }
 
 Done!
 
-==== Insecure (bad idea)
+#### Insecure (bad idea)
 
 *This route is not recommended*
 

--- a/docs/Distributed.md
+++ b/docs/Distributed.md
@@ -1,0 +1,212 @@
+= Distributed sccache
+
+Background:
+
+ - You should read about JSON Web Tokens - https://jwt.io/.
+   - HS256 in short: you can sign a piece of (typically unencrypted)
+     data with a key. Verification involves signing the data again
+     with the same key and comparing the result. As a result, if you
+     want two parties to verify each others messages, the key must be
+     shared beforehand.
+ - 'secure token's referenced below should be generated with a CSPRNG
+   (your OS random number generator should suffice).
+   For example, on Linux this is accessible with: `openssl rand -hex 64`.
+ - When relying on random number generators (for generating keys or
+   tokens), be aware that a lack of entropy is possible in cloud or
+   virtualized environments in some scenarios.
+
+== Overview
+
+Distributed sccache consists of three parts:
+
+ - the client, an sccache binary that wishes to perform a compilation on
+   remote machines
+ - the scheduler (`sccache-dist` binary), responsible for deciding where
+   a compilation job should run
+ - the server (`sccache-dist` binary), responsible for actually executing
+   a build
+
+All servers are required to be a 64-bit Linux install. Clients may request
+compilation from Linux, Windows or OSX. Linux compilations will attempt to
+automatically package the compiler in use, while Windows and OSX users will
+need to specify a toolchain for cross-compilation ahead of time.
+
+== Communication
+
+The HTTP implementation of sccache has the following API:
+
+ - scheduler
+   - `POST alloc_job`
+      - Called by a client to submit a compilation request.
+      - Returns information on where the job is allocated it should run.
+   - `POST heartbeat_server`
+      - Called (repeatedly) by servers to register as available for jobs.
+   - `POST state`
+      - Called by servers to inform the scheduler of the state of the job.
+   - `GET status`
+      - Returns information about the scheduler.
+ - `server`
+   - `POST assign_job`
+      - Called by the scheduler to inform of a new job being assigned to this server.
+      - Returns whether the toolchain is already on the server or needs submitting.
+   - `POST submit_toolchain`
+      - Called by the client to submit a toolchain.
+   - `POST run_job`
+      - Called by the client to run a job.
+      - Returns the compilation stdout along with files created.
+
+There are two axes of security in this setup:
+
+1. Can the scheduler trust the servers?
+2. Is the client permitted to submit and run jobs?
+
+=== Server Trust
+
+If a server is malicious, they can return malicious compilation output to a user.
+To protect against this, servers must be authenticated. You have three means for
+doing this, and the scheduler and all servers must use the same mechanism.
+
+Once a server has registered itself using the selected authentication, the scheduler
+will trust the registered server address and use it for builds.
+
+==== JWT HS256 (preferred)
+
+This method uses secret key to create a per-IP-and-port token for each server.
+Acquiring a token will only allow participation as a server if the attacker can
+additionally impersonate the IP and port the token was generated for.
+
+You *must* keep the secret key safe.
+
+*To use it*:
+
+Create a scheduler key with `sccache-dist auth generate-jwt-hs256-key` (which will
+use your OS random number generator) and put it in your scheduler config file as
+follows:
+
+```
+server_auth = { type = "jwt_hs256", secret_key = "YOUR_KEY_HERE" }
+```
+
+Now generate a token for the server, giving the IP and port the scheduler can
+connect to the server on (IP `192.168.1.10` and port `10501` here):
+
+```
+sccache-dist auth generate-jwt-hs256-server-token \
+    --config /path/to/scheduler-config.toml \
+    --server 192.168.1.10:10501
+```
+
+This will output a token (you can examine it with https://jwt.io if you're
+curious) that you should add to your server config file as follows:
+
+```
+scheduler_auth = { type = "jwt_token", token = "YOUR_TOKEN_HERE" }
+```
+
+Done!
+
+==== Token
+
+This method simply shares a token between the scheduler and all servers. A token
+leak from anywhere allows any attacker to participate as a server.
+
+*To use it*:
+
+Choose a 'secure token' you can share between your scheduler and all servers.
+
+Put the following in your scheduler config file:
+
+```
+server_auth = { type = "token", token = "YOUR_TOKEN_HERE" }
+```
+
+Put the following in your server config file:
+
+```
+scheduler_auth = { type = "token", token = "YOUR_TOKEN_HERE" }
+```
+
+Done!
+
+==== Insecure (bad idea)
+
+*This route is not recommended*
+
+This method uses a hardcoded token that effectively disables authentication and
+provides no security at all.
+
+*To use it*:
+
+Put the following in your scheduler config file:
+
+```
+server_auth = { type = "DANGEROUSLY_INSECURE" }
+```
+
+Put the following in your server config file:
+
+```
+scheduler_auth = { type = "DANGEROUSLY_INSECURE" }
+```
+
+Done!
+
+=== Client Trust
+
+If a client is malicious, they can cause a DoS of distributed sccache servers or
+explore ways to escape the build sandbox. To protect against this, clients must
+be authenticated. You have two means for doing this, and the scheduler and all
+clients must use the same mechanism.
+
+Each client will use the authentication for the initial job allocation request
+to the scheduler. A successful allocation will return a job token that is used
+to authorise requests to the appropriate server for that specific job.
+
+This job token is a JWT HS256 token of the job id, signed with a server key.
+The key for each server is randomly generated on server startup and given to
+the scheduler during registration. This means that the server can verify users
+without either a) adding client authentication to every server or b) needing
+secret transfer between scheduler and server on every job allocation.
+
+==== Token
+
+This method simply shares a token between the scheduler and all clients. A token
+leak from anywhere allows any attacker to participate as a client.
+
+*To use it*:
+
+Choose a 'secure token' you can share between your scheduler and all clients.
+
+Put the following in your scheduler config file:
+
+```
+client_auth = { type = "token", token = "YOUR_TOKEN_HERE" }
+```
+
+Put the following in your client config file:
+
+```
+auth = { type = "token", token = "YOUR_TOKEN_HERE" }
+```
+
+Done!
+
+==== Insecure (bad idea)
+
+*This route is not recommended*
+
+This method uses a hardcoded token that effectively disables authentication and
+provides no security at all.
+
+*To use it*:
+
+Put the following in your scheduler config file:
+
+```
+client_auth = { type = "DANGEROUSLY_INSECURE" }
+```
+
+Remove any `auth =` setting under the `[dist]` heading in your client config file
+(it will default to insecure).
+
+Done!

--- a/src/bin/sccache-dist/build.rs
+++ b/src/bin/sccache-dist/build.rs
@@ -62,16 +62,13 @@ pub struct OverlayBuilder {
 }
 
 impl OverlayBuilder {
-    pub fn new(bubblewrap: &Path, dir: &Path) -> Result<Self> {
+    pub fn new(bubblewrap: PathBuf, dir: PathBuf) -> Result<Self> {
         info!("Creating overlay builder");
 
         if !nix::unistd::getuid().is_root() || !nix::unistd::geteuid().is_root() {
             // Not root, or a setuid binary - haven't put enough thought into supporting this, bail
             bail!("not running as root")
         }
-
-        let bubblewrap = bubblewrap.to_owned();
-        let dir = dir.to_owned();
 
         // TODO: pidfile
         let ret = Self {

--- a/src/bin/sccache-dist/main.rs
+++ b/src/bin/sccache-dist/main.rs
@@ -336,6 +336,7 @@ fn run(command: Command) -> Result<i32> {
 
             let check_server_auth: Box<Fn(&str) -> Option<ServerId> + Send + Sync> = match server_auth {
                 scheduler_config::ServerAuth::Insecure => {
+                    warn!("Scheduler starting with DANGEROUSLY_INSECURE server authentication");
                     let token = INSECURE_DIST_SERVER_TOKEN;
                     Box::new(move |server_token| check_server_token(server_token, &token))
                 },
@@ -367,6 +368,7 @@ fn run(command: Command) -> Result<i32> {
             let server_id = ServerId(public_addr);
             let scheduler_auth = match scheduler_auth {
                 server_config::SchedulerAuth::Insecure => {
+                    warn!("Server starting with DANGEROUSLY_INSECURE scheduler authentication");
                     create_server_token(server_id, &INSECURE_DIST_SERVER_TOKEN)
                 },
                 server_config::SchedulerAuth::Token { token } => {

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -194,7 +194,7 @@ impl<T: CommandCreatorSync, I: CCompilerImpl> Compiler<T> for CCompiler<I> {
                     compiler: self.compiler.clone(),
                 }))
             }
-            CompilerArguments::CannotCache(why) => CompilerArguments::CannotCache(why),
+            CompilerArguments::CannotCache(why, extra_info) => CompilerArguments::CannotCache(why, extra_info),
             CompilerArguments::NotCompilation => CompilerArguments::NotCompilation,
         }
     }

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -154,9 +154,9 @@ mod test {
 
     #[test]
     fn test_parse_arguments_clangmodules() {
-        assert_eq!(CompilerArguments::CannotCache("-fcxx-modules"),
+        assert_eq!(CompilerArguments::CannotCache("-fcxx-modules", None),
                    _parse_arguments(&stringvec!["-c", "foo.c", "-fcxx-modules", "-o", "foo.o"]));
-        assert_eq!(CompilerArguments::CannotCache("-fmodules"),
+        assert_eq!(CompilerArguments::CannotCache("-fmodules", None),
                    _parse_arguments(&stringvec!["-c", "foo.c", "-fmodules", "-o", "foo.o"]));
     }
 }

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -24,7 +24,7 @@ use ::compiler::{
 use dist;
 use compiler::args::*;
 use compiler::c::{CCompilerImpl, CCompilerKind, Language, ParsedArguments};
-use compiler::gcc::GCCArgAttribute::*;
+use compiler::gcc::ArgData::*;
 use futures::future::{self, Future};
 use futures_cpupool::CpuPool;
 use mock_command::{
@@ -38,7 +38,7 @@ use std::io::{
     self,
     Write,
 };
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process;
 use util::{run_input_output, OsStrExt};
 
@@ -81,17 +81,17 @@ impl CCompilerImpl for Clang {
     }
 }
 
-pub static ARGS: [(ArgInfo, gcc::GCCArgAttribute); 8] = [
-    take_arg!("--serialize-diagnostics", String, Separated, PassThrough),
-    take_arg!("--target", String, Separated, PassThrough),
+pub static ARGS: [ArgInfo<gcc::ArgData>; 8] = [
+    take_arg!("--serialize-diagnostics", OsString, Separated, PassThrough),
+    take_arg!("--target", OsString, Separated, PassThrough),
     // TODO: should be extracted and reprocessed, though bear in mind some
     // flags are not valid under a -Xclang
-    take_arg!("-Xclang", String, Separated, TooHard),
-    flag!("-fcxx-modules", TooHard),
-    flag!("-fmodules", TooHard),
-    take_arg!("-gcc-toolchain", String, Separated, PassThrough),
-    take_arg!("-include-pch", Path, CanBeSeparated, PreprocessorArgument),
-    take_arg!("-target", String, Separated, PassThrough),
+    take_arg!("-Xclang", OsString, Separated, TooHard),
+    flag!("-fcxx-modules", TooHardFlag),
+    flag!("-fmodules", TooHardFlag),
+    take_arg!("-gcc-toolchain", OsString, Separated, PassThrough),
+    take_arg!("-include-pch", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    take_arg!("-target", OsString, Separated, PassThrough),
 ];
 
 #[cfg(test)]

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -467,6 +467,17 @@ pub enum CompilerArguments<T>
     NotCompilation,
 }
 
+macro_rules! try_arg {
+    ($arg:expr) => {{
+        match $arg {
+            Ok(arg) => arg,
+            Err(e) => {
+                return CompilerArguments::CannotCache(e)
+            },
+        }
+    }};
+}
+
 /// Specifics about cache misses.
 #[derive(Debug, PartialEq)]
 pub enum MissType {

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -462,17 +462,26 @@ pub enum CompilerArguments<T>
     /// Commandline can be handled.
     Ok(T),
     /// Cannot cache this compilation.
-    CannotCache(&'static str),
+    CannotCache(&'static str, Option<String>),
     /// This commandline is not a compile.
     NotCompilation,
 }
 
-macro_rules! try_arg {
-    ($arg:expr) => {{
+macro_rules! cannot_cache {
+    ($why:expr) => {
+        return CompilerArguments::CannotCache($why, None)
+    };
+    ($why:expr, $extra_info:expr) => {
+        return CompilerArguments::CannotCache($why, Some($extra_info))
+    };
+}
+
+macro_rules! try_or_cannot_cache {
+    ($arg:expr, $why:expr) => {{
         match $arg {
             Ok(arg) => arg,
             Err(e) => {
-                return CompilerArguments::CannotCache(e)
+                cannot_cache!($why, e.to_string())
             },
         }
     }};

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -310,7 +310,7 @@ pub trait CompilerHasher<T>: fmt::Debug + Send + 'static
     fn box_clone(&self) -> Box<CompilerHasher<T>>;
 }
 
-#[cfg(not(feature = "dist"))]
+#[cfg(not(feature = "dist-client"))]
 fn dist_or_local_compile<T>(_dist_client: Arc<dist::Client>,
                             creator: T,
                             _cwd: PathBuf,
@@ -328,7 +328,7 @@ fn dist_or_local_compile<T>(_dist_client: Arc<dist::Client>,
         .map(move |o| (cacheable, o)))
 }
 
-#[cfg(feature = "dist")]
+#[cfg(feature = "dist-client")]
 fn dist_or_local_compile<T>(dist_client: Arc<dist::Client>,
                             creator: T,
                             cwd: PathBuf,

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -72,91 +72,94 @@ impl CCompilerImpl for GCC {
     }
 }
 
-#[derive(Clone, Debug)]
-pub enum GCCArgAttribute {
-    TooHard,
-    PassThrough,
-    PreprocessorArgument,
-    DoCompilation,
-    Output,
-    NeedDepTarget,
-    DepTarget,
-    Language,
-    SplitDwarf,
-    ProfileGenerate,
-    TestCoverage,
-    Coverage,
+ArgData!{ pub
+    TooHardFlag(()),
+    TooHard(OsString),
+    PassThrough(OsString),
+    PassThroughPath(PathBuf),
+    PreprocessorArgumentFlag(()),
+    PreprocessorArgument(OsString),
+    PreprocessorArgumentPath(PathBuf),
+    DoCompilation(()),
+    Output(PathBuf),
+    NeedDepTarget(()),
+    DepTarget(OsString),
+    Language(OsString),
+    SplitDwarf(()),
+    ProfileGenerate(()),
+    TestCoverage(()),
+    Coverage(()),
 }
 
-use self::GCCArgAttribute::*;
+use self::ArgData::*;
 
 // Mostly taken from https://github.com/ccache/ccache/blob/master/src/compopt.c#L32-L84
-pub static ARGS: [(ArgInfo, GCCArgAttribute); 65] = [
-    flag!("-", TooHard),
+pub static ARGS: [ArgInfo<ArgData>; 65] = [
+    flag!("-", TooHardFlag),
     flag!("--coverage", Coverage),
-    take_arg!("--param", String, Separated, PassThrough),
-    flag!("--save-temps", TooHard),
-    take_arg!("--serialize-diagnostics", Path, Separated, PassThrough),
-    take_arg!("--sysroot", Path, Separated, PassThrough),
-    take_arg!("-A", String, Separated, PassThrough),
-    take_arg!("-B", Path, CanBeSeparated, PassThrough),
-    take_arg!("-D", String, CanBeSeparated, PreprocessorArgument),
-    flag!("-E", TooHard),
-    take_arg!("-F", Path, CanBeSeparated, PreprocessorArgument),
-    take_arg!("-G", String, Separated, PassThrough),
-    take_arg!("-I", Path, CanBeSeparated, PreprocessorArgument),
-    take_arg!("-L", String, Separated, PassThrough),
-    flag!("-M", TooHard),
+    take_arg!("--param", OsString, Separated, PassThrough),
+    flag!("--save-temps", TooHardFlag),
+    take_arg!("--serialize-diagnostics", PathBuf, Separated, PassThroughPath),
+    take_arg!("--sysroot", PathBuf, Separated, PassThroughPath),
+    take_arg!("-A", OsString, Separated, PassThrough),
+    take_arg!("-B", PathBuf, CanBeSeparated, PassThroughPath),
+    take_arg!("-D", OsString, CanBeSeparated, PreprocessorArgument),
+    flag!("-E", TooHardFlag),
+    take_arg!("-F", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    take_arg!("-G", OsString, Separated, PassThrough),
+    take_arg!("-I", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    take_arg!("-L", OsString, Separated, PassThrough),
+    flag!("-M", TooHardFlag),
     flag!("-MD", NeedDepTarget),
-    take_arg!("-MF", Path, Separated, PreprocessorArgument),
-    flag!("-MM", TooHard),
+    take_arg!("-MF", PathBuf, Separated, PreprocessorArgumentPath),
+    flag!("-MM", TooHardFlag),
     flag!("-MMD", NeedDepTarget),
     flag!("-MP", NeedDepTarget),
-    take_arg!("-MQ", String, Separated, PreprocessorArgument),
-    take_arg!("-MT", String, Separated, DepTarget),
-    flag!("-P", TooHard),
-    take_arg!("-U", String, CanBeSeparated, PreprocessorArgument),
-    take_arg!("-V", String, Separated, PassThrough),
-    take_arg!("-Xassembler", String, Separated, PassThrough),
-    take_arg!("-Xlinker", String, Separated, PassThrough),
-    take_arg!("-Xpreprocessor", String, Separated, PreprocessorArgument),
-    take_arg!("-arch", String, Separated, PassThrough),
-    take_arg!("-aux-info", String, Separated, PassThrough),
-    take_arg!("-b", String, Separated, PassThrough),
+    take_arg!("-MQ", OsString, Separated, PreprocessorArgument),
+    take_arg!("-MT", OsString, Separated, DepTarget),
+    flag!("-P", TooHardFlag),
+    take_arg!("-U", OsString, CanBeSeparated, PreprocessorArgument),
+    take_arg!("-V", OsString, Separated, PassThrough),
+    take_arg!("-Xassembler", OsString, Separated, PassThrough),
+    take_arg!("-Xlinker", OsString, Separated, PassThrough),
+    take_arg!("-Xpreprocessor", OsString, Separated, PreprocessorArgument),
+    take_arg!("-arch", OsString, Separated, PassThrough),
+    take_arg!("-aux-info", OsString, Separated, PassThrough),
+    take_arg!("-b", OsString, Separated, PassThrough),
     flag!("-c", DoCompilation),
-    take_arg!("-dependency-file", Path, Separated, PreprocessorArgument),
-    flag!("-fno-working-directory", PreprocessorArgument),
-    flag!("-fplugin=libcc1plugin", TooHard),
+    take_arg!("-dependency-file", PathBuf, Separated, PreprocessorArgumentPath),
+    flag!("-fno-working-directory", PreprocessorArgumentFlag),
+    flag!("-fplugin=libcc1plugin", TooHardFlag),
     flag!("-fprofile-arcs", ProfileGenerate),
     flag!("-fprofile-generate", ProfileGenerate),
-    flag!("-fprofile-use", TooHard),
-    flag!("-frepo", TooHard),
-    flag!("-fsyntax-only", TooHard),
+    flag!("-fprofile-use", TooHardFlag),
+    flag!("-frepo", TooHardFlag),
+    flag!("-fsyntax-only", TooHardFlag),
     flag!("-ftest-coverage", TestCoverage),
-    flag!("-fworking-directory", PreprocessorArgument),
+    flag!("-fworking-directory", PreprocessorArgumentFlag),
     flag!("-gsplit-dwarf", SplitDwarf),
-    take_arg!("-idirafter", Path, CanBeSeparated, PreprocessorArgument),
-    take_arg!("-iframework", Path, CanBeSeparated, PreprocessorArgument),
-    take_arg!("-imacros", Path, CanBeSeparated, PreprocessorArgument),
-    take_arg!("-imultilib", Path, CanBeSeparated, PreprocessorArgument),
-    take_arg!("-include", Path, CanBeSeparated, PreprocessorArgument),
-    take_arg!("-install_name", String, Separated, PassThrough),
-    take_arg!("-iprefix", Path, CanBeSeparated, PreprocessorArgument),
-    take_arg!("-iquote", Path, CanBeSeparated, PreprocessorArgument),
-    take_arg!("-isysroot", Path, CanBeSeparated, PreprocessorArgument),
-    take_arg!("-isystem", Path, CanBeSeparated, PreprocessorArgument),
-    take_arg!("-iwithprefix", Path, CanBeSeparated, PreprocessorArgument),
-    take_arg!("-iwithprefixbefore", Path, CanBeSeparated, PreprocessorArgument),
-    flag!("-nostdinc", PreprocessorArgument),
-    flag!("-nostdinc++", PreprocessorArgument),
-    take_arg!("-o", Path, Separated, Output),
-    flag!("-remap", PreprocessorArgument),
-    flag!("-save-temps", TooHard),
-    take_arg!("-stdlib", String, Concatenated('='), PreprocessorArgument),
-    flag!("-trigraphs", PreprocessorArgument),
-    take_arg!("-u", String, CanBeSeparated, PassThrough),
-    take_arg!("-x", String, CanBeSeparated, Language),
-    take_arg!("@", String, Concatenated, TooHard),
+    take_arg!("-idirafter", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    take_arg!("-iframework", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    take_arg!("-imacros", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    take_arg!("-imultilib", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    take_arg!("-include", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    take_arg!("-install_name", OsString, Separated, PassThrough),
+    take_arg!("-iprefix", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    take_arg!("-iquote", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    take_arg!("-isysroot", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    take_arg!("-isystem", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    take_arg!("-iwithprefix", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    take_arg!("-iwithprefixbefore", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    flag!("-nostdinc", PreprocessorArgumentFlag),
+    flag!("-nostdinc++", PreprocessorArgumentFlag),
+    take_arg!("-o", PathBuf, Separated, Output),
+    flag!("-remap", PreprocessorArgumentFlag),
+    flag!("-save-temps", TooHardFlag),
+    take_arg!("-stdlib", OsString, Concatenated('='), PreprocessorArgument),
+    flag!("-trigraphs", PreprocessorArgumentFlag),
+    take_arg!("-u", OsString, CanBeSeparated, PassThrough),
+    take_arg!("-x", OsString, CanBeSeparated, Language),
+    take_arg!("@", OsString, Concatenated, TooHard),
 ];
 
 /// Parse `arguments`, determining whether it is supported.
@@ -174,7 +177,7 @@ pub fn parse_arguments<S>(
     arg_info: S,
 ) -> CompilerArguments<ParsedArguments>
 where
-    S: SearchableArgInfo<Info = (ArgInfo, GCCArgAttribute)>,
+    S: SearchableArgInfo<ArgData>,
 {
     let mut output_arg = None;
     let mut input_arg = None;
@@ -193,16 +196,17 @@ where
     // and interpreting it as a list of more arguments.
     let it = ExpandIncludeFile::new(cwd, arguments);
 
-    for item in ArgsIter::new(it, arg_info) {
+    for arg in ArgsIter::new(it, arg_info) {
+        let arg = try_arg!(arg.map_err(|e| e.static_description()));
         // Check if the value part of this argument begins with '@'. If so, we either
         // failed to expand it, or it was a concatenated argument - either way, bail.
         // We refuse to cache concatenated arguments (like "-include@foo") because they're a
         // mess. See https://github.com/mozilla/sccache/issues/150#issuecomment-318586953
-        match item.arg {
+        match arg {
             Argument::WithValue(_, ref v, ArgDisposition::Separated) |
             Argument::WithValue(_, ref v, ArgDisposition::CanBeConcatenated(_)) |
             Argument::WithValue(_, ref v, ArgDisposition::CanBeSeparated(_)) => {
-                if OsString::from(v.clone()).starts_with("@") {
+                if v.clone().into_arg().starts_with("@") {
                     return CompilerArguments::CannotCache("@");
                 }
             },
@@ -211,41 +215,43 @@ where
             Argument::WithValue(_, _, ArgDisposition::Concatenated(_)) |
             Argument::Raw(_) |
             Argument::UnknownFlag(_) |
-            Argument::Flag(_) => {},
+            Argument::Flag(_, _) => {},
         }
 
-        match item.data {
-            Some(TooHard) => {
-                return CompilerArguments::CannotCache(item.arg.to_str().expect(
+        match arg.get_data() {
+            Some(TooHardFlag(())) |
+            Some(TooHard(_)) => {
+                return CompilerArguments::CannotCache(arg.to_str().expect(
                     "Can't be Argument::Raw/UnknownFlag",
                 ))
             }
-            Some(SplitDwarf) => split_dwarf = true,
-            Some(DoCompilation) => compilation = true,
-            Some(ProfileGenerate) => profile_generate = true,
-            Some(TestCoverage) => outputs_gcno = true,
-            Some(Coverage) => {
+            Some(SplitDwarf(())) => split_dwarf = true,
+            Some(DoCompilation(())) => compilation = true,
+            Some(ProfileGenerate(())) => profile_generate = true,
+            Some(TestCoverage(())) => outputs_gcno = true,
+            Some(Coverage(())) => {
                 outputs_gcno = true;
                 profile_generate = true;
             }
-            Some(Output) => output_arg = item.arg.get_value().map(|s| s.unwrap_path()),
-            Some(NeedDepTarget) => need_explicit_dep_target = true,
-            Some(DepTarget) => dep_target = item.arg.get_value().map(OsString::from),
-            Some(PreprocessorArgument) |
-            Some(PassThrough) => {}
-            Some(Language) => {
-                let lang = item.arg.get_value().map(OsString::from);
-                let lang = lang.as_ref().map(|a| a.to_string_lossy());
-                language = match lang.as_ref().map(|a| a.as_ref()) {
-                    Some("c") => Some(Language::C),
-                    Some("c++") => Some(Language::Cxx),
-                    Some("objective-c") => Some(Language::ObjectiveC),
-                    Some("objective-c++") => Some(Language::ObjectiveCxx),
+            Some(Output(p)) => output_arg = Some(p.clone()),
+            Some(NeedDepTarget(())) => need_explicit_dep_target = true,
+            Some(DepTarget(s)) => dep_target = Some(s.clone()),
+            Some(PreprocessorArgumentFlag(())) |
+            Some(PreprocessorArgument(_)) |
+            Some(PreprocessorArgumentPath(_)) |
+            Some(PassThrough(_)) |
+            Some(PassThroughPath(_)) => {}
+            Some(Language(lang)) => {
+                language = match lang.to_string_lossy().as_ref() {
+                    "c" => Some(Language::C),
+                    "c++" => Some(Language::Cxx),
+                    "objective-c" => Some(Language::ObjectiveC),
+                    "objective-c++" => Some(Language::ObjectiveCxx),
                     _ => return CompilerArguments::CannotCache("-x"),
                 };
             }
             None => {
-                match item.arg {
+                match arg {
                     Argument::Raw(ref val) => {
                         if input_arg.is_some() {
                             multiple_input = true;
@@ -257,21 +263,25 @@ where
                 }
             }
         }
-        let args = match item.data {
-            Some(SplitDwarf) |
-            Some(ProfileGenerate) |
-            Some(TestCoverage) |
-            Some(Coverage) |
-            Some(PassThrough) => Some(&mut common_args),
-            Some(PreprocessorArgument) |
-            Some(NeedDepTarget) => Some(&mut preprocessor_args),
-            Some(DoCompilation) |
-            Some(Language) |
-            Some(Output) |
-            Some(DepTarget) => None,
-            Some(TooHard) => unreachable!(),
+        let args = match arg.get_data() {
+            Some(SplitDwarf(())) |
+            Some(ProfileGenerate(())) |
+            Some(TestCoverage(())) |
+            Some(Coverage(())) |
+            Some(PassThrough(_)) |
+            Some(PassThroughPath(_)) => Some(&mut common_args),
+            Some(PreprocessorArgumentFlag(())) |
+            Some(PreprocessorArgument(_)) |
+            Some(PreprocessorArgumentPath(_)) |
+            Some(NeedDepTarget(())) => Some(&mut preprocessor_args),
+            Some(DoCompilation(())) |
+            Some(Language(_)) |
+            Some(Output(_)) |
+            Some(DepTarget(_)) => None,
+            Some(TooHardFlag(())) |
+            Some(TooHard(_)) => unreachable!(),
             None => {
-                match item.arg {
+                match arg {
                     Argument::Raw(_) => None,
                     Argument::UnknownFlag(_) => Some(&mut common_args),
                     _ => unreachable!(),
@@ -282,11 +292,11 @@ where
             // Normalize attributes such as "-I foo", "-D FOO=bar", as
             // "-Ifoo", "-DFOO=bar", etc. and "-includefoo", "idirafterbar" as
             // "-include foo", "-idirafter bar", etc.
-            let norm = match item.arg.to_str() {
+            let norm = match arg.to_str() {
                 Some(s) if s.len() == 2 => NormalizedDisposition::Concatenated,
                 _ => NormalizedDisposition::Separated,
             };
-            args.extend(item.arg.normalize(norm));
+            args.extend(arg.normalize(norm));
         };
     }
 
@@ -327,7 +337,7 @@ where
     }
     if need_explicit_dep_target {
         preprocessor_args.push("-MT".into());
-        preprocessor_args.push(dep_target.unwrap_or(output.clone().into_os_string()));
+        preprocessor_args.push(dep_target.unwrap_or_else(|| output.clone().into_os_string()));
     }
     outputs.insert("obj", output);
 

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -73,25 +73,25 @@ impl CCompilerImpl for GCC {
 }
 
 ArgData!{ pub
-    TooHardFlag(()),
+    TooHardFlag,
     TooHard(OsString),
     PassThrough(OsString),
     PassThroughPath(PathBuf),
-    PreprocessorArgumentFlag(()),
+    PreprocessorArgumentFlag,
     PreprocessorArgument(OsString),
     PreprocessorArgumentPath(PathBuf),
-    DoCompilation(()),
+    DoCompilation,
     Output(PathBuf),
-    NeedDepTarget(()),
+    NeedDepTarget,
     // Though you might think this should be a path as it's a Makefile target,
     // it's not treated as a path by the compiler - it's just written wholesale
     // (including any funny make syntax) into the dep file.
     DepTarget(OsString),
     Language(OsString),
-    SplitDwarf(()),
-    ProfileGenerate(()),
-    TestCoverage(()),
-    Coverage(()),
+    SplitDwarf,
+    ProfileGenerate,
+    TestCoverage,
+    Coverage,
 }
 
 use self::ArgData::*;
@@ -222,24 +222,24 @@ where
         }
 
         match arg.get_data() {
-            Some(TooHardFlag(())) |
+            Some(TooHardFlag) |
             Some(TooHard(_)) => {
                 cannot_cache!(arg.flag_str().expect(
                     "Can't be Argument::Raw/UnknownFlag",
                 ))
             }
-            Some(SplitDwarf(())) => split_dwarf = true,
-            Some(DoCompilation(())) => compilation = true,
-            Some(ProfileGenerate(())) => profile_generate = true,
-            Some(TestCoverage(())) => outputs_gcno = true,
-            Some(Coverage(())) => {
+            Some(SplitDwarf) => split_dwarf = true,
+            Some(DoCompilation) => compilation = true,
+            Some(ProfileGenerate) => profile_generate = true,
+            Some(TestCoverage) => outputs_gcno = true,
+            Some(Coverage) => {
                 outputs_gcno = true;
                 profile_generate = true;
             }
             Some(Output(p)) => output_arg = Some(p.clone()),
-            Some(NeedDepTarget(())) => need_explicit_dep_target = true,
+            Some(NeedDepTarget) => need_explicit_dep_target = true,
             Some(DepTarget(s)) => dep_target = Some(s.clone()),
-            Some(PreprocessorArgumentFlag(())) |
+            Some(PreprocessorArgumentFlag) |
             Some(PreprocessorArgument(_)) |
             Some(PreprocessorArgumentPath(_)) |
             Some(PassThrough(_)) |
@@ -267,21 +267,21 @@ where
             }
         }
         let args = match arg.get_data() {
-            Some(SplitDwarf(())) |
-            Some(ProfileGenerate(())) |
-            Some(TestCoverage(())) |
-            Some(Coverage(())) |
+            Some(SplitDwarf) |
+            Some(ProfileGenerate) |
+            Some(TestCoverage) |
+            Some(Coverage) |
             Some(PassThrough(_)) |
             Some(PassThroughPath(_)) => Some(&mut common_args),
-            Some(PreprocessorArgumentFlag(())) |
+            Some(PreprocessorArgumentFlag) |
             Some(PreprocessorArgument(_)) |
             Some(PreprocessorArgumentPath(_)) |
-            Some(NeedDepTarget(())) => Some(&mut preprocessor_args),
-            Some(DoCompilation(())) |
+            Some(NeedDepTarget) => Some(&mut preprocessor_args),
+            Some(DoCompilation) |
             Some(Language(_)) |
             Some(Output(_)) |
             Some(DepTarget(_)) => None,
-            Some(TooHardFlag(())) |
+            Some(TooHardFlag) |
             Some(TooHard(_)) => unreachable!(),
             None => {
                 match arg {

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -209,7 +209,7 @@ where
             Argument::WithValue(_, ref v, ArgDisposition::Separated) |
             Argument::WithValue(_, ref v, ArgDisposition::CanBeConcatenated(_)) |
             Argument::WithValue(_, ref v, ArgDisposition::CanBeSeparated(_)) => {
-                if v.clone().into_arg().starts_with("@") {
+                if v.clone().into_os_string().starts_with("@") {
                     cannot_cache!("@");
                 }
             },
@@ -224,7 +224,7 @@ where
         match arg.get_data() {
             Some(TooHardFlag(())) |
             Some(TooHard(_)) => {
-                cannot_cache!(arg.to_str().expect(
+                cannot_cache!(arg.flag_str().expect(
                     "Can't be Argument::Raw/UnknownFlag",
                 ))
             }
@@ -295,11 +295,11 @@ where
             // Normalize attributes such as "-I foo", "-D FOO=bar", as
             // "-Ifoo", "-DFOO=bar", etc. and "-includefoo", "idirafterbar" as
             // "-include foo", "-idirafter bar", etc.
-            let norm = match arg.to_str() {
+            let norm = match arg.flag_str() {
                 Some(s) if s.len() == 2 => NormalizedDisposition::Concatenated,
                 _ => NormalizedDisposition::Separated,
             };
-            args.extend(arg.normalize(norm));
+            args.extend(arg.normalize(norm).iter_os_strings());
         };
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -16,6 +16,7 @@
 mod args;
 mod c;
 mod clang;
+#[macro_use]
 mod compiler;
 mod gcc;
 mod msvc;

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -203,17 +203,17 @@ fn encode_path(dst: &mut Write, path: &Path) -> io::Result<()> {
 }
 
 ArgData!{
-    TooHardFlag(()),
+    TooHardFlag,
     TooHard(OsString),
     TooHardPath(PathBuf),
     PreprocessorArgument(OsString),
     PreprocessorArgumentPath(PathBuf),
-    DoCompilation(()),
-    ShowIncludes(()),
+    DoCompilation,
+    ShowIncludes,
     Output(PathBuf),
     DepFile(PathBuf),
     ProgramDatabase(PathBuf),
-    DebugInfo(()),
+    DebugInfo,
     XClang(OsString),
 }
 
@@ -270,15 +270,15 @@ pub fn parse_arguments(arguments: &[OsString], cwd: &Path, is_clang: bool) -> Co
     for arg in ArgsIter::new(it, &ARGS[..]) {
         let arg = try_or_cannot_cache!(arg, "argument parse");
         match arg.get_data() {
-            Some(TooHardFlag(())) |
+            Some(TooHardFlag) |
             Some(TooHard(_)) |
             Some(TooHardPath(_)) => {
                 cannot_cache!(arg.flag_str().expect(
                     "Can't be Argument::Raw/UnknownFlag",
                 ))
             }
-            Some(DoCompilation(())) => compilation = true,
-            Some(ShowIncludes(())) => show_includes = true,
+            Some(DoCompilation) => compilation = true,
+            Some(ShowIncludes) => show_includes = true,
             Some(Output(out)) => {
                 output_arg = Some(out.clone());
                 // Can't usefully cache output that goes to nul anyway,
@@ -289,7 +289,7 @@ pub fn parse_arguments(arguments: &[OsString], cwd: &Path, is_clang: bool) -> Co
             }
             Some(DepFile(p)) => depfile = Some(p.clone()),
             Some(ProgramDatabase(p)) => pdb = Some(p.clone()),
-            Some(DebugInfo(())) => debug_info = true,
+            Some(DebugInfo) => debug_info = true,
             Some(PreprocessorArgument(_)) |
             Some(PreprocessorArgumentPath(_)) => {}
             Some(XClang(s)) => xclangs.push(s.clone()),
@@ -313,7 +313,7 @@ pub fn parse_arguments(arguments: &[OsString], cwd: &Path, is_clang: bool) -> Co
                 preprocessor_args.extend(arg.normalize(NormalizedDisposition::Concatenated).iter_os_strings())
             },
             Some(ProgramDatabase(_)) |
-            Some(DebugInfo(())) => {
+            Some(DebugInfo) => {
                 common_args.extend(arg.normalize(NormalizedDisposition::Concatenated).iter_os_strings())
             },
             _ => {}
@@ -327,14 +327,14 @@ pub fn parse_arguments(arguments: &[OsString], cwd: &Path, is_clang: bool) -> Co
         // Eagerly bail if it looks like we need to do more complicated work
         use compiler::gcc::ArgData::*;
         let args = match arg.get_data() {
-            Some(SplitDwarf(())) |
-            Some(ProfileGenerate(())) |
-            Some(TestCoverage(())) |
-            Some(Coverage(())) |
-            Some(DoCompilation(())) |
+            Some(SplitDwarf) |
+            Some(ProfileGenerate) |
+            Some(TestCoverage) |
+            Some(Coverage) |
+            Some(DoCompilation) |
             Some(Language(_)) |
             Some(Output(_)) |
-            Some(TooHardFlag(())) |
+            Some(TooHardFlag) |
             Some(TooHard(_)) => {
                 cannot_cache!(arg.flag_str().unwrap_or(
                     "Can't handle complex arguments through clang",
@@ -349,11 +349,11 @@ pub fn parse_arguments(arguments: &[OsString], cwd: &Path, is_clang: bool) -> Co
             }
             Some(PassThrough(_)) |
             Some(PassThroughPath(_)) => Some(&mut common_args),
-            Some(PreprocessorArgumentFlag(())) |
+            Some(PreprocessorArgumentFlag) |
             Some(PreprocessorArgument(_)) |
             Some(PreprocessorArgumentPath(_)) |
             Some(DepTarget(_)) |
-            Some(NeedDepTarget(())) => Some(&mut preprocessor_args),
+            Some(NeedDepTarget) => Some(&mut preprocessor_args),
         };
         if let Some(args) = args {
             // Normalize attributes such as "-I foo", "-D FOO=bar", as

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -71,7 +71,7 @@ pub struct RustHasher {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParsedArguments {
-    /// The full commandline, with arguments and their values as pairs.
+    /// The full commandline, with all parsed aguments
     arguments: Vec<Argument<ArgData>>,
     /// The location of compiler outputs.
     output_dir: PathBuf,
@@ -339,7 +339,7 @@ impl FromArg for ArgLinkLibrary {
             // If no kind is specified, the default is dylib.
             (name, None) => ("dylib".to_owned(), name),
         };
-        Ok(ArgLinkLibrary { kind: kind, name: name })
+        Ok(ArgLinkLibrary { kind, name })
     }
 }
 impl IntoArg for ArgLinkLibrary {
@@ -361,7 +361,7 @@ impl FromArg for ArgLinkPath {
             // If no kind is specified, the path is used to search for all kinds
             (path, None) => ("all".to_owned(), path),
         };
-        Ok(ArgLinkPath { kind: kind, path: path.into() })
+        Ok(ArgLinkPath { kind, path: path.into() })
     }
 }
 impl IntoArg for ArgLinkPath {
@@ -451,9 +451,9 @@ impl IntoArg for ArgTarget {
 }
 
 ArgData!{
-    TooHardFlag(()),
+    TooHardFlag,
     TooHardPath(PathBuf),
-    NotCompilationFlag(()),
+    NotCompilationFlag,
     NotCompilation(OsString),
     LinkLibrary(ArgLinkLibrary),
     LinkPath(ArgLinkPath),
@@ -524,13 +524,13 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
     for arg in ArgsIter::new(arguments.iter().map(|s| s.clone()), &ARGS[..]) {
         let arg = try_or_cannot_cache!(arg, "argument parse");
         match arg.get_data() {
-            Some(TooHardFlag(())) |
+            Some(TooHardFlag) |
             Some(TooHardPath(_)) => {
                 cannot_cache!(arg.flag_str().expect(
                     "Can't be Argument::Raw/UnknownFlag",
                 ))
             }
-            Some(NotCompilationFlag(())) |
+            Some(NotCompilationFlag) |
             Some(NotCompilation(_)) => return CompilerArguments::NotCompilation,
             Some(LinkLibrary(ArgLinkLibrary { kind, name })) => {
                 if kind == "static" {

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -394,7 +394,7 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
         let arg_str = arg.to_os_string();
         let value_str = match arg.get_data() {
             Some(v) => {
-                if let Ok(v) = v.clone().into_arg().into_string() {
+                if let Ok(v) = v.clone().into_os_string().into_string() {
                     Some(v)
                 } else {
                     cannot_cache!("not utf-8");
@@ -406,12 +406,12 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
         // strip colors if necessary.
         match arg.get_data() {
             Some(Color(_)) => {}
-            _ => args.push((arg_str, arg.get_data().map(|s| s.clone().into_arg()))),
+            _ => args.push((arg_str, arg.get_data().map(|s| s.clone().into_os_string()))),
         }
         match arg.get_data() {
             Some(TooHardFlag(())) |
             Some(TooHardPath(_)) => {
-                cannot_cache!(arg.to_str().expect(
+                cannot_cache!(arg.flag_str().expect(
                     "Can't be Argument::Raw/UnknownFlag",
                 ))
             }

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -317,59 +317,62 @@ impl<T> Compiler<T> for Rust
     }
 }
 
-#[derive(Clone, Debug)]
-enum RustArgAttribute {
-    TooHard,
-    NotCompilation,
-    LinkLibrary,
-    LinkPath,
-    Emit,
-    Extern,
-    Color,
-    CrateName,
-    CrateType,
-    OutDir,
-    CodeGen,
-    PassThrough,
+ArgData!{
+    TooHardFlag(()),
+    TooHardPath(PathBuf),
+    NotCompilationFlag(()),
+    NotCompilation(OsString),
+    LinkLibrary(PathBuf),
+    LinkPath(PathBuf),
+    Emit(OsString),
+    Extern(OsString),
+    Color(OsString),
+    CrateName(OsString),
+    CrateType(OsString),
+    OutDir(OsString),
+    CodeGen(OsString),
+    CodeGenPath(PathBuf),
+    PassThrough(OsString),
+    PassThroughPath(PathBuf),
 }
 
-use self::RustArgAttribute::*;
+use self::ArgData::*;
 
 // These are taken from https://github.com/rust-lang/rust/blob/b671c32ddc8c36d50866428d83b7716233356721/src/librustc/session/config.rs#L1186
-static ARGS: [(ArgInfo, RustArgAttribute); 33] = [
-    flag!("-", TooHard),
-    take_arg!("--allow", Path, CanBeSeparated('='), PassThrough),
-    take_arg!("--cap-lints", Path, CanBeSeparated('='), PassThrough),
-    take_arg!("--cfg", Path, CanBeSeparated('='), PassThrough),
-    take_arg!("--codegen", Path, CanBeSeparated('='), CodeGen),
-    take_arg!("--color", String, CanBeSeparated('='), Color),
-    take_arg!("--crate-name", String, CanBeSeparated('='), CrateName),
-    take_arg!("--crate-type", String, CanBeSeparated('='), CrateType),
-    take_arg!("--deny", Path, CanBeSeparated('='), PassThrough),
-    take_arg!("--emit", String, CanBeSeparated('='), Emit),
-    take_arg!("--error-format", String, CanBeSeparated('='), PassThrough),
-    take_arg!("--explain", String, CanBeSeparated('='), NotCompilation),
-    take_arg!("--extern", String, CanBeSeparated('='), Extern),
-    take_arg!("--forbid", Path, CanBeSeparated('='), PassThrough),
-    flag!("--help", NotCompilation),
-    take_arg!("--out-dir", String, CanBeSeparated('='), OutDir),
-    take_arg!("--pretty", String, CanBeSeparated('='), NotCompilation),
-    take_arg!("--print", String, CanBeSeparated('='), NotCompilation),
-    take_arg!("--sysroot", String, CanBeSeparated('='), NotCompilation),
-    take_arg!("--target", Path, CanBeSeparated('='), PassThrough),
-    take_arg!("--unpretty", String, CanBeSeparated('='), NotCompilation),
-    flag!("--version", NotCompilation),
-    take_arg!("--warn", Path, CanBeSeparated('='), PassThrough),
-    take_arg!("-A", String, CanBeSeparated, PassThrough),
-    take_arg!("-C", String, CanBeSeparated, CodeGen),
-    take_arg!("-D", String, CanBeSeparated, PassThrough),
-    take_arg!("-F", String, CanBeSeparated, PassThrough),
-    take_arg!("-L", Path, CanBeSeparated, LinkPath),
-    flag!("-V", NotCompilation),
-    take_arg!("-W", String, CanBeSeparated, PassThrough),
-    take_arg!("-Z", String, CanBeSeparated, PassThrough),
-    take_arg!("-l", Path, CanBeSeparated, LinkLibrary),
-    take_arg!("-o", Path, CanBeSeparated, TooHard),
+static ARGS: [ArgInfo<ArgData>; 33] = [
+    flag!("-", TooHardFlag),
+    take_arg!("--allow", PathBuf, CanBeSeparated('='), PassThroughPath),
+    take_arg!("--cap-lints", PathBuf, CanBeSeparated('='), PassThroughPath),
+    take_arg!("--cfg", PathBuf, CanBeSeparated('='), PassThroughPath),
+    take_arg!("--codegen", PathBuf, CanBeSeparated('='), CodeGenPath),
+    take_arg!("--color", OsString, CanBeSeparated('='), Color),
+    take_arg!("--crate-name", OsString, CanBeSeparated('='), CrateName),
+    take_arg!("--crate-type", OsString, CanBeSeparated('='), CrateType),
+    take_arg!("--deny", PathBuf, CanBeSeparated('='), PassThroughPath),
+    take_arg!("--emit", OsString, CanBeSeparated('='), Emit),
+    take_arg!("--error-format", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("--explain", OsString, CanBeSeparated('='), NotCompilation),
+    take_arg!("--extern", OsString, CanBeSeparated('='), Extern),
+    take_arg!("--forbid", PathBuf, CanBeSeparated('='), PassThroughPath),
+    flag!("--help", NotCompilationFlag),
+    take_arg!("--out-dir", OsString, CanBeSeparated('='), OutDir),
+    take_arg!("--pretty", OsString, CanBeSeparated('='), NotCompilation),
+    take_arg!("--print", OsString, CanBeSeparated('='), NotCompilation),
+    take_arg!("--sysroot", OsString, CanBeSeparated('='), NotCompilation),
+    take_arg!("--target", PathBuf, CanBeSeparated('='), PassThroughPath),
+    take_arg!("--unpretty", OsString, CanBeSeparated('='), NotCompilation),
+    flag!("--version", NotCompilationFlag),
+    take_arg!("--warn", PathBuf, CanBeSeparated('='), PassThroughPath),
+    take_arg!("-A", OsString, CanBeSeparated, PassThrough),
+    take_arg!("-C", OsString, CanBeSeparated, CodeGen),
+    take_arg!("-D", OsString, CanBeSeparated, PassThrough),
+    take_arg!("-F", OsString, CanBeSeparated, PassThrough),
+    take_arg!("-L", PathBuf, CanBeSeparated, LinkPath),
+    flag!("-V", NotCompilationFlag),
+    take_arg!("-W", OsString, CanBeSeparated, PassThrough),
+    take_arg!("-Z", OsString, CanBeSeparated, PassThrough),
+    take_arg!("-l", PathBuf, CanBeSeparated, LinkLibrary),
+    take_arg!("-o", PathBuf, CanBeSeparated, TooHardPath),
 ];
 
 fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<ParsedArguments>
@@ -386,11 +389,12 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
     let mut static_link_paths: Vec<PathBuf> = vec![];
     let mut color_mode = ColorMode::Auto;
 
-    for item in ArgsIter::new(arguments.iter().map(|s| s.clone()), &ARGS[..]) {
-        let arg = item.arg.to_os_string();
-        let value = match item.arg.get_value() {
+    for arg in ArgsIter::new(arguments.iter().map(|s| s.clone()), &ARGS[..]) {
+        let arg = try_arg!(arg.map_err(|e| e.static_description()));
+        let arg_str = arg.to_os_string();
+        let value_str = match arg.get_data() {
             Some(v) => {
-                if let Ok(v) = OsString::from(v).into_string() {
+                if let Ok(v) = v.clone().into_arg().into_string() {
                     Some(v)
                 } else {
                     return CompilerArguments::CannotCache("not utf-8");
@@ -400,23 +404,25 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
         };
         // We'll drop --color arguments, we're going to pass --color=always and the client will
         // strip colors if necessary.
-        match item.data {
-            Some(Color) => {}
-            _ => args.push((arg, item.arg.get_value().map(|s| s.into()))),
+        match arg.get_data() {
+            Some(Color(_)) => {}
+            _ => args.push((arg_str, arg.get_data().map(|s| s.clone().into_arg()))),
         }
-        match item.data {
-            Some(TooHard) => {
-                return CompilerArguments::CannotCache(item.arg.to_str().expect(
+        match arg.get_data() {
+            Some(TooHardFlag(())) |
+            Some(TooHardPath(_)) => {
+                return CompilerArguments::CannotCache(arg.to_str().expect(
                     "Can't be Argument::Raw/UnknownFlag",
                 ))
             }
-            Some(NotCompilation) => return CompilerArguments::NotCompilation,
-            Some(LinkLibrary) |
-            Some(LinkPath) => {
-                if let Some(v) = value {
+            Some(NotCompilationFlag(())) |
+            Some(NotCompilation(_)) => return CompilerArguments::NotCompilation,
+            Some(LinkLibrary(_)) |
+            Some(LinkPath(_)) => {
+                if let Some(v) = value_str {
                     let mut split_it = v.splitn(2, "=");
-                    match item.data {
-                        Some(LinkLibrary) => {
+                    match arg.get_data() {
+                        Some(LinkLibrary(_)) => {
                             let (libtype, lib) = match (split_it.next(), split_it.next()) {
                                 (Some(libtype), Some(lib)) => (libtype, lib),
                                 // If no kind is specified, the default is dylib.
@@ -428,7 +434,7 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
                                 static_lib_names.push(lib.to_string());
                             }
                         }
-                        Some(LinkPath) => {
+                        Some(LinkPath(_)) => {
                             match (split_it.next(), split_it.next()) {
                                 // For locating static libraries, we only care about `-L native=path`
                                 // and `-L path`.
@@ -444,34 +450,35 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
                     }
                 }
             }
-            Some(Emit) => {
+            Some(Emit(_)) => {
                 if emit.is_some() {
                     // We don't support passing --emit more than once.
                     return CompilerArguments::CannotCache("more than one --emit");
                 }
-                emit = value.map(|a| a.split(",").map(&str::to_owned).collect());
+                emit = value_str.map(|a| a.split(",").map(&str::to_owned).collect());
             }
-            Some(CrateType) => {
+            Some(CrateType(_)) => {
                 // We can't cache non-rlib/staticlib crates, because rustc invokes the
                 // system linker to link them, and we don't know about all the linker inputs.
-                if let Some(v) = value {
+                if let Some(v) = value_str {
                     if v.split(",").any(|t| t != "lib" && t != "rlib" && t != "staticlib") {
                         return CompilerArguments::CannotCache("crate-type");
                     }
                 }
             }
-            Some(CrateName) => crate_name = value,
-            Some(OutDir) => output_dir = value,
-            Some(Extern) => {
-                if let Some(val) = value {
+            Some(CrateName(_)) => crate_name = value_str,
+            Some(OutDir(_)) => output_dir = value_str,
+            Some(Extern(_)) => {
+                if let Some(val) = value_str {
                     if let Some(crate_file) = val.splitn(2, "=").nth(1) {
                         externs.push(PathBuf::from(crate_file));
                     }
                 }
             }
-            Some(CodeGen) => {
+            Some(CodeGen(_)) |
+            Some(CodeGenPath(_)) => {
                 // We want to capture some info from codegen options.
-                if let Some(codegen_arg) = value {
+                if let Some(codegen_arg) = value_str {
                     let mut split_it = codegen_arg.splitn(2, "=");
                     let name = split_it.next();
                     let val = split_it.next();
@@ -492,17 +499,18 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
                     }
                 }
             }
-            Some(Color) => {
+            Some(Color(_)) => {
                 // We'll just assume the last specified value wins.
-                color_mode = match value.as_ref().map(|s| s.as_ref()) {
+                color_mode = match value_str.as_ref().map(|s| s.as_ref()) {
                     Some("always") => ColorMode::On,
                     Some("never") => ColorMode::Off,
                     _ => ColorMode::Auto,
                 };
             }
-            Some(PassThrough) => {}
+            Some(PassThrough(_)) |
+            Some(PassThroughPath(_)) => {}
             None => {
-                match item.arg {
+                match arg {
                     Argument::Raw(ref val) => {
                         if input.is_some() {
                             // Can't cache compilations with multiple inputs.

--- a/src/dist/cache.rs
+++ b/src/dist/cache.rs
@@ -1,159 +1,174 @@
-use boxfnonce::BoxFnOnce;
-use config;
 use dist::Toolchain;
 use lru_disk_cache::{LruDiskCache, ReadSeek};
-use lru_disk_cache::Error as LruError;
 use lru_disk_cache::Result as LruResult;
 use ring::digest::{SHA512, Context};
-use serde_json;
-use std::collections::HashMap;
-use std::ffi::OsStr;
-use std::fs::{self, File};
-use std::io::{self, BufReader, Read, Write};
+use std::fs;
+use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
-use tempfile;
 use util;
 
 use errors::*;
 
-#[derive(Clone, Debug)]
-pub struct CustomToolchain {
-    archive: PathBuf,
-    compiler_executable: String,
-}
+#[cfg(feature = "dist-client")]
+pub use self::client::ClientToolchains;
 
-// TODO: possibly shouldn't be public
-pub struct ClientToolchains {
-    cache_dir: PathBuf,
-    cache: Mutex<TcCache>,
-    // Lookup from dist toolchain -> toolchain details
-    custom_toolchains: Mutex<HashMap<Toolchain, CustomToolchain>>,
-    // Lookup from local path -> toolchain details
-    custom_toolchain_paths: Mutex<HashMap<PathBuf, (CustomToolchain, Option<Toolchain>)>>,
-    // Local machine mapping from 'weak' hashes to strong toolchain hashes
-    // - Weak hashes are what sccache uses to determine if a compiler has changed
-    //   on the local machine - they're fast and 'good enough' (assuming we trust
-    //   the local machine), but not safe if other users can update the cache.
-    // - Strong hashes (or 'archive ids') are the hash of the complete compiler contents that
-    //   will be sent over the wire for use in distributed compilation - it is assumed
-    //   that if two of them match, the contents of a compiler archive cannot
-    //   have been tampered with
-    weak_map: Mutex<HashMap<String, String>>,
-}
+#[cfg(feature = "dist-client")]
+mod client {
+    use boxfnonce::BoxFnOnce;
+    use config;
+    use dist::Toolchain;
+    use lru_disk_cache::Error as LruError;
+    use serde_json;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::io::{self, Read, Write};
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+    use tempfile;
 
-impl ClientToolchains {
-    pub fn new(cache_dir: &Path, cache_size: u64, config_custom_toolchains: &[config::DistCustomToolchain]) -> Self {
-        let cache_dir = cache_dir.to_owned();
-        fs::create_dir_all(&cache_dir).unwrap();
+    use super::{TcCache, path_key};
+    use errors::*;
 
-        let toolchain_creation_dir = cache_dir.join("toolchain_tmp");
-        if toolchain_creation_dir.exists() {
-            fs::remove_dir_all(&toolchain_creation_dir).unwrap()
-        }
-        fs::create_dir(&toolchain_creation_dir).unwrap();
+    #[derive(Clone, Debug)]
+    pub struct CustomToolchain {
+        archive: PathBuf,
+        compiler_executable: String,
+    }
 
-        let weak_map_path = cache_dir.join("weak_map.json");
-        if !weak_map_path.exists() {
-            fs::File::create(&weak_map_path).unwrap().write_all(b"{}").unwrap()
-        }
-        let weak_map = serde_json::from_reader(fs::File::open(weak_map_path).unwrap()).unwrap();
+    // TODO: possibly shouldn't be public
+    #[cfg(feature = "dist-client")]
+    pub struct ClientToolchains {
+        cache_dir: PathBuf,
+        cache: Mutex<TcCache>,
+        // Lookup from dist toolchain -> toolchain details
+        custom_toolchains: Mutex<HashMap<Toolchain, CustomToolchain>>,
+        // Lookup from local path -> toolchain details
+        custom_toolchain_paths: Mutex<HashMap<PathBuf, (CustomToolchain, Option<Toolchain>)>>,
+        // Local machine mapping from 'weak' hashes to strong toolchain hashes
+        // - Weak hashes are what sccache uses to determine if a compiler has changed
+        //   on the local machine - they're fast and 'good enough' (assuming we trust
+        //   the local machine), but not safe if other users can update the cache.
+        // - Strong hashes (or 'archive ids') are the hash of the complete compiler contents that
+        //   will be sent over the wire for use in distributed compilation - it is assumed
+        //   that if two of them match, the contents of a compiler archive cannot
+        //   have been tampered with
+        weak_map: Mutex<HashMap<String, String>>,
+    }
 
-        let tc_cache_dir = cache_dir.join("tc");
-        let cache = Mutex::new(TcCache::new(&tc_cache_dir, cache_size).unwrap());
+    #[cfg(feature = "dist-client")]
+    impl ClientToolchains {
+        pub fn new(cache_dir: &Path, cache_size: u64, config_custom_toolchains: &[config::DistCustomToolchain]) -> Self {
+            let cache_dir = cache_dir.to_owned();
+            fs::create_dir_all(&cache_dir).unwrap();
 
-        let mut custom_toolchain_paths = HashMap::new();
-        for ct in config_custom_toolchains.into_iter() {
-            if custom_toolchain_paths.contains_key(&ct.compiler_executable) {
-                panic!("Multiple toolchains for {:?}", ct.compiler_executable)
+            let toolchain_creation_dir = cache_dir.join("toolchain_tmp");
+            if toolchain_creation_dir.exists() {
+                fs::remove_dir_all(&toolchain_creation_dir).unwrap()
             }
-            let config::DistCustomToolchain { compiler_executable, archive, archive_compiler_executable } = ct;
+            fs::create_dir(&toolchain_creation_dir).unwrap();
 
-            debug!("Registering custom toolchain for {:?}", compiler_executable);
-            let custom_tc = CustomToolchain {
-                archive: archive.clone(),
-                compiler_executable: archive_compiler_executable.clone(),
-            };
-            assert!(custom_toolchain_paths.insert(compiler_executable.clone(), (custom_tc, None)).is_none());
-        }
-        let custom_toolchain_paths = Mutex::new(custom_toolchain_paths);
-
-        Self {
-            cache_dir,
-            cache,
-            custom_toolchains: Mutex::new(HashMap::new()),
-            custom_toolchain_paths,
-            // TODO: shouldn't clear on restart, but also should have some
-            // form of pruning
-            weak_map: Mutex::new(weak_map),
-        }
-    }
-
-    // Get the bytes of a toolchain tar
-    // TODO: by this point the toolchain should be known to exist
-    pub fn get_toolchain(&self, tc: &Toolchain) -> Option<Vec<u8>> {
-        // TODO: be more relaxed about path casing and slashes on Windows
-        let mut rdr = if let Some(custom_tc) = self.custom_toolchains.lock().unwrap().get(tc) {
-            Box::new(fs::File::open(&custom_tc.archive).unwrap())
-        } else {
-            match self.cache.lock().unwrap().get(tc) {
-                Ok(rdr) => rdr,
-                Err(LruError::FileNotInCache) => return None,
-                Err(e) => panic!("{}", e),
+            let weak_map_path = cache_dir.join("weak_map.json");
+            if !weak_map_path.exists() {
+                fs::File::create(&weak_map_path).unwrap().write_all(b"{}").unwrap()
             }
-        };
-        let mut ret = vec![];
-        rdr.read_to_end(&mut ret).unwrap();
-        Some(ret)
-    }
-    // TODO: It's more correct to have a FnBox or Box<FnOnce> here
-    // If the toolchain doesn't already exist, create it and insert into the cache
-    pub fn put_toolchain(&self, compiler_path: &Path, weak_key: &str, create: BoxFnOnce<(fs::File,), io::Result<()>>) -> Result<(Toolchain, Option<String>)> {
-        if let Some(tc_and_compiler_path) = self.get_custom_toolchain(compiler_path) {
-            debug!("Using custom toolchain for {:?}", compiler_path);
-            let (tc, compiler_path) = tc_and_compiler_path.unwrap();
-            return Ok((tc, Some(compiler_path)))
-        }
-        if let Some(archive_id) = self.weak_to_strong(weak_key) {
-            debug!("Using cached toolchain {} -> {}", weak_key, archive_id);
-            return Ok((Toolchain { archive_id }, None))
-        }
-        debug!("Weak key {} appears to be new", weak_key);
-        // Only permit one toolchain creation at a time. Not an issue if there are multiple attempts
-        // to create the same toolchain, just a waste of time
-        let mut cache = self.cache.lock().unwrap();
-        let tmpfile = tempfile::NamedTempFile::new_in(self.cache_dir.join("toolchain_tmp"))?;
-        create.call(tmpfile.reopen()?)?;
-        let tc = cache.insert_file(tmpfile.path())?;
-        self.record_weak(weak_key.to_owned(), tc.archive_id.clone());
-        Ok((tc, None))
-    }
+            let weak_map = serde_json::from_reader(fs::File::open(weak_map_path).unwrap()).unwrap();
 
-    fn get_custom_toolchain(&self, compiler_path: &Path) -> Option<Result<(Toolchain, String)>> {
-        return match self.custom_toolchain_paths.lock().unwrap().get_mut(compiler_path) {
-            Some((custom_tc, Some(tc))) => Some(Ok((tc.clone(), custom_tc.compiler_executable.clone()))),
-            Some((custom_tc, maybe_tc @ None)) => {
-                let archive_id = match path_key(&custom_tc.archive) {
-                    Ok(archive_id) => archive_id,
-                    Err(e) => return Some(Err(e)),
+            let tc_cache_dir = cache_dir.join("tc");
+            let cache = Mutex::new(TcCache::new(&tc_cache_dir, cache_size).unwrap());
+
+            let mut custom_toolchain_paths = HashMap::new();
+            for ct in config_custom_toolchains.into_iter() {
+                if custom_toolchain_paths.contains_key(&ct.compiler_executable) {
+                    panic!("Multiple toolchains for {:?}", ct.compiler_executable)
+                }
+                let config::DistCustomToolchain { compiler_executable, archive, archive_compiler_executable } = ct;
+
+                debug!("Registering custom toolchain for {:?}", compiler_executable);
+                let custom_tc = CustomToolchain {
+                    archive: archive.clone(),
+                    compiler_executable: archive_compiler_executable.clone(),
                 };
-                let tc = Toolchain { archive_id };
-                *maybe_tc = Some(tc.clone());
-                assert!(self.custom_toolchains.lock().unwrap().insert(tc.clone(), custom_tc.clone()).is_none());
-                Some(Ok((tc, custom_tc.compiler_executable.clone())))
-            },
-            None => None,
-        }
-    }
+                assert!(custom_toolchain_paths.insert(compiler_executable.clone(), (custom_tc, None)).is_none());
+            }
+            let custom_toolchain_paths = Mutex::new(custom_toolchain_paths);
 
-    fn weak_to_strong(&self, weak_key: &str) -> Option<String> {
-        self.weak_map.lock().unwrap().get(weak_key).map(String::to_owned)
-    }
-    fn record_weak(&self, weak_key: String, key: String) {
-        let mut weak_map = self.weak_map.lock().unwrap();
-        weak_map.insert(weak_key, key);
-        let weak_map_path = self.cache_dir.join("weak_map.json");
-        serde_json::to_writer(fs::File::create(weak_map_path).unwrap(), &*weak_map).unwrap()
+            Self {
+                cache_dir,
+                cache,
+                custom_toolchains: Mutex::new(HashMap::new()),
+                custom_toolchain_paths,
+                // TODO: shouldn't clear on restart, but also should have some
+                // form of pruning
+                weak_map: Mutex::new(weak_map),
+            }
+        }
+
+        // Get the bytes of a toolchain tar
+        // TODO: by this point the toolchain should be known to exist
+        pub fn get_toolchain(&self, tc: &Toolchain) -> Option<Vec<u8>> {
+            // TODO: be more relaxed about path casing and slashes on Windows
+            let mut rdr = if let Some(custom_tc) = self.custom_toolchains.lock().unwrap().get(tc) {
+                Box::new(fs::File::open(&custom_tc.archive).unwrap())
+            } else {
+                match self.cache.lock().unwrap().get(tc) {
+                    Ok(rdr) => rdr,
+                    Err(LruError::FileNotInCache) => return None,
+                    Err(e) => panic!("{}", e),
+                }
+            };
+            let mut ret = vec![];
+            rdr.read_to_end(&mut ret).unwrap();
+            Some(ret)
+        }
+        // TODO: It's more correct to have a FnBox or Box<FnOnce> here
+        // If the toolchain doesn't already exist, create it and insert into the cache
+        pub fn put_toolchain(&self, compiler_path: &Path, weak_key: &str, create: BoxFnOnce<(fs::File,), io::Result<()>>) -> Result<(Toolchain, Option<String>)> {
+            if let Some(tc_and_compiler_path) = self.get_custom_toolchain(compiler_path) {
+                debug!("Using custom toolchain for {:?}", compiler_path);
+                let (tc, compiler_path) = tc_and_compiler_path.unwrap();
+                return Ok((tc, Some(compiler_path)))
+            }
+            if let Some(archive_id) = self.weak_to_strong(weak_key) {
+                debug!("Using cached toolchain {} -> {}", weak_key, archive_id);
+                return Ok((Toolchain { archive_id }, None))
+            }
+            debug!("Weak key {} appears to be new", weak_key);
+            // Only permit one toolchain creation at a time. Not an issue if there are multiple attempts
+            // to create the same toolchain, just a waste of time
+            let mut cache = self.cache.lock().unwrap();
+            let tmpfile = tempfile::NamedTempFile::new_in(self.cache_dir.join("toolchain_tmp"))?;
+            create.call(tmpfile.reopen()?)?;
+            let tc = cache.insert_file(tmpfile.path())?;
+            self.record_weak(weak_key.to_owned(), tc.archive_id.clone());
+            Ok((tc, None))
+        }
+
+        fn get_custom_toolchain(&self, compiler_path: &Path) -> Option<Result<(Toolchain, String)>> {
+            return match self.custom_toolchain_paths.lock().unwrap().get_mut(compiler_path) {
+                Some((custom_tc, Some(tc))) => Some(Ok((tc.clone(), custom_tc.compiler_executable.clone()))),
+                Some((custom_tc, maybe_tc @ None)) => {
+                    let archive_id = match path_key(&custom_tc.archive) {
+                        Ok(archive_id) => archive_id,
+                        Err(e) => return Some(Err(e)),
+                    };
+                    let tc = Toolchain { archive_id };
+                    *maybe_tc = Some(tc.clone());
+                    assert!(self.custom_toolchains.lock().unwrap().insert(tc.clone(), custom_tc.clone()).is_none());
+                    Some(Ok((tc, custom_tc.compiler_executable.clone())))
+                },
+                None => None,
+            }
+        }
+
+        fn weak_to_strong(&self, weak_key: &str) -> Option<String> {
+            self.weak_map.lock().unwrap().get(weak_key).map(String::to_owned)
+        }
+        fn record_weak(&self, weak_key: String, key: String) {
+            let mut weak_map = self.weak_map.lock().unwrap();
+            weak_map.insert(weak_key, key);
+            let weak_map_path = self.cache_dir.join("weak_map.json");
+            serde_json::to_writer(fs::File::create(weak_map_path).unwrap(), &*weak_map).unwrap()
+        }
     }
 }
 
@@ -171,7 +186,7 @@ impl TcCache {
         self.inner.contains_key(make_lru_key_path(&tc.archive_id))
     }
 
-    pub fn insert_with<F: FnOnce(File) -> io::Result<()>>(&mut self, tc: &Toolchain, with: F) -> Result<()> {
+    pub fn insert_with<F: FnOnce(fs::File) -> io::Result<()>>(&mut self, tc: &Toolchain, with: F) -> Result<()> {
         self.inner.insert_with(make_lru_key_path(&tc.archive_id), with).map_err(|e| -> Error { e.into() })?;
         let verified_archive_id = file_key(self.get(tc)?)?;
         // TODO: remove created toolchain?
@@ -182,15 +197,17 @@ impl TcCache {
         self.inner.get(make_lru_key_path(&tc.archive_id))
     }
 
-    fn insert_file<P: AsRef<OsStr>>(&mut self, path: P) -> Result<Toolchain> {
+    #[cfg(feature = "dist-client")]
+    fn insert_file(&mut self, path: &Path) -> Result<Toolchain> {
         let archive_id = path_key(&path)?;
         self.inner.insert_file(make_lru_key_path(&archive_id), path).map_err(|e| -> Error { e.into() })?;
         Ok(Toolchain { archive_id })
     }
 }
 
-fn path_key<P: AsRef<OsStr>>(path: P) -> Result<String> {
-    file_key(File::open(path.as_ref())?)
+#[cfg(feature = "dist-client")]
+fn path_key(path: &Path) -> Result<String> {
+    file_key(fs::File::open(path)?)
 }
 fn file_key<RS: ReadSeek + 'static>(rs: RS) -> Result<String> {
     hash_reader(rs)

--- a/src/dist/cache.rs
+++ b/src/dist/cache.rs
@@ -43,7 +43,7 @@ pub struct ClientToolchains {
 }
 
 impl ClientToolchains {
-    pub fn new(cache_dir: &Path, cache_size: u64, config_custom_toolchains: &[config::CustomToolchain]) -> Self {
+    pub fn new(cache_dir: &Path, cache_size: u64, config_custom_toolchains: &[config::DistCustomToolchain]) -> Self {
         let cache_dir = cache_dir.to_owned();
         fs::create_dir_all(&cache_dir).unwrap();
 
@@ -67,7 +67,7 @@ impl ClientToolchains {
             if custom_toolchain_paths.contains_key(&ct.compiler_executable) {
                 panic!("Multiple toolchains for {:?}", ct.compiler_executable)
             }
-            let config::CustomToolchain { compiler_executable, archive, archive_compiler_executable } = ct;
+            let config::DistCustomToolchain { compiler_executable, archive, archive_compiler_executable } = ct;
 
             debug!("Registering custom toolchain for {:?}", compiler_executable);
             let custom_tc = CustomToolchain {

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -11,556 +11,609 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![allow(unused)]
 
-use bincode;
-use boxfnonce::BoxFnOnce;
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use config;
-use jwt;
-use futures::{Future, Stream};
-use num_cpus;
-use rand::{self, Rng};
-use reqwest;
-use rouille;
-use serde;
-use serde_json;
-use std;
-use std::fs;
-use std::io::{self, Read, Write};
-use std::net::{IpAddr, SocketAddr};
-use std::path::Path;
-use std::thread;
-use std::time::Duration;
-use super::cache;
-use super::{
-    ServerId, JobId, Toolchain, CompileCommand,
-    ToolchainReader, InputsReader,
+#[cfg(feature = "dist-client")]
+pub use self::client::Client;
+#[cfg(feature = "dist-server")]
+pub use self::server::Scheduler;
+#[cfg(feature = "dist-server")]
+pub use self::server::Server;
 
-    AllocJobResult, JobAlloc,
-    AssignJobResult,
-    HeartbeatServerResult,
-    RunJobResult,
-    StatusResult,
-    SubmitToolchainResult,
-    UpdateJobStateResult, JobState,
+//#[allow(unused)]
+mod common {
+    use bincode;
+    use futures::{Future, Stream};
+    use reqwest;
+    use serde;
+    use std::net::{IpAddr, SocketAddr};
+    use dist::{JobId, CompileCommand};
 
-    SchedulerIncoming, SchedulerOutgoing,
-    ServerIncoming, ServerOutgoing,
-};
-use tokio_core;
+    use errors::*;
 
-use errors::*;
+    const SCHEDULER_PORT: u16 = 10500;
+    const SERVER_PORT: u16 = 10501;
 
-const SCHEDULER_PORT: u16 = 10500;
-const SERVER_PORT: u16 = 10501;
+    // TODO: move this into the config module
+    pub struct Cfg;
 
-const JWT_KEY_LENGTH: usize = 256 / 8;
-lazy_static!{
-    static ref JWT_HEADER: jwt::Header = jwt::Header::new(jwt::Algorithm::HS256);
-    static ref JWT_VALIDATION: jwt::Validation = jwt::Validation::new(jwt::Algorithm::HS256);
-}
+    impl Cfg {
+        pub fn scheduler_listen_addr() -> SocketAddr {
+            let ip_addr = "0.0.0.0".parse().unwrap();
+            SocketAddr::new(ip_addr, SCHEDULER_PORT)
+        }
+        pub fn scheduler_connect_addr(scheduler_addr: IpAddr) -> SocketAddr {
+            SocketAddr::new(scheduler_addr, SCHEDULER_PORT)
+        }
 
-// TODO: move this into the config module
-struct Cfg;
-
-impl Cfg {
-    fn scheduler_listen_addr() -> SocketAddr {
-        let ip_addr = "0.0.0.0".parse().unwrap();
-        SocketAddr::new(ip_addr, SCHEDULER_PORT)
-    }
-    fn scheduler_connect_addr(scheduler_addr: IpAddr) -> SocketAddr {
-        SocketAddr::new(scheduler_addr, SCHEDULER_PORT)
-    }
-
-    fn server_listen_addr() -> SocketAddr {
-        let ip_addr = "0.0.0.0".parse().unwrap();
-        SocketAddr::new(ip_addr, SERVER_PORT)
-    }
-}
-
-// Based on rouille::input::json::json_input
-#[derive(Debug)]
-pub enum RouilleBincodeError {
-    BodyAlreadyExtracted,
-    WrongContentType,
-    ParseError(bincode::Error),
-}
-impl From<bincode::Error> for RouilleBincodeError {
-    fn from(err: bincode::Error) -> RouilleBincodeError {
-        RouilleBincodeError::ParseError(err)
-    }
-}
-impl std::error::Error for RouilleBincodeError {
-    fn description(&self) -> &str {
-        match *self {
-            RouilleBincodeError::BodyAlreadyExtracted => {
-                "the body of the request was already extracted"
-            },
-            RouilleBincodeError::WrongContentType => {
-                "the request didn't have a binary content type"
-            },
-            RouilleBincodeError::ParseError(_) => {
-                "error while parsing the bincode body"
-            },
+        pub fn server_listen_addr() -> SocketAddr {
+            let ip_addr = "0.0.0.0".parse().unwrap();
+            SocketAddr::new(ip_addr, SERVER_PORT)
         }
     }
-    fn cause(&self) -> Option<&std::error::Error> {
-        match *self {
-            RouilleBincodeError::ParseError(ref e) => Some(e),
-            _ => None
+
+    // Note that content-length is necessary due to https://github.com/tiny-http/tiny-http/issues/147
+    pub trait ReqwestRequestBuilderExt {
+        fn bincode<T: serde::Serialize + ?Sized>(&mut self, bincode: &T) -> Result<&mut Self>;
+        fn bytes(&mut self, bytes: Vec<u8>) -> &mut Self;
+        fn bearer_auth(&mut self, token: String) -> &mut Self;
+    }
+    impl ReqwestRequestBuilderExt for reqwest::RequestBuilder {
+        fn bincode<T: serde::Serialize + ?Sized>(&mut self, bincode: &T) -> Result<&mut Self> {
+            let bytes = bincode::serialize(bincode, bincode::Infinite)?;
+            Ok(self.bytes(bytes))
+        }
+        fn bytes(&mut self, bytes: Vec<u8>) -> &mut Self {
+            self.header(reqwest::header::ContentType::octet_stream())
+                .header(reqwest::header::ContentLength(bytes.len() as u64))
+                .body(bytes)
+        }
+        fn bearer_auth(&mut self, token: String) -> &mut Self {
+            self.header(reqwest::header::Authorization(reqwest::header::Bearer { token }))
         }
     }
-}
-impl std::fmt::Display for RouilleBincodeError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
-        write!(fmt, "{}", std::error::Error::description(self))
+    impl ReqwestRequestBuilderExt for reqwest::unstable::async::RequestBuilder {
+        fn bincode<T: serde::Serialize + ?Sized>(&mut self, bincode: &T) -> Result<&mut Self> {
+            let bytes = bincode::serialize(bincode, bincode::Infinite)?;
+            Ok(self.bytes(bytes))
+        }
+        fn bytes(&mut self, bytes: Vec<u8>) -> &mut Self {
+            self.header(reqwest::header::ContentType::octet_stream())
+                .header(reqwest::header::ContentLength(bytes.len() as u64))
+                .body(bytes)
+        }
+        fn bearer_auth(&mut self, token: String) -> &mut Self {
+            self.header(reqwest::header::Authorization(reqwest::header::Bearer { token }))
+        }
+    }
+
+    pub fn bincode_req<T: serde::de::DeserializeOwned + 'static>(req: &mut reqwest::RequestBuilder) -> Result<T> {
+        let mut res = req.send()?;
+        let status = res.status();
+        let mut body = vec![];
+        res.copy_to(&mut body).unwrap();
+        if !status.is_success() {
+            Err(format!("Error {} (Headers={:?}): {}", status.as_u16(), res.headers(), String::from_utf8_lossy(&body)).into())
+        } else {
+            bincode::deserialize(&body).map_err(Into::into)
+        }
+    }
+    pub fn bincode_req_fut<T: serde::de::DeserializeOwned + 'static>(req: &mut reqwest::unstable::async::RequestBuilder) -> SFuture<T> {
+        Box::new(req.send().map_err(Into::into)
+            .and_then(|res| {
+                let status = res.status();
+                res.into_body().concat2()
+                    .map(move |b| (status, b)).map_err(Into::into)
+            })
+            .and_then(|(status, body)| {
+                if !status.is_success() {
+                    return f_err(format!("Error {}: {}", status.as_u16(), String::from_utf8_lossy(&body)))
+                }
+                match bincode::deserialize(&body) {
+                    Ok(r) => f_ok(r),
+                    Err(e) => f_err(e),
+                }
+            }))
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[derive(Eq, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    pub struct JobJwt {
+        pub job_id: JobId,
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct HeartbeatServerHttpRequest {
+        pub client_jwt_key: Vec<u8>,
+        pub num_cpus: usize,
+    }
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct RunJobHttpRequest {
+        pub command: CompileCommand,
+        pub outputs: Vec<String>,
     }
 }
-fn bincode_input<O>(request: &rouille::Request) -> std::result::Result<O, RouilleBincodeError> where O: serde::de::DeserializeOwned {
-    if let Some(header) = request.header("Content-Type") {
-        if !header.starts_with("application/octet-stream") {
+
+#[cfg(feature = "dist-server")]
+mod server {
+    use bincode;
+    use byteorder::{BigEndian, ReadBytesExt};
+    use jwt;
+    use num_cpus;
+    use rand::{self, Rng};
+    use reqwest;
+    use rouille;
+    use serde;
+    use serde_json;
+    use std;
+    use std::io::Read;
+    use std::net::{IpAddr, SocketAddr};
+    use std::thread;
+    use std::time::Duration;
+
+    use dist::{
+        self,
+
+        ServerId, JobId, Toolchain,
+        ToolchainReader, InputsReader,
+
+        AllocJobResult,
+        AssignJobResult,
+        HeartbeatServerResult,
+        RunJobResult,
+        StatusResult,
+        SubmitToolchainResult,
+        UpdateJobStateResult, JobState,
+    };
+    use super::common::{
+        Cfg,
+        ReqwestRequestBuilderExt,
+        bincode_req,
+
+        JobJwt,
+        HeartbeatServerHttpRequest,
+        RunJobHttpRequest,
+    };
+    use errors::*;
+
+    const JWT_KEY_LENGTH: usize = 256 / 8;
+    lazy_static!{
+        static ref JWT_HEADER: jwt::Header = jwt::Header::new(jwt::Algorithm::HS256);
+        static ref JWT_VALIDATION: jwt::Validation = jwt::Validation::new(jwt::Algorithm::HS256);
+    }
+
+    // Based on rouille::input::json::json_input
+    #[derive(Debug)]
+    pub enum RouilleBincodeError {
+        BodyAlreadyExtracted,
+        WrongContentType,
+        ParseError(bincode::Error),
+    }
+    impl From<bincode::Error> for RouilleBincodeError {
+        fn from(err: bincode::Error) -> RouilleBincodeError {
+            RouilleBincodeError::ParseError(err)
+        }
+    }
+    impl std::error::Error for RouilleBincodeError {
+        fn description(&self) -> &str {
+            match *self {
+                RouilleBincodeError::BodyAlreadyExtracted => {
+                    "the body of the request was already extracted"
+                },
+                RouilleBincodeError::WrongContentType => {
+                    "the request didn't have a binary content type"
+                },
+                RouilleBincodeError::ParseError(_) => {
+                    "error while parsing the bincode body"
+                },
+            }
+        }
+        fn cause(&self) -> Option<&std::error::Error> {
+            match *self {
+                RouilleBincodeError::ParseError(ref e) => Some(e),
+                _ => None
+            }
+        }
+    }
+    impl std::fmt::Display for RouilleBincodeError {
+        fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
+            write!(fmt, "{}", std::error::Error::description(self))
+        }
+    }
+    fn bincode_input<O>(request: &rouille::Request) -> std::result::Result<O, RouilleBincodeError> where O: serde::de::DeserializeOwned {
+        if let Some(header) = request.header("Content-Type") {
+            if !header.starts_with("application/octet-stream") {
+                return Err(RouilleBincodeError::WrongContentType);
+            }
+        } else {
             return Err(RouilleBincodeError::WrongContentType);
         }
-    } else {
-        return Err(RouilleBincodeError::WrongContentType);
-    }
 
-    if let Some(mut b) = request.data() {
-        bincode::deserialize_from::<_, O, _>(&mut b, bincode::Infinite).map_err(From::from)
-    } else {
-        Err(RouilleBincodeError::BodyAlreadyExtracted)
-    }
-}
-
-// Based on rouille::Response::json
-pub fn bincode_response<T>(content: &T) -> rouille::Response where T: serde::Serialize {
-    let data = bincode::serialize(content, bincode::Infinite).unwrap();
-
-    rouille::Response {
-        status_code: 200,
-        headers: vec![("Content-Type".into(), "application/octet-stream".into())],
-        data: rouille::ResponseBody::from_data(data),
-        upgrade: None,
-    }
-}
-
-// Based on try_or_400 in rouille
-#[derive(Serialize)]
-pub struct ErrJson<'a> {
-    description: &'a str,
-    cause: Option<Box<ErrJson<'a>>>,
-}
-
-impl<'a> ErrJson<'a> {
-    fn from_err<E: ?Sized + std::error::Error>(err: &'a E) -> ErrJson<'a> {
-        let cause = err.cause().map(ErrJson::from_err).map(Box::new);
-        ErrJson { description: err.description(), cause }
-    }
-    fn into_data(self) -> String {
-        serde_json::to_string(&self).unwrap()
-    }
-}
-macro_rules! try_or_500 {
-    ($result:expr) => (
-        match $result {
-            Ok(r) => r,
-            Err(err) => {
-                let json = ErrJson::from_err(&err);
-                return rouille::Response::json(&json).with_status_code(500)
-            },
-        }
-    );
-}
-fn make_401(short_err: &str) -> rouille::Response {
-    rouille::Response {
-        status_code: 401,
-        headers: vec![("WWW-Authenticate".into(), format!("Bearer error=\"{}\"", short_err).into())],
-        data: rouille::ResponseBody::empty(),
-        upgrade: None,
-    }
-}
-fn bearer_http_auth(request: &rouille::Request) -> Option<&str> {
-    let header = request.header("Authorization")?;
-
-    let mut split = header.splitn(2, |c| c == ' ');
-
-    let authtype = split.next()?;
-    if authtype != "Bearer" {
-        return None
-    }
-
-    split.next()
-}
-macro_rules! try_jwt_or_401 {
-    ($request:ident, $key:expr, $valid_claims:expr) => {{
-        let claims: Result<_> = match bearer_http_auth($request) {
-            Some(token) => {
-                jwt::decode(&token, $key, &JWT_VALIDATION)
-                    .map_err(Into::into)
-                    .and_then(|res| {
-                        fn identical_t<T>(_: &T, _: &T) {}
-                        let valid_claims = $valid_claims;
-                        identical_t(&res.claims, &valid_claims);
-                        if res.claims == valid_claims { Ok(()) } else { Err("invalid claims".into()) }
-                    })
-            },
-            None => Err("no Authorization header".into()),
-        };
-        match claims {
-            Ok(()) => (),
-            Err(err) => {
-                let json = ErrJson::from_err(&err);
-                let mut res = make_401("invalid_jwt");
-                res.data = rouille::ResponseBody::from_data(json.into_data());
-                return res
-            },
-        }
-    }};
-}
-
-// Note that content-length is necessary due to https://github.com/tiny-http/tiny-http/issues/147
-trait ReqwestRequestBuilderExt {
-    fn bincode<T: serde::Serialize + ?Sized>(&mut self, bincode: &T) -> Result<&mut Self>;
-    fn bytes(&mut self, bytes: Vec<u8>) -> &mut Self;
-    fn bearer_auth(&mut self, token: String) -> &mut Self;
-}
-impl ReqwestRequestBuilderExt for reqwest::RequestBuilder {
-    fn bincode<T: serde::Serialize + ?Sized>(&mut self, bincode: &T) -> Result<&mut Self> {
-        let bytes = bincode::serialize(bincode, bincode::Infinite)?;
-        Ok(self.bytes(bytes))
-    }
-    fn bytes(&mut self, bytes: Vec<u8>) -> &mut Self {
-        self.header(reqwest::header::ContentType::octet_stream())
-            .header(reqwest::header::ContentLength(bytes.len() as u64))
-            .body(bytes)
-    }
-    fn bearer_auth(&mut self, token: String) -> &mut Self {
-        self.header(reqwest::header::Authorization(reqwest::header::Bearer { token }))
-    }
-}
-impl ReqwestRequestBuilderExt for reqwest::unstable::async::RequestBuilder {
-    fn bincode<T: serde::Serialize + ?Sized>(&mut self, bincode: &T) -> Result<&mut Self> {
-        let bytes = bincode::serialize(bincode, bincode::Infinite)?;
-        Ok(self.bytes(bytes))
-    }
-    fn bytes(&mut self, bytes: Vec<u8>) -> &mut Self {
-        self.header(reqwest::header::ContentType::octet_stream())
-            .header(reqwest::header::ContentLength(bytes.len() as u64))
-            .body(bytes)
-    }
-    fn bearer_auth(&mut self, token: String) -> &mut Self {
-        self.header(reqwest::header::Authorization(reqwest::header::Bearer { token }))
-    }
-}
-
-fn bincode_req<T: serde::de::DeserializeOwned + 'static>(req: &mut reqwest::RequestBuilder) -> Result<T> {
-    let mut res = req.send()?;
-    let status = res.status();
-    let mut body = vec![];
-    res.copy_to(&mut body).unwrap();
-    if !status.is_success() {
-        Err(format!("Error {} (Headers={:?}): {}", status.as_u16(), res.headers(), String::from_utf8_lossy(&body)).into())
-    } else {
-        bincode::deserialize(&body).map_err(Into::into)
-    }
-}
-
-fn bincode_req_fut<T: serde::de::DeserializeOwned + 'static>(req: &mut reqwest::unstable::async::RequestBuilder) -> SFuture<T> {
-    Box::new(req.send().map_err(Into::into)
-        .and_then(|res| {
-            let status = res.status();
-            res.into_body().concat2()
-                .map(move |b| (status, b)).map_err(Into::into)
-        })
-        .and_then(|(status, body)| {
-            if !status.is_success() {
-                return f_err(format!("Error {}: {}", status.as_u16(), String::from_utf8_lossy(&body)))
-            }
-            match bincode::deserialize(&body) {
-                Ok(r) => f_ok(r),
-                Err(e) => f_err(e),
-            }
-        }))
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[derive(Eq, PartialEq)]
-#[serde(deny_unknown_fields)]
-struct JobJwt {
-    job_id: JobId,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct HeartbeatServerHttpRequest {
-    client_jwt_key: Vec<u8>,
-    num_cpus: usize,
-}
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RunJobHttpRequest {
-    command: CompileCommand,
-    outputs: Vec<String>,
-}
-
-pub struct Scheduler<S> {
-    handler: S,
-    // Is this client permitted to use the scheduler?
-    check_client_auth: Box<Fn(&str) -> bool + Send + Sync>,
-    // Do we believe the server is who they appear to be?
-    check_server_auth: Box<Fn(&str) -> Option<ServerId> + Send + Sync>,
-}
-
-impl<S: SchedulerIncoming + 'static> Scheduler<S> {
-    pub fn new(handler: S, check_client_auth: Box<Fn(&str) -> bool + Send + Sync>, check_server_auth: Box<Fn(&str) -> Option<ServerId> + Send + Sync>) -> Self {
-        Self { handler, check_client_auth, check_server_auth }
-    }
-
-    pub fn start(self) -> ! {
-        let Self { handler, check_client_auth, check_server_auth } = self;
-        let requester = SchedulerRequester { client: reqwest::Client::new() };
-        let addr = Cfg::scheduler_listen_addr();
-
-        macro_rules! check_server_auth_or_401 {
-            ($request:ident) => {{
-                match bearer_http_auth($request).and_then(&*check_server_auth) {
-                    Some(server_id) if server_id.addr().ip() == $request.remote_addr().ip() => server_id,
-                    Some(_) => return make_401("invalid_bearer_token_mismatched_address"),
-                    None => return make_401("invalid_bearer_token"),
-                }}
-            };
-        }
-
-        info!("Scheduler listening for clients on {}", addr);
-        let server = rouille::Server::new(addr, move |request| {
-            let request_id = request.remote_addr();
-            trace!("Req {}: {:?}", request_id, request);
-            let response = (|| router!(request,
-                (POST) (/api/v1/scheduler/alloc_job) => {
-                    if !bearer_http_auth(request).map_or(false, &*check_client_auth) {
-                        return make_401("invalid_bearer_token")
-                    }
-                    let toolchain = try_or_400!(bincode_input(request));
-                    trace!("Req {}: alloc_job: {:?}", request_id, toolchain);
-
-                    let res: AllocJobResult = try_or_500!(handler.handle_alloc_job(&requester, toolchain));
-                    bincode_response(&res)
-                },
-                (POST) (/api/v1/scheduler/heartbeat_server) => {
-                    let server_id = check_server_auth_or_401!(request);
-                    let heartbeat_server = try_or_400!(bincode_input(request));
-                    trace!("Req {}: heartbeat_server: {:?}", request_id, heartbeat_server);
-
-                    let HeartbeatServerHttpRequest { num_cpus, client_jwt_key } = heartbeat_server;
-                    let generate_job_auth = Box::new(move |job_id| {
-                        let claims = JobJwt { job_id };
-                        jwt::encode(&JWT_HEADER, &claims, &client_jwt_key).unwrap()
-                    });
-                    let res: HeartbeatServerResult = handler.handle_heartbeat_server(server_id, num_cpus, generate_job_auth).unwrap();
-                    bincode_response(&res)
-                },
-                (POST) (/api/v1/scheduler/job_state/{job_id: JobId}) => {
-                    let server_id = check_server_auth_or_401!(request);
-                    let job_state = try_or_400!(bincode_input(request));
-                    trace!("Req {}: job state: {:?}", request_id, job_state);
-
-                    let res: UpdateJobStateResult = handler.handle_update_job_state(job_id, server_id, job_state).unwrap();
-                    bincode_response(&res)
-                },
-                (GET) (/api/v1/scheduler/status) => {
-                    let res: StatusResult = handler.handle_status().unwrap();
-                    bincode_response(&res)
-                },
-                _ => {
-                    warn!("Unknown request {:?}", request);
-                    rouille::Response::empty_404()
-                },
-            )) ();
-            trace!("Res {}: {:?}", request_id, response);
-            response
-        }).unwrap();
-        server.run();
-
-        unreachable!()
-    }
-}
-
-struct SchedulerRequester {
-    client: reqwest::Client,
-}
-
-impl SchedulerOutgoing for SchedulerRequester {
-    fn do_assign_job(&self, server_id: ServerId, job_id: JobId, tc: Toolchain, auth: String) -> Result<AssignJobResult> {
-        let url = format!("http://{}/api/v1/distserver/assign_job/{}", server_id.addr(), job_id);
-        bincode_req(self.client.post(&url).bearer_auth(auth).bincode(&tc)?)
-    }
-}
-
-pub struct Server<S> {
-    scheduler_addr: SocketAddr,
-    scheduler_auth: String,
-    handler: S,
-    client_jwt_key: Vec<u8>,
-}
-
-impl<S: ServerIncoming + 'static> Server<S> {
-    pub fn new(scheduler_addr: IpAddr, scheduler_auth: String, handler: S) -> Self {
-        let mut client_jwt_key = vec![0; JWT_KEY_LENGTH];
-        let mut rng = rand::OsRng::new().unwrap();
-        rng.fill_bytes(&mut client_jwt_key);
-        Self {
-            scheduler_addr: Cfg::scheduler_connect_addr(scheduler_addr),
-            scheduler_auth,
-            client_jwt_key,
-            handler,
-        }
-    }
-
-    pub fn start(self) -> ! {
-        let Self { scheduler_addr, scheduler_auth, client_jwt_key, handler } = self;
-        let requester = ServerRequester { client: reqwest::Client::new(), scheduler_addr, scheduler_auth: scheduler_auth.clone() };
-        let addr = Cfg::server_listen_addr();
-
-        // TODO: detect if this panics
-        let heartbeat_req = HeartbeatServerHttpRequest { num_cpus: num_cpus::get(), client_jwt_key: client_jwt_key.clone() };
-        thread::spawn(move || {
-            let url = format!("http://{}:{}/api/v1/scheduler/heartbeat_server", scheduler_addr.ip(), scheduler_addr.port());
-            let client = reqwest::Client::new();
-            loop {
-                trace!("Performing heartbeat");
-                match bincode_req(client.post(&url).bearer_auth(scheduler_auth.clone()).bincode(&heartbeat_req).unwrap()) {
-                    Ok(HeartbeatServerResult { is_new }) => {
-                        trace!("Heartbeat success is_new={}", is_new);
-                        // TODO: if is_new, terminate all running jobs
-                        thread::sleep(Duration::from_secs(30))
-                    },
-                    Err(e) => {
-                        error!("Failed to send heartbeat to server: {}", e);
-                        thread::sleep(Duration::from_secs(10))
-                    },
-                }
-            }
-        });
-
-        info!("Server listening for clients on {}", addr);
-        let server = rouille::Server::new(addr, move |request| {
-            let request_id = request.remote_addr();
-            trace!("Req {}: {:?}", request_id, request);
-            let response = (|| router!(request,
-                (POST) (/api/v1/distserver/assign_job/{job_id: JobId}) => {
-                    try_jwt_or_401!(request, &client_jwt_key, JobJwt { job_id });
-                    let toolchain = try_or_400!(bincode_input(request));
-                    trace!("Req {}: assign_job({}): {:?}", request_id, job_id, toolchain);
-
-                    let res: AssignJobResult = try_or_500!(handler.handle_assign_job(job_id, toolchain));
-                    bincode_response(&res)
-                },
-                (POST) (/api/v1/distserver/submit_toolchain/{job_id: JobId}) => {
-                    try_jwt_or_401!(request, &client_jwt_key, JobJwt { job_id });
-                    trace!("Req {}: submit_toolchain({})", request_id, job_id);
-
-                    let mut body = request.data().unwrap();
-                    let toolchain_rdr = ToolchainReader(Box::new(body));
-                    let res: SubmitToolchainResult = try_or_500!(handler.handle_submit_toolchain(&requester, job_id, toolchain_rdr));
-                    bincode_response(&res)
-                },
-                (POST) (/api/v1/distserver/run_job/{job_id: JobId}) => {
-                    try_jwt_or_401!(request, &client_jwt_key, JobJwt { job_id });
-
-                    let mut body = request.data().unwrap();
-                    let bincode_length = body.read_u32::<BigEndian>().unwrap() as u64;
-
-                    let mut bincode_reader = body.take(bincode_length);
-                    let runjob = bincode::deserialize_from(&mut bincode_reader, bincode::Infinite).unwrap();
-                    trace!("Req {}: run_job({}): {:?}", request_id, job_id, runjob);
-                    let RunJobHttpRequest { command, outputs } = runjob;
-                    let body = bincode_reader.into_inner();
-                    let inputs_rdr = InputsReader(Box::new(body));
-                    let outputs = outputs.into_iter().collect();
-
-                    let res: RunJobResult = try_or_500!(handler.handle_run_job(&requester, job_id, command, outputs, inputs_rdr));
-                    bincode_response(&res)
-                },
-                _ => {
-                    warn!("Unknown request {:?}", request);
-                    rouille::Response::empty_404()
-                },
-            ))();
-            trace!("Res {}: {:?}", request_id, response);
-            response
-        }).unwrap();
-        server.run();
-
-        unreachable!()
-    }
-}
-
-struct ServerRequester {
-    client: reqwest::Client,
-    scheduler_addr: SocketAddr,
-    scheduler_auth: String,
-}
-
-impl ServerOutgoing for ServerRequester {
-    fn do_update_job_state(&self, job_id: JobId, state: JobState) -> Result<UpdateJobStateResult> {
-        let url = format!("http://{}/api/v1/scheduler/job_state/{}", self.scheduler_addr, job_id);
-        bincode_req(self.client.post(&url).bearer_auth(self.scheduler_auth.clone()).bincode(&state)?)
-    }
-}
-
-pub struct Client {
-    auth: &'static config::DistAuth,
-    scheduler_addr: SocketAddr,
-    client: reqwest::unstable::async::Client,
-    tc_cache: cache::ClientToolchains,
-}
-
-impl Client {
-    pub fn new(handle: &tokio_core::reactor::Handle, scheduler_addr: IpAddr, cache_dir: &Path, cache_size: u64, custom_toolchains: &[config::DistCustomToolchain], auth: &'static config::DistAuth) -> Self {
-        Self {
-            auth,
-            scheduler_addr: Cfg::scheduler_connect_addr(scheduler_addr),
-            client: reqwest::unstable::async::Client::new(handle),
-            tc_cache: cache::ClientToolchains::new(cache_dir, cache_size, custom_toolchains),
-        }
-    }
-}
-
-impl super::Client for Client {
-    fn do_alloc_job(&self, tc: Toolchain) -> SFuture<AllocJobResult> {
-        let token = match self.auth {
-            config::DistAuth::Token { token } => token,
-        };
-        let url = format!("http://{}/api/v1/scheduler/alloc_job", self.scheduler_addr);
-        Box::new(f_res(self.client.post(&url).bearer_auth(token.to_owned()).bincode(&tc).map(bincode_req_fut)).and_then(|r| r))
-    }
-    fn do_submit_toolchain(&self, job_alloc: JobAlloc, tc: Toolchain) -> SFuture<SubmitToolchainResult> {
-        let url = format!("http://{}/api/v1/distserver/submit_toolchain/{}", job_alloc.server_id.addr(), job_alloc.job_id);
-        if let Some(toolchain_bytes) = self.tc_cache.get_toolchain(&tc) {
-            bincode_req_fut(self.client.post(&url).bearer_auth(job_alloc.auth.clone()).bytes(toolchain_bytes))
+        if let Some(mut b) = request.data() {
+            bincode::deserialize_from::<_, O, _>(&mut b, bincode::Infinite).map_err(From::from)
         } else {
-            f_err("couldn't find toolchain locally")
+            Err(RouilleBincodeError::BodyAlreadyExtracted)
         }
     }
-    fn do_run_job(&self, job_alloc: JobAlloc, command: CompileCommand, outputs: Vec<String>, mut write_inputs: Box<FnMut(&mut Write)>) -> SFuture<RunJobResult> {
-        let url = format!("http://{}/api/v1/distserver/run_job/{}", job_alloc.server_id.addr(), job_alloc.job_id);
-        let bincode = bincode::serialize(&RunJobHttpRequest { command, outputs }, bincode::Infinite).unwrap();
-        let bincode_length = bincode.len();
-        let mut inputs = vec![];
-        write_inputs(&mut inputs);
 
-        let mut body = vec![];
-        body.write_u32::<BigEndian>(bincode_length as u32).unwrap();
-        body.write(&bincode).unwrap();
-        body.write(&inputs).unwrap();
+    // Based on rouille::Response::json
+    pub fn bincode_response<T>(content: &T) -> rouille::Response where T: serde::Serialize {
+        let data = bincode::serialize(content, bincode::Infinite).unwrap();
 
-        bincode_req_fut(self.client.post(&url).bearer_auth(job_alloc.auth.clone()).bytes(body))
+        rouille::Response {
+            status_code: 200,
+            headers: vec![("Content-Type".into(), "application/octet-stream".into())],
+            data: rouille::ResponseBody::from_data(data),
+            upgrade: None,
+        }
     }
 
-    fn put_toolchain(&self, compiler_path: &Path, weak_key: &str, create: BoxFnOnce<(fs::File,), io::Result<()>>) -> Result<(Toolchain, Option<String>)> {
-        self.tc_cache.put_toolchain(compiler_path, weak_key, create)
+    // Based on try_or_400 in rouille
+    #[derive(Serialize)]
+    pub struct ErrJson<'a> {
+        description: &'a str,
+        cause: Option<Box<ErrJson<'a>>>,
     }
-    fn may_dist(&self) -> bool {
-        true
+
+    impl<'a> ErrJson<'a> {
+        fn from_err<E: ?Sized + std::error::Error>(err: &'a E) -> ErrJson<'a> {
+            let cause = err.cause().map(ErrJson::from_err).map(Box::new);
+            ErrJson { description: err.description(), cause }
+        }
+        fn into_data(self) -> String {
+            serde_json::to_string(&self).unwrap()
+        }
+    }
+    macro_rules! try_or_500 {
+        ($result:expr) => (
+            match $result {
+                Ok(r) => r,
+                Err(err) => {
+                    let json = ErrJson::from_err(&err);
+                    return rouille::Response::json(&json).with_status_code(500)
+                },
+            }
+        );
+    }
+    fn make_401(short_err: &str) -> rouille::Response {
+        rouille::Response {
+            status_code: 401,
+            headers: vec![("WWW-Authenticate".into(), format!("Bearer error=\"{}\"", short_err).into())],
+            data: rouille::ResponseBody::empty(),
+            upgrade: None,
+        }
+    }
+    fn bearer_http_auth(request: &rouille::Request) -> Option<&str> {
+        let header = request.header("Authorization")?;
+
+        let mut split = header.splitn(2, |c| c == ' ');
+
+        let authtype = split.next()?;
+        if authtype != "Bearer" {
+            return None
+        }
+
+        split.next()
+    }
+    macro_rules! try_jwt_or_401 {
+        ($request:ident, $key:expr, $valid_claims:expr) => {{
+            let claims: Result<_> = match bearer_http_auth($request) {
+                Some(token) => {
+                    jwt::decode(&token, $key, &JWT_VALIDATION)
+                        .map_err(Into::into)
+                        .and_then(|res| {
+                            fn identical_t<T>(_: &T, _: &T) {}
+                            let valid_claims = $valid_claims;
+                            identical_t(&res.claims, &valid_claims);
+                            if res.claims == valid_claims { Ok(()) } else { Err("invalid claims".into()) }
+                        })
+                },
+                None => Err("no Authorization header".into()),
+            };
+            match claims {
+                Ok(()) => (),
+                Err(err) => {
+                    let json = ErrJson::from_err(&err);
+                    let mut res = make_401("invalid_jwt");
+                    res.data = rouille::ResponseBody::from_data(json.into_data());
+                    return res
+                },
+            }
+        }};
+    }
+
+    pub struct Scheduler<S> {
+        handler: S,
+        // Is this client permitted to use the scheduler?
+        check_client_auth: Box<Fn(&str) -> bool + Send + Sync>,
+        // Do we believe the server is who they appear to be?
+        check_server_auth: Box<Fn(&str) -> Option<ServerId> + Send + Sync>,
+    }
+
+    impl<S: dist::SchedulerIncoming + 'static> Scheduler<S> {
+        pub fn new(handler: S, check_client_auth: Box<Fn(&str) -> bool + Send + Sync>, check_server_auth: Box<Fn(&str) -> Option<ServerId> + Send + Sync>) -> Self {
+            Self { handler, check_client_auth, check_server_auth }
+        }
+
+        pub fn start(self) -> ! {
+            let Self { handler, check_client_auth, check_server_auth } = self;
+            let requester = SchedulerRequester { client: reqwest::Client::new() };
+            let addr = Cfg::scheduler_listen_addr();
+
+            macro_rules! check_server_auth_or_401 {
+                ($request:ident) => {{
+                    match bearer_http_auth($request).and_then(&*check_server_auth) {
+                        Some(server_id) if server_id.addr().ip() == $request.remote_addr().ip() => server_id,
+                        Some(_) => return make_401("invalid_bearer_token_mismatched_address"),
+                        None => return make_401("invalid_bearer_token"),
+                    }}
+                };
+            }
+
+            info!("Scheduler listening for clients on {}", addr);
+            let server = rouille::Server::new(addr, move |request| {
+                let request_id = request.remote_addr();
+                trace!("Req {}: {:?}", request_id, request);
+                let response = (|| router!(request,
+                    (POST) (/api/v1/scheduler/alloc_job) => {
+                        if !bearer_http_auth(request).map_or(false, &*check_client_auth) {
+                            return make_401("invalid_bearer_token")
+                        }
+                        let toolchain = try_or_400!(bincode_input(request));
+                        trace!("Req {}: alloc_job: {:?}", request_id, toolchain);
+
+                        let res: AllocJobResult = try_or_500!(handler.handle_alloc_job(&requester, toolchain));
+                        bincode_response(&res)
+                    },
+                    (POST) (/api/v1/scheduler/heartbeat_server) => {
+                        let server_id = check_server_auth_or_401!(request);
+                        let heartbeat_server = try_or_400!(bincode_input(request));
+                        trace!("Req {}: heartbeat_server: {:?}", request_id, heartbeat_server);
+
+                        let HeartbeatServerHttpRequest { num_cpus, client_jwt_key } = heartbeat_server;
+                        let generate_job_auth = Box::new(move |job_id| {
+                            let claims = JobJwt { job_id };
+                            jwt::encode(&JWT_HEADER, &claims, &client_jwt_key).unwrap()
+                        });
+                        let res: HeartbeatServerResult = handler.handle_heartbeat_server(server_id, num_cpus, generate_job_auth).unwrap();
+                        bincode_response(&res)
+                    },
+                    (POST) (/api/v1/scheduler/job_state/{job_id: JobId}) => {
+                        let server_id = check_server_auth_or_401!(request);
+                        let job_state = try_or_400!(bincode_input(request));
+                        trace!("Req {}: job state: {:?}", request_id, job_state);
+
+                        let res: UpdateJobStateResult = handler.handle_update_job_state(job_id, server_id, job_state).unwrap();
+                        bincode_response(&res)
+                    },
+                    (GET) (/api/v1/scheduler/status) => {
+                        let res: StatusResult = handler.handle_status().unwrap();
+                        bincode_response(&res)
+                    },
+                    _ => {
+                        warn!("Unknown request {:?}", request);
+                        rouille::Response::empty_404()
+                    },
+                )) ();
+                trace!("Res {}: {:?}", request_id, response);
+                response
+            }).unwrap();
+            server.run();
+
+            unreachable!()
+        }
+    }
+
+    struct SchedulerRequester {
+        client: reqwest::Client,
+    }
+
+    impl dist::SchedulerOutgoing for SchedulerRequester {
+        fn do_assign_job(&self, server_id: ServerId, job_id: JobId, tc: Toolchain, auth: String) -> Result<AssignJobResult> {
+            let url = format!("http://{}/api/v1/distserver/assign_job/{}", server_id.addr(), job_id);
+            bincode_req(self.client.post(&url).bearer_auth(auth).bincode(&tc)?)
+        }
+    }
+
+    pub struct Server<S> {
+        scheduler_addr: SocketAddr,
+        scheduler_auth: String,
+        handler: S,
+        client_jwt_key: Vec<u8>,
+    }
+
+    impl<S: dist::ServerIncoming + 'static> Server<S> {
+        pub fn new(scheduler_addr: IpAddr, scheduler_auth: String, handler: S) -> Self {
+            let mut client_jwt_key = vec![0; JWT_KEY_LENGTH];
+            let mut rng = rand::OsRng::new().unwrap();
+            rng.fill_bytes(&mut client_jwt_key);
+            Self {
+                scheduler_addr: Cfg::scheduler_connect_addr(scheduler_addr),
+                scheduler_auth,
+                client_jwt_key,
+                handler,
+            }
+        }
+
+        pub fn start(self) -> ! {
+            let Self { scheduler_addr, scheduler_auth, client_jwt_key, handler } = self;
+            let requester = ServerRequester { client: reqwest::Client::new(), scheduler_addr, scheduler_auth: scheduler_auth.clone() };
+            let addr = Cfg::server_listen_addr();
+
+            // TODO: detect if this panics
+            let heartbeat_req = HeartbeatServerHttpRequest { num_cpus: num_cpus::get(), client_jwt_key: client_jwt_key.clone() };
+            thread::spawn(move || {
+                let url = format!("http://{}:{}/api/v1/scheduler/heartbeat_server", scheduler_addr.ip(), scheduler_addr.port());
+                let client = reqwest::Client::new();
+                loop {
+                    trace!("Performing heartbeat");
+                    match bincode_req(client.post(&url).bearer_auth(scheduler_auth.clone()).bincode(&heartbeat_req).unwrap()) {
+                        Ok(HeartbeatServerResult { is_new }) => {
+                            trace!("Heartbeat success is_new={}", is_new);
+                            // TODO: if is_new, terminate all running jobs
+                            thread::sleep(Duration::from_secs(30))
+                        },
+                        Err(e) => {
+                            error!("Failed to send heartbeat to server: {}", e);
+                            thread::sleep(Duration::from_secs(10))
+                        },
+                    }
+                }
+            });
+
+            info!("Server listening for clients on {}", addr);
+            let server = rouille::Server::new(addr, move |request| {
+                let request_id = request.remote_addr();
+                trace!("Req {}: {:?}", request_id, request);
+                let response = (|| router!(request,
+                    (POST) (/api/v1/distserver/assign_job/{job_id: JobId}) => {
+                        try_jwt_or_401!(request, &client_jwt_key, JobJwt { job_id });
+                        let toolchain = try_or_400!(bincode_input(request));
+                        trace!("Req {}: assign_job({}): {:?}", request_id, job_id, toolchain);
+
+                        let res: AssignJobResult = try_or_500!(handler.handle_assign_job(job_id, toolchain));
+                        bincode_response(&res)
+                    },
+                    (POST) (/api/v1/distserver/submit_toolchain/{job_id: JobId}) => {
+                        try_jwt_or_401!(request, &client_jwt_key, JobJwt { job_id });
+                        trace!("Req {}: submit_toolchain({})", request_id, job_id);
+
+                        let mut body = request.data().unwrap();
+                        let toolchain_rdr = ToolchainReader(Box::new(body));
+                        let res: SubmitToolchainResult = try_or_500!(handler.handle_submit_toolchain(&requester, job_id, toolchain_rdr));
+                        bincode_response(&res)
+                    },
+                    (POST) (/api/v1/distserver/run_job/{job_id: JobId}) => {
+                        try_jwt_or_401!(request, &client_jwt_key, JobJwt { job_id });
+
+                        let mut body = request.data().unwrap();
+                        let bincode_length = body.read_u32::<BigEndian>().unwrap() as u64;
+
+                        let mut bincode_reader = body.take(bincode_length);
+                        let runjob = bincode::deserialize_from(&mut bincode_reader, bincode::Infinite).unwrap();
+                        trace!("Req {}: run_job({}): {:?}", request_id, job_id, runjob);
+                        let RunJobHttpRequest { command, outputs } = runjob;
+                        let body = bincode_reader.into_inner();
+                        let inputs_rdr = InputsReader(Box::new(body));
+                        let outputs = outputs.into_iter().collect();
+
+                        let res: RunJobResult = try_or_500!(handler.handle_run_job(&requester, job_id, command, outputs, inputs_rdr));
+                        bincode_response(&res)
+                    },
+                    _ => {
+                        warn!("Unknown request {:?}", request);
+                        rouille::Response::empty_404()
+                    },
+                ))();
+                trace!("Res {}: {:?}", request_id, response);
+                response
+            }).unwrap();
+            server.run();
+
+            unreachable!()
+        }
+    }
+
+    struct ServerRequester {
+        client: reqwest::Client,
+        scheduler_addr: SocketAddr,
+        scheduler_auth: String,
+    }
+
+    impl dist::ServerOutgoing for ServerRequester {
+        fn do_update_job_state(&self, job_id: JobId, state: JobState) -> Result<UpdateJobStateResult> {
+            let url = format!("http://{}/api/v1/scheduler/job_state/{}", self.scheduler_addr, job_id);
+            bincode_req(self.client.post(&url).bearer_auth(self.scheduler_auth.clone()).bincode(&state)?)
+        }
+    }
+}
+
+#[cfg(feature = "dist-client")]
+mod client {
+    use bincode;
+    use boxfnonce::BoxFnOnce;
+    use byteorder::{BigEndian, WriteBytesExt};
+    use config;
+    use futures::Future;
+    use reqwest;
+    use std::fs;
+    use std::io::{self, Write};
+    use std::net::{IpAddr, SocketAddr};
+    use std::path::Path;
+    use super::super::cache;
+    use tokio_core;
+
+    use dist::{
+        self,
+        Toolchain, CompileCommand,
+        AllocJobResult, JobAlloc, RunJobResult, SubmitToolchainResult,
+    };
+    use super::common::{
+        Cfg,
+        ReqwestRequestBuilderExt,
+        bincode_req_fut,
+
+        RunJobHttpRequest,
+    };
+    use errors::*;
+
+    pub struct Client {
+        auth: &'static config::DistAuth,
+        scheduler_addr: SocketAddr,
+        client: reqwest::unstable::async::Client,
+        tc_cache: cache::ClientToolchains,
+    }
+
+    impl Client {
+        pub fn new(handle: &tokio_core::reactor::Handle, scheduler_addr: IpAddr, cache_dir: &Path, cache_size: u64, custom_toolchains: &[config::DistCustomToolchain], auth: &'static config::DistAuth) -> Self {
+            Self {
+                auth,
+                scheduler_addr: Cfg::scheduler_connect_addr(scheduler_addr),
+                client: reqwest::unstable::async::Client::new(handle),
+                tc_cache: cache::ClientToolchains::new(cache_dir, cache_size, custom_toolchains),
+            }
+        }
+    }
+
+    impl dist::Client for Client {
+        fn do_alloc_job(&self, tc: Toolchain) -> SFuture<AllocJobResult> {
+            let token = match self.auth {
+                config::DistAuth::Token { token } => token,
+            };
+            let url = format!("http://{}/api/v1/scheduler/alloc_job", self.scheduler_addr);
+            Box::new(f_res(self.client.post(&url).bearer_auth(token.to_owned()).bincode(&tc).map(bincode_req_fut)).and_then(|r| r))
+        }
+        fn do_submit_toolchain(&self, job_alloc: JobAlloc, tc: Toolchain) -> SFuture<SubmitToolchainResult> {
+            let url = format!("http://{}/api/v1/distserver/submit_toolchain/{}", job_alloc.server_id.addr(), job_alloc.job_id);
+            if let Some(toolchain_bytes) = self.tc_cache.get_toolchain(&tc) {
+                bincode_req_fut(self.client.post(&url).bearer_auth(job_alloc.auth.clone()).bytes(toolchain_bytes))
+            } else {
+                f_err("couldn't find toolchain locally")
+            }
+        }
+        fn do_run_job(&self, job_alloc: JobAlloc, command: CompileCommand, outputs: Vec<String>, mut write_inputs: Box<FnMut(&mut Write)>) -> SFuture<RunJobResult> {
+            let url = format!("http://{}/api/v1/distserver/run_job/{}", job_alloc.server_id.addr(), job_alloc.job_id);
+            let bincode = bincode::serialize(&RunJobHttpRequest { command, outputs }, bincode::Infinite).unwrap();
+            let bincode_length = bincode.len();
+            let mut inputs = vec![];
+            write_inputs(&mut inputs);
+
+            let mut body = vec![];
+            body.write_u32::<BigEndian>(bincode_length as u32).unwrap();
+            body.write(&bincode).unwrap();
+            body.write(&inputs).unwrap();
+
+            bincode_req_fut(self.client.post(&url).bearer_auth(job_alloc.auth.clone()).bytes(body))
+        }
+
+        fn put_toolchain(&self, compiler_path: &Path, weak_key: &str, create: BoxFnOnce<(fs::File,), io::Result<()>>) -> Result<(Toolchain, Option<String>)> {
+            self.tc_cache.put_toolchain(compiler_path, weak_key, create)
+        }
+        fn may_dist(&self) -> bool {
+            true
+        }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,7 +25,6 @@ use futures::Future;
 use futures::future;
 #[cfg(feature = "hyper")]
 use hyper;
-#[cfg(feature = "jsonwebtoken")]
 use jwt;
 use lru_disk_cache;
 #[cfg(feature = "memcached")]
@@ -45,7 +44,7 @@ error_chain! {
         Io(io::Error);
         Lru(lru_disk_cache::Error);
         Json(serde_json::Error);
-        Jwt(jwt::errors::Error) #[cfg(feature = "jsonwebtoken")];
+        Jwt(jwt::errors::Error);
         Openssl(openssl::error::ErrorStack) #[cfg(feature = "openssl")];
         Bincode(bincode::Error);
         Memcached(memcached::proto::Error) #[cfg(feature = "memcached")];

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,6 +25,7 @@ use futures::Future;
 use futures::future;
 #[cfg(feature = "hyper")]
 use hyper;
+#[cfg(feature = "jsonwebtoken")]
 use jwt;
 use lru_disk_cache;
 #[cfg(feature = "memcached")]
@@ -35,6 +36,7 @@ use openssl;
 use serde_json;
 #[cfg(feature = "redis")]
 use redis;
+#[cfg(feature = "reqwest")]
 use reqwest;
 use tempfile;
 
@@ -44,12 +46,12 @@ error_chain! {
         Io(io::Error);
         Lru(lru_disk_cache::Error);
         Json(serde_json::Error);
-        Jwt(jwt::errors::Error);
+        Jwt(jwt::errors::Error) #[cfg(feature = "jsonwebtoken")];
         Openssl(openssl::error::ErrorStack) #[cfg(feature = "openssl")];
         Bincode(bincode::Error);
         Memcached(memcached::proto::Error) #[cfg(feature = "memcached")];
         Redis(redis::RedisError) #[cfg(feature = "redis")];
-        Reqwest(reqwest::Error);
+        Reqwest(reqwest::Error) #[cfg(feature = "reqwest")];
         StrFromUtf8(::std::string::FromUtf8Error) #[cfg(feature = "gcs")];
         TempfilePersist(tempfile::PersistError);
         Tls(native_tls::Error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,6 @@ extern crate hyper;
 extern crate hyper_tls;
 #[cfg(test)]
 extern crate itertools;
-#[cfg(feature = "jsonwebtoken")]
 extern crate jsonwebtoken as jwt;
 #[cfg(windows)]
 extern crate kernel32;
@@ -62,6 +61,7 @@ extern crate num_cpus;
 extern crate number_prefix;
 #[cfg(feature = "openssl")]
 extern crate openssl;
+extern crate rand;
 extern crate ring;
 #[cfg(feature = "redis")]
 extern crate redis;
@@ -109,7 +109,7 @@ mod client;
 mod cmdline;
 mod commands;
 mod compiler;
-mod config;
+pub mod config;
 pub mod dist;
 mod jobserver;
 mod mock_command;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ extern crate hyper;
 extern crate hyper_tls;
 #[cfg(test)]
 extern crate itertools;
+#[cfg(feature = "jsonwebtoken")]
 extern crate jsonwebtoken as jwt;
 #[cfg(windows)]
 extern crate kernel32;
@@ -66,8 +67,10 @@ extern crate ring;
 #[cfg(feature = "redis")]
 extern crate redis;
 extern crate regex;
+#[cfg(feature = "reqwest")]
 extern crate reqwest;
 extern crate retry;
+#[cfg(feature = "rouille")]
 #[macro_use]
 extern crate rouille;
 extern crate serde;

--- a/src/server.rs
+++ b/src/server.rs
@@ -146,6 +146,7 @@ pub fn start_server(port: u16) -> Result<()> {
                 &CONFIG.dist.cache_dir.join("client"),
                 CONFIG.dist.toolchain_cache_size,
                 &CONFIG.dist.custom_toolchains,
+                &CONFIG.dist.auth,
             ))
         },
         #[cfg(not(feature = "dist"))]

--- a/src/server.rs
+++ b/src/server.rs
@@ -562,9 +562,13 @@ impl<C> SccacheService<C>
                         let res = CompileResponse::CompileStarted;
                         return Message::WithBody(Response::Compile(res), rx)
                     }
-                    CompilerArguments::CannotCache(why) => {
+                    CompilerArguments::CannotCache(why, extra_info) => {
                         //TODO: save counts of why
-                        debug!("parse_arguments: CannotCache({}): {:?}", why, cmd);
+                        if let Some(extra_info) = extra_info {
+                            debug!("parse_arguments: CannotCache({}, {}): {:?}", why, extra_info, cmd)
+                        } else {
+                            debug!("parse_arguments: CannotCache({}): {:?}", why, cmd)
+                        }
                         stats.requests_not_cacheable += 1;
                     }
                     CompilerArguments::NotCompilation => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -137,7 +137,7 @@ pub fn start_server(port: u16) -> Result<()> {
     let core = Core::new()?;
     let pool = CpuPool::new(20);
     let dist_client: Arc<dist::Client> = match CONFIG.dist.scheduler_addr {
-        #[cfg(feature = "dist")]
+        #[cfg(feature = "dist-client")]
         Some(addr) => {
             info!("Enabling distributed sccache to {}", addr);
             Arc::new(dist::http::Client::new(
@@ -149,7 +149,7 @@ pub fn start_server(port: u16) -> Result<()> {
                 &CONFIG.dist.auth,
             ))
         },
-        #[cfg(not(feature = "dist"))]
+        #[cfg(not(feature = "dist-client"))]
         Some(_) => {
             warn!("Scheduler address configured but dist feature disabled, disabling distributed sccache");
             Arc::new(dist::NoopClient)


### PR DESCRIPTION
This now correctly pulls apart arguments like `rustc -l static=a` into their constituent parts at parse time. There should be no functional changes in this PR.

This is the majority of the major argument handling rework I mentioned, pulled out of the rust distributed work for ease of review. Each of the commits can be considered in isolation.

Should be reviewed after #274 (or just examine the commits after the scheduler auth one).