### PR TITLE
Use the counted_array macro for the ARGS arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "counted-array"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "crc"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,6 +1421,7 @@ dependencies = [
  "cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "counted-array 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "daemonize 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2336,6 +2342,7 @@ dependencies = [
 "checksum conhash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99d6364d028778d0d98b6014fa5882da377cd10d3492b7734d266a428e9b1fca"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
+"checksum counted-array 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "384f8c53175c890920b6e0127b730709d2a173ca6c4dfdc81618ac9b46f648fe"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crossbeam-deque 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3486aefc4c0487b9cb52372c97df0a48b8c249514af1ee99703bf70d2f2ceda1"
 "checksum crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30fecfcac6abfef8771151f8be4abc9e4edc112c2bcb233314cafde2680536e9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ byteorder = "1.0"
 bytes = "0.4"
 chrono = { version = "0.4", optional = true }
 clap = "2.23.0"
+counted-array = "0.1"
 directories = "1"
 env_logger = "0.5"
 error-chain = { version = "0.12", default-features = false }

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -81,7 +81,7 @@ impl CCompilerImpl for Clang {
     }
 }
 
-pub static ARGS: [ArgInfo<gcc::ArgData>; 10] = [
+counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("--serialize-diagnostics", OsString, Separated, PassThrough),
     take_arg!("--target", OsString, Separated, PassThrough),
     // TODO: should be extracted and reprocessed, though bear in mind some
@@ -95,7 +95,7 @@ pub static ARGS: [ArgInfo<gcc::ArgData>; 10] = [
     take_arg!("-gcc-toolchain", OsString, Separated, PassThrough),
     take_arg!("-include-pch", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
     take_arg!("-target", OsString, Separated, PassThrough),
-];
+]);
 
 #[cfg(test)]
 mod test {

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -97,7 +97,7 @@ ArgData!{ pub
 use self::ArgData::*;
 
 // Mostly taken from https://github.com/ccache/ccache/blob/master/src/compopt.c#L32-L84
-pub static ARGS: [ArgInfo<ArgData>; 65] = [
+counted_array!(pub static ARGS: [ArgInfo<ArgData>; _] = [
     flag!("-", TooHardFlag),
     flag!("--coverage", Coverage),
     take_arg!("--param", OsString, Separated, PassThrough),
@@ -163,7 +163,7 @@ pub static ARGS: [ArgInfo<ArgData>; 65] = [
     take_arg!("-u", OsString, CanBeSeparated, PassThrough),
     take_arg!("-x", OsString, CanBeSeparated, Language),
     take_arg!("@", OsString, Concatenated, TooHard),
-];
+]);
 
 /// Parse `arguments`, determining whether it is supported.
 ///

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -219,7 +219,7 @@ ArgData!{
 
 use self::ArgData::*;
 
-static ARGS: [ArgInfo<ArgData>; 23] = [
+counted_array!(static ARGS: [ArgInfo<ArgData>; _] = [
     take_arg!("-D", OsString, Concatenated, PreprocessorArgument),
     take_arg!("-FA", OsString, Concatenated, TooHard),
     take_arg!("-FI", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
@@ -243,7 +243,7 @@ static ARGS: [ArgInfo<ArgData>; 23] = [
     take_arg!("-o", PathBuf, Separated, Output), // Deprecated but valid
     flag!("-showIncludes", ShowIncludes),
     take_arg!("@", PathBuf, Concatenated, TooHardPath),
-];
+]);
 
 pub fn parse_arguments(arguments: &[OsString], cwd: &Path, is_clang: bool) -> CompilerArguments<ParsedArguments> {
     let mut output_arg = None;

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -667,7 +667,7 @@ ArgData!{
 use self::ArgData::*;
 
 // These are taken from https://github.com/rust-lang/rust/blob/b671c32ddc8c36d50866428d83b7716233356721/src/librustc/session/config.rs#L1186
-static ARGS: [ArgInfo<ArgData>; 34] = [
+counted_array!(static ARGS: [ArgInfo<ArgData>; _] = [
     flag!("-", TooHardFlag),
     take_arg!("--allow", OsString, CanBeSeparated('='), PassThrough),
     take_arg!("--cap-lints", OsString, CanBeSeparated('='), PassThrough),
@@ -702,7 +702,7 @@ static ARGS: [ArgInfo<ArgData>; 34] = [
     take_arg!("-Z", OsString, CanBeSeparated, PassThrough),
     take_arg!("-l", ArgLinkLibrary, CanBeSeparated, LinkLibrary),
     take_arg!("-o", PathBuf, CanBeSeparated, TooHardPath),
-];
+]);
 
 fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<ParsedArguments>
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ extern crate bytes;
 extern crate chrono;
 #[macro_use]
 extern crate clap;
+#[macro_use]
+extern crate counted_array;
 #[cfg(feature = "rust-crypto")]
 extern crate crypto;
 #[cfg(unix)]


### PR DESCRIPTION
One of the most annoying thing from using static arrays in rust is that
there is no size inference, and you end up having to give the proper
size. Which makes updates to the arrays cumbersome.

I was reading "This Week in Rust 252", which linked to (RFC: Elide array
size)[https://github.com/rust-lang/rfcs/pull/2545], set to address this
very problem, and @durka linked to his counted-arrays crate, which
already existed and essentially implements the idea behind the RFC.