### PR TITLE
Fix various trivial warnings on macos

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -342,6 +342,7 @@ impl<I: CCompilerImpl> Compilation for CCompilation<I> {
 }
 
 struct CCompilerPackager {
+    #[allow(dead_code)]
     executable: PathBuf,
 }
 

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -866,6 +866,7 @@ impl Compilation for RustCompilation {
 }
 
 struct RustCompilerPackager {
+    #[allow(dead_code)]
     sysroot: PathBuf,
 }
 

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -36,8 +36,10 @@ use std::io::{
     Cursor,
     Write,
 };
+#[cfg(not(target_os="macos"))]
 use std::net::TcpListener;
 use std::path::Path;
+#[cfg(not(target_os="macos"))]
 use std::process::Command;
 use std::sync::{Arc,Mutex,mpsc};
 use std::thread;

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -85,6 +85,7 @@ pub fn next_command_calls<C: Fn(&[OsString]) -> Result<MockChild> + Send + 'stat
     creator.lock().unwrap().next_command_calls(call);
 }
 
+#[cfg(not(target_os="macos"))]
 pub fn find_sccache_binary() -> PathBuf {
     // Older versions of cargo put the test binary next to the sccache binary.
     // Newer versions put it in the deps/ subdirectory.

--- a/tests/sccache_cargo.rs
+++ b/tests/sccache_cargo.rs
@@ -6,35 +6,36 @@
 extern crate assert_cmd;
 extern crate chrono;
 extern crate env_logger;
+#[cfg(not(target_os="macos"))]
 #[macro_use]
 extern crate log;
 extern crate predicates;
 extern crate tempdir;
-
-use std::env;
-use std::io::Write;
-use std::fs;
-use std::path::Path;
-use assert_cmd::prelude::*;
-use chrono::Local;
-use predicates::prelude::*;
-use std::process::{Command, Stdio};
-use tempdir::TempDir;
-
-fn stop() {
-    trace!("sccache --stop-server");
-    drop(Command::main_binary().unwrap()
-         .arg("--stop-server")
-         .stdout(Stdio::null())
-         .stderr(Stdio::null())
-         .status());
-}
 
 /// Test that building a simple Rust crate with cargo using sccache results in a cache hit
 /// when built a second time.
 #[test]
 #[cfg(not(target_os="macos"))] // test currently fails on macos
 fn test_rust_cargo() {
+    use std::env;
+    use std::io::Write;
+    use std::fs;
+    use std::path::Path;
+    use assert_cmd::prelude::*;
+    use chrono::Local;
+    use predicates::prelude::*;
+    use std::process::{Command, Stdio};
+    use tempdir::TempDir;
+
+    fn stop() {
+        trace!("sccache --stop-server");
+        drop(Command::main_binary().unwrap()
+            .arg("--stop-server")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status());
+    }
+
     drop(env_logger::Builder::new()
          .format(|f, record| {
              write!(


### PR DESCRIPTION
This patch fixes various warnings:

* Allow unused fields in CCompilerPackager and RustCompilerPackager
* Fix some unused warning in the sccache_cargo mod by moving use directives

This patch contains no functional change.

I'm not sure whether the `dead_code` annotation is fine but I couldn't figure out how to the unused warning with a `cfg` directive.