### PR TITLE
Sccache support for building Rust on Windows

### DIFF
--- a/lru-disk-cache/src/lib.rs
+++ b/lru-disk-cache/src/lib.rs
@@ -3,7 +3,7 @@ extern crate filetime;
 extern crate log;
 //extern crate lru_cache;
 extern crate linked_hash_map;
-mod lru_cache;
+pub mod lru_cache;
 extern crate walkdir;
 
 #[cfg(test)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -646,7 +646,7 @@ pub fn run_command(cmd: Command) -> Result<i32> {
         }
         #[cfg(not(feature = "dist-client"))]
         Command::PackageToolchain(_executable, _out) => {
-            bail!("Toolchain packaging not compiled in")
+            bail!("Toolchain packaging not compiled in, please rebuild with the dist-client feature")
         }
         Command::Compile { exe, cmdline, cwd, env_vars } => {
             trace!("Command::Compile {{ {:?}, {:?}, {:?} }}", exe, cmdline, cwd);

--- a/src/compiler/args.rs
+++ b/src/compiler/args.rs
@@ -9,7 +9,7 @@ use std::str;
 
 pub type ArgParseResult<T> = StdResult<T, ArgParseError>;
 pub type ArgToStringResult = StdResult<String, ArgToStringError>;
-pub type PathTransformer<'a> = &'a mut FnMut(&Path) -> Option<String>;
+pub type PathTransformerFn<'a> = &'a mut FnMut(&Path) -> Option<String>;
 
 #[derive(Debug, PartialEq)]
 pub enum ArgParseError {
@@ -290,7 +290,7 @@ macro_rules! ArgData {
             fn into_arg_os_string(self) -> OsString {
                 ArgData!{ __matchify self into_arg_os_string () () $($tok)+ }
             }
-            fn into_arg_string(self, transformer: PathTransformer) -> ArgToStringResult {
+            fn into_arg_string(self, transformer: PathTransformerFn) -> ArgToStringResult {
                 ArgData!{ __matchify self into_arg_string (transformer) () $($tok)+ }
             }
         }
@@ -324,7 +324,7 @@ pub trait FromArg: Sized {
 
 pub trait IntoArg: Sized {
     fn into_arg_os_string(self) -> OsString;
-    fn into_arg_string(self, transformer: PathTransformer) -> ArgToStringResult;
+    fn into_arg_string(self, transformer: PathTransformerFn) -> ArgToStringResult;
 }
 
 impl FromArg for OsString {
@@ -339,23 +339,23 @@ impl FromArg for String {
 
 impl IntoArg for OsString {
     fn into_arg_os_string(self) -> OsString { self }
-    fn into_arg_string(self, _transformer: PathTransformer) -> ArgToStringResult {
+    fn into_arg_string(self, _transformer: PathTransformerFn) -> ArgToStringResult {
         self.into_string().map_err(ArgToStringError::InvalidUnicode)
     }
 }
 impl IntoArg for PathBuf {
     fn into_arg_os_string(self) -> OsString { self.into() }
-    fn into_arg_string(self, transformer: PathTransformer) -> ArgToStringResult {
+    fn into_arg_string(self, transformer: PathTransformerFn) -> ArgToStringResult {
         transformer(&self).ok_or_else(|| ArgToStringError::FailedPathTransform(self))
     }
 }
 impl IntoArg for String {
     fn into_arg_os_string(self) -> OsString { self.into() }
-    fn into_arg_string(self, _transformer: PathTransformer) -> ArgToStringResult { Ok(self) }
+    fn into_arg_string(self, _transformer: PathTransformerFn) -> ArgToStringResult { Ok(self) }
 }
 impl IntoArg for () {
     fn into_arg_os_string(self) -> OsString { OsString::new() }
-    fn into_arg_string(self, _transformer: PathTransformer) -> ArgToStringResult { Ok(String::new()) }
+    fn into_arg_string(self, _transformer: PathTransformerFn) -> ArgToStringResult { Ok(String::new()) }
 }
 
 pub fn split_os_string_arg(val: OsString, split: &str) -> ArgParseResult<(String, Option<String>)> {

--- a/src/compiler/args.rs
+++ b/src/compiler/args.rs
@@ -146,6 +146,7 @@ impl<T: ArgumentValue> Argument<T> {
     }
 
     /// Transforms a parsed argument into an iterator over strings, with transformed paths.
+    #[cfg(feature = "dist-client")]
     pub fn iter_strings<F: FnMut(&Path) -> Option<String>>(&self, path_transformer: F) -> IterStrings<T, F> {
         IterStrings {
             arg: self,
@@ -206,12 +207,14 @@ impl<'a, T: ArgumentValue> Iterator for Iter<'a, T> {
     }
 }
 
+#[cfg(feature = "dist-client")]
 pub struct IterStrings<'a, T: 'a, F> {
     arg: &'a Argument<T>,
     emitted: usize,
     path_transformer: F,
 }
 
+#[cfg(feature = "dist-client")]
 impl<'a, T: ArgumentValue, F: FnMut(&Path) -> Option<String>> Iterator for IterStrings<'a, T, F> {
     type Item = ArgToStringResult;
 

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -187,6 +187,10 @@ impl <I> CCompiler<I>
 
 impl<T: CommandCreatorSync, I: CCompilerImpl> Compiler<T> for CCompiler<I> {
     fn kind(&self) -> CompilerKind { CompilerKind::C(self.compiler.kind()) }
+    #[cfg(feature = "dist-client")]
+    fn get_toolchain_packager(&self) -> Box<pkg::ToolchainPackager> {
+        Box::new(CToolchainPackager { executable: self.executable.clone() })
+    }
     fn parse_arguments(&self,
                        arguments: &[OsString],
                        cwd: &Path) -> CompilerArguments<Box<CompilerHasher<T> + 'static>> {
@@ -362,7 +366,7 @@ impl pkg::ToolchainPackager for CToolchainPackager {
         use std::env;
         use std::os::unix::ffi::OsStrExt;
 
-        info!("Packaging C compiler");
+        info!("Packaging C compiler for executable {}", self.executable.display());
         // TODO: write our own, since this is GPL
         let curdir = env::current_dir().unwrap();
         env::set_current_dir("/tmp").unwrap();

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -303,15 +303,12 @@ impl<I: CCompilerImpl> Compilation for CCompilation<I> {
     }
 
     #[cfg(feature = "dist-client")]
-    fn into_dist_packagers(self: Box<Self>, path_transformer: &mut dist::PathTransformer) -> Result<(Box<pkg::InputsPackager>, Box<pkg::ToolchainPackager>)> {
+    fn into_dist_packagers(self: Box<Self>, path_transformer: dist::PathTransformer) -> Result<(Box<pkg::InputsPackager>, Box<pkg::ToolchainPackager>)> {
         let CCompilation { parsed_args, cwd, preprocessed_input, executable, .. } = *{self};
         trace!("Dist inputs: {:?}", parsed_args.input);
 
         let input_path = cwd.join(&parsed_args.input);
-        let input_path = pkg::simplify_path(&input_path)?;
-        let dist_input_path = path_transformer.to_dist(&input_path).unwrap();
-
-        let inputs_packager = Box::new(CInputsPackager { input_path, dist_input_path, preprocessed_input });
+        let inputs_packager = Box::new(CInputsPackager { input_path, preprocessed_input, path_transformer });
         let toolchain_packager = Box::new(CToolchainPackager { executable });
         Ok((inputs_packager, toolchain_packager))
     }
@@ -325,16 +322,19 @@ impl<I: CCompilerImpl> Compilation for CCompilation<I> {
 #[cfg(feature = "dist-client")]
 struct CInputsPackager {
     input_path: PathBuf,
-    dist_input_path: String,
+    path_transformer: dist::PathTransformer,
     preprocessed_input: Vec<u8>,
 }
 
 #[cfg(feature = "dist-client")]
 impl pkg::InputsPackager for CInputsPackager {
-    fn write_inputs(self: Box<Self>, wtr: &mut io::Write) -> Result<()> {
+    fn write_inputs(self: Box<Self>, wtr: &mut io::Write) -> Result<dist::PathTransformer> {
         use tar;
 
-        let CInputsPackager { input_path, dist_input_path, preprocessed_input } = *{self};
+        let CInputsPackager { input_path, mut path_transformer, preprocessed_input } = *{self};
+
+        let input_path = pkg::simplify_path(&input_path)?;
+        let dist_input_path = path_transformer.to_dist(&input_path).unwrap();
 
         let mut builder = tar::Builder::new(wtr);
 
@@ -345,7 +345,7 @@ impl pkg::InputsPackager for CInputsPackager {
 
         // Finish archive
         let _ = builder.into_inner();
-        Ok(())
+        Ok(path_transformer)
     }
 }
 

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -93,6 +93,9 @@ pub trait Compiler<T>: Send + 'static
 {
     /// Return the kind of compiler.
     fn kind(&self) -> CompilerKind;
+    /// Retrieve a packager
+    #[cfg(feature = "dist-client")]
+    fn get_toolchain_packager(&self) -> Box<pkg::ToolchainPackager>;
     /// Determine whether `arguments` are supported by this compiler.
     fn parse_arguments(&self,
                        arguments: &[OsString],

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -432,7 +432,6 @@ pub trait Compilation {
                                  -> Result<(CompileCommand, Option<dist::CompileCommand>, Cacheable)>;
 
     /// Create a function that will create the inputs used to perform a distributed compilation
-    // TODO: It's more correct to have a FnBox or Box<FnOnce> here
     #[cfg(feature = "dist-client")]
     fn into_dist_packagers(self: Box<Self>, _path_transformer: &mut dist::PathTransformer)
                            -> Result<(Box<pkg::InputsPackager>, Box<pkg::ToolchainPackager>)> {

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -341,6 +341,7 @@ fn dist_or_local_compile<T>(dist_client: Arc<dist::Client>,
                             -> SFuture<(Cacheable, process::Output)>
         where T: CommandCreatorSync {
     use futures::future;
+    use std::error::Error as StdError;
     use std::io;
 
     debug!("[{}]: Attempting distributed compilation", out_pretty);
@@ -415,7 +416,8 @@ fn dist_or_local_compile<T>(dist_client: Arc<dist::Client>,
         })
         // Something failed, do a local compilation
         .or_else(move |e| {
-            info!("[{}]: Could not perform distributed compile, falling back to local: {}", compile_out_pretty3, e);
+            let cause = e.cause().map(|c| format!(": {}", c)).unwrap_or_else(String::new);
+            info!("[{}]: Could not perform distributed compile, falling back to local: {}{}", compile_out_pretty3, e, cause);
             compile_cmd.execute(&creator)
         })
         .map(move |o| (cacheable, o))

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -402,6 +402,9 @@ pub fn generate_compile_commands(path_transformer: &mut dist::PathTransformer,
                                 env_vars: &[(OsString, OsString)])
                                 -> Result<(CompileCommand, Option<dist::CompileCommand>, Cacheable)>
 {
+    #[cfg(not(feature = "dist-client"))]
+    let _ = path_transformer;
+
     trace!("compile");
 
     let out_file = match parsed_args.outputs.get("obj") {
@@ -434,6 +437,9 @@ pub fn generate_compile_commands(path_transformer: &mut dist::PathTransformer,
         cwd: cwd.to_owned(),
     };
 
+    #[cfg(not(feature = "dist-client"))]
+    let dist_command = None;
+    #[cfg(feature = "dist-client")]
     let dist_command = (|| {
         // https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Overall-Options.html
         let language = match parsed_args.language {

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -547,6 +547,9 @@ fn generate_compile_commands(path_transformer: &mut dist::PathTransformer,
                             env_vars: &[(OsString, OsString)])
                             -> Result<(CompileCommand, Option<dist::CompileCommand>, Cacheable)>
 {
+    #[cfg(not(feature = "dist-client"))]
+    let _ = path_transformer;
+
     trace!("compile");
     let out_file = match parsed_args.outputs.get("obj") {
         Some(obj) => obj,
@@ -585,6 +588,9 @@ fn generate_compile_commands(path_transformer: &mut dist::PathTransformer,
         cwd: cwd.to_owned(),
     };
 
+    #[cfg(not(feature = "dist-client"))]
+    let dist_command = None;
+    #[cfg(feature = "dist-client")]
     let dist_command = (|| {
         // http://releases.llvm.org/6.0.0/tools/clang/docs/UsersManual.html#clang-cl
         // TODO: Use /T... for language?

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -388,6 +388,10 @@ impl<T> Compiler<T> for Rust
     where T: CommandCreatorSync,
 {
     fn kind(&self) -> CompilerKind { CompilerKind::Rust }
+    #[cfg(feature = "dist-client")]
+    fn get_toolchain_packager(&self) -> Box<pkg::ToolchainPackager> {
+        Box::new(RustToolchainPackager { sysroot: self.sysroot.clone() })
+    }
     /// Parse `arguments` as rustc command-line arguments, determine if
     /// we can cache the result of compilation. This is only intended to
     /// cover a subset of rustc invocations, primarily focused on those

--- a/src/config.rs
+++ b/src/config.rs
@@ -187,10 +187,18 @@ impl CacheConfigs {
 
 #[derive(Debug, PartialEq, Eq)]
 #[derive(Serialize, Deserialize)]
-pub struct DistCustomToolchain {
-    pub compiler_executable: PathBuf,
-    pub archive: PathBuf,
-    pub archive_compiler_executable: String,
+#[serde(tag = "type")]
+pub enum DistToolchainConfig {
+    #[serde(rename = "no_dist")]
+    NoDist {
+        compiler_executable: PathBuf,
+    },
+    #[serde(rename = "path_override")]
+    PathOverride {
+        compiler_executable: PathBuf,
+        archive: PathBuf,
+        archive_compiler_executable: String,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -215,7 +223,7 @@ pub struct DistConfig {
     pub auth: DistAuth,
     pub scheduler_addr: Option<IpAddr>,
     pub cache_dir: PathBuf,
-    pub custom_toolchains: Vec<DistCustomToolchain>,
+    pub toolchains: Vec<DistToolchainConfig>,
     pub toolchain_cache_size: u64,
 }
 
@@ -225,7 +233,7 @@ impl Default for DistConfig {
             auth: Default::default(),
             scheduler_addr: Default::default(),
             cache_dir: default_dist_cache_dir(),
-            custom_toolchains: Default::default(),
+            toolchains: Default::default(),
             toolchain_cache_size: default_toolchain_cache_size(),
         }
     }

--- a/src/dist/cache.rs
+++ b/src/dist/cache.rs
@@ -118,7 +118,6 @@ mod client {
             };
             Some(file)
         }
-        // TODO: It's more correct to have a FnBox or Box<FnOnce> here
         // If the toolchain doesn't already exist, create it and insert into the cache
         pub fn put_toolchain(&self, compiler_path: &Path, weak_key: &str, toolchain_packager: Box<ToolchainPackager>) -> Result<(Toolchain, Option<String>)> {
             if let Some(tc_and_compiler_path) = self.get_custom_toolchain(compiler_path) {

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -610,7 +610,7 @@ mod client {
     }
 
     impl Client {
-        pub fn new(handle: &tokio_core::reactor::Handle, pool: &CpuPool, scheduler_addr: IpAddr, cache_dir: &Path, cache_size: u64, custom_toolchains: &[config::DistCustomToolchain], auth: &'static config::DistAuth) -> Self {
+        pub fn new(handle: &tokio_core::reactor::Handle, pool: &CpuPool, scheduler_addr: IpAddr, cache_dir: &Path, cache_size: u64, toolchain_configs: &[config::DistToolchainConfig], auth: &'static config::DistAuth) -> Self {
             let timeout = Duration::new(REQUEST_TIMEOUT_SECS, 0);
             let client = reqwest::ClientBuilder::new().timeout(timeout).build().unwrap();
             let client_async = reqwest::unstable::async::ClientBuilder::new().timeout(timeout).build(handle).unwrap();
@@ -620,7 +620,7 @@ mod client {
                 client,
                 client_async,
                 pool: pool.clone(),
-                tc_cache: cache::ClientToolchains::new(cache_dir, cache_size, custom_toolchains),
+                tc_cache: cache::ClientToolchains::new(cache_dir, cache_size, toolchain_configs),
             }
         }
     }

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -468,7 +468,7 @@ pub trait Client {
     // To Server
     fn do_submit_toolchain(&self, job_alloc: JobAlloc, tc: Toolchain) -> SFuture<SubmitToolchainResult>;
     // To Server
-    fn do_run_job(&self, job_alloc: JobAlloc, command: CompileCommand, outputs: Vec<String>, inputs_packager: Box<pkg::InputsPackager>) -> SFuture<RunJobResult>;
+    fn do_run_job(&self, job_alloc: JobAlloc, command: CompileCommand, outputs: Vec<String>, inputs_packager: Box<pkg::InputsPackager>) -> SFuture<(RunJobResult, PathTransformer)>;
     fn put_toolchain(&self, compiler_path: &Path, weak_key: &str, toolchain_packager: Box<pkg::ToolchainPackager>) -> Result<(Toolchain, Option<String>)>;
     fn may_dist(&self) -> bool;
 }
@@ -484,7 +484,7 @@ impl Client for NoopClient {
     fn do_submit_toolchain(&self, _job_alloc: JobAlloc, _tc: Toolchain) -> SFuture<SubmitToolchainResult> {
         panic!("NoopClient");
     }
-    fn do_run_job(&self, _job_alloc: JobAlloc, _command: CompileCommand, _outputs: Vec<String>, _inputs_packager: Box<pkg::InputsPackager>) -> SFuture<RunJobResult> {
+    fn do_run_job(&self, _job_alloc: JobAlloc, _command: CompileCommand, _outputs: Vec<String>, _inputs_packager: Box<pkg::InputsPackager>) -> SFuture<(RunJobResult, PathTransformer)> {
         panic!("NoopClient");
     }
 

--- a/src/dist/pkg.rs
+++ b/src/dist/pkg.rs
@@ -31,6 +31,10 @@ pub trait InputsPackager: Send {
     fn write_inputs(self: Box<Self>, wtr: &mut io::Write) -> Result<dist::PathTransformer>;
 }
 
+pub trait OutputsRepackager {
+    fn repackage_outputs(self: Box<Self>, wtr: &mut io::Write) -> Result<dist::PathTransformer>;
+}
+
 #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
 mod toolchain_imp {
     use std::fs;

--- a/src/dist/pkg.rs
+++ b/src/dist/pkg.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use dist;
 use std::io;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -27,7 +28,7 @@ pub trait ToolchainPackager {
 }
 
 pub trait InputsPackager: Send {
-    fn write_inputs(self: Box<Self>, wtr: &mut io::Write) -> Result<()>;
+    fn write_inputs(self: Box<Self>, wtr: &mut io::Write) -> Result<dist::PathTransformer>;
 }
 
 #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]

--- a/src/server.rs
+++ b/src/server.rs
@@ -146,7 +146,7 @@ pub fn start_server(port: u16) -> Result<()> {
                 addr,
                 &CONFIG.dist.cache_dir.join("client"),
                 CONFIG.dist.toolchain_cache_size,
-                &CONFIG.dist.custom_toolchains,
+                &CONFIG.dist.toolchains,
                 &CONFIG.dist.auth,
             ))
         },


### PR DESCRIPTION
The RlibDepDecoder is the most important piece here - in short, you can't distribute dylibs cross-platform (without something like Wine), so we either need to be pessimistic (and disallow distributed compilation if there's every a dylib anywhere in the deps folder, which is almost certain after first compilation) or have some way of telling what is a dependency of a particular crate rlib (we know the direct rlib dependencies of the thing we're compiling as they're passed in explicitly, we're interested in going a step down). `-Z ls` does this.

As a nice side effect, it makes other compiles more efficient too as it reduces what you send over the wire.

I did some informal measurements distributing over Wireless G from Windows 4core i3 non-SSD laptop to an 8core i7 SSD laptop: Firefox clobber build went from ~100mins to ~55mins. YMMV.

Unfortunately, while I was playing I saw an oddity with generated `.d` files - it looks like remapping prefixes is perhaps not working in some situations. The firefox build works, so I need to look at the implications.