### PR TITLE
Fix -showIncludes prefix detection for clang.exe on Windows.

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -718,6 +718,7 @@ gcc
                 debug!("Found MSVC (is clang: {})", is_clang);
                 let prefix = msvc::detect_showincludes_prefix(&creator,
                                                               executable.as_ref(),
+                                                              is_clang,
                                                               env,
                                                               &pool);
                 return Box::new(prefix.and_then(move |prefix| {


### PR DESCRIPTION
clang.exe reports the same set of built-in preprocessor defines as clang-cl.exe,
but it doesn't accept MSVC commandline options unless you pass --driver-mode=cl.
This breaks sccache's test for the -showIncludes prefix. We fix this by always
passing --driver-mode=cl for this test when we detect clang or clang-cl.