### PR TITLE
Set env vars correctly for building rustc

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -628,6 +628,8 @@ fn detect_compiler<T>(creator: &T,
         let child = creator.clone().new_command_sync(&executable)
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
+            .env_clear()
+            .envs(env.iter().map(|&(ref k, ref v)| (k, v)))
             .args(&["--version"])
             .spawn();
         let output = child.and_then(move |child| {
@@ -655,7 +657,8 @@ fn detect_compiler<T>(creator: &T,
     Box::new(is_rustc.and_then(move |is_rustc| {
         if is_rustc {
             debug!("Found rustc");
-            Box::new(Rust::new(creator, executable, pool).map(|c| Some(Box::new(c) as Box<Compiler<T>>)))
+            Box::new(Rust::new(creator, executable, &env, pool)
+                .map(|c| Some(Box::new(c) as Box<Compiler<T>>)))
         } else {
             detect_c_compiler(creator, executable, env, pool)
         }

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -51,7 +51,7 @@ use std::time::{
 };
 use tempdir::TempDir;
 use tempfile::NamedTempFile;
-use util::{fmt_duration_as_secs, run_input_output};
+use util::{fmt_duration_as_secs, ref_env, run_input_output};
 use tokio_core::reactor::{Handle, Timeout};
 
 use errors::*;
@@ -629,7 +629,7 @@ fn detect_compiler<T>(creator: &T,
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .env_clear()
-            .envs(env.iter().map(|&(ref k, ref v)| (k, v)))
+            .envs(ref_env(env))
             .args(&["--version"])
             .spawn();
         let output = child.and_then(move |child| {

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -34,7 +34,7 @@ use std::process::Stdio;
 use std::time::Instant;
 use tempdir::TempDir;
 use util::{fmt_duration_as_secs, run_input_output, Digest};
-use util::{HashToDigest, OsStrExt};
+use util::{HashToDigest, OsStrExt, ref_env};
 
 use errors::*;
 
@@ -152,7 +152,7 @@ fn hash_source_files<T>(creator: &T,
         .arg("-o")
         .arg(&dep_file)
         .env_clear()
-        .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
+        .envs(ref_env(env_vars))
         .current_dir(cwd);
     trace!("[{}]: get dep-info: {:?}", crate_name, cmd);
     let dep_info = run_input_output(cmd, None);
@@ -224,7 +224,7 @@ fn get_compiler_outputs<T>(creator: &T,
     cmd.args(&arguments)
         .args(&["--print", "file-names"])
         .env_clear()
-        .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
+        .envs(ref_env(env_vars))
         .current_dir(cwd);
     if log_enabled!(Trace) {
         trace!("get_compiler_outputs: {:?}", cmd);
@@ -250,7 +250,7 @@ impl Rust {
             .stderr(Stdio::null())
             .arg("--print=sysroot")
             .env_clear()
-            .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)));
+            .envs(ref_env(env_vars));
         let output = run_input_output(cmd, None);
         let sysroot_and_libs = output.and_then(move |output| -> Result<_> {
             //debug!("output.and_then: {}", output);

--- a/src/mock_command.rs
+++ b/src/mock_command.rs
@@ -224,11 +224,7 @@ impl RunCommand for AsyncCommand {
     fn envs<I, K, V>(&mut self, vars: I) -> &mut Self
         where I: IntoIterator<Item=(K, V)>, K: AsRef<OsStr>, V: AsRef<OsStr>
     {
-        //TODO: when Command::envs stabilizes, use that:
-        // https://github.com/rust-lang/rust/issues/38526
-        for (k, v) in vars {
-            self.inner().env(k, v);
-        }
+        self.inner().envs(vars);
         self
     }
     fn env_clear(&mut self) -> &mut AsyncCommand {

--- a/src/util.rs
+++ b/src/util.rs
@@ -292,6 +292,11 @@ impl<'a> Hasher for HashToDigest<'a> {
     }
 }
 
+/// Turns a slice of environment var tuples into the type expected by Command::envs.
+pub fn ref_env(env: &[(OsString, OsString)]) -> impl Iterator<Item = (&OsString, &OsString)> {
+    env.iter().map(|&(ref k, ref v)| (k, v))
+}
+
 #[cfg(test)]
 mod tests {
     use std::ffi::{OsStr, OsString};


### PR DESCRIPTION
This adds env variables during the compiler detection phase for rust. The rustc build script uses a bootstrap compiler that requires some of those env variables to run, even for `--version`.

Also, the `RUSTC_COLOR` env variable is filtered out, because it interferes with the automatic color handling in sccache.

I wanted to experiment with using this to build rustc, and immediately hit a few errors. This fixes those enough to build a working stage1 compiler. There are still other problems, though...
- more env vars should be included in the hash key
- no support for incremental compilation means this might not be that useful, yet