### PR TITLE
Stop using icecc-create-env to build environments

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -193,7 +193,10 @@ impl<T: CommandCreatorSync, I: CCompilerImpl> Compiler<T> for CCompiler<I> {
     fn kind(&self) -> CompilerKind { CompilerKind::C(self.compiler.kind()) }
     #[cfg(feature = "dist-client")]
     fn get_toolchain_packager(&self) -> Box<pkg::ToolchainPackager> {
-        Box::new(CToolchainPackager { executable: self.executable.clone() })
+        Box::new(CToolchainPackager {
+            executable: self.executable.clone(),
+            kind: self.compiler.kind(),
+        })
     }
     fn parse_arguments(&self,
                        arguments: &[OsString],

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -378,10 +378,9 @@ struct CToolchainPackager {
 impl pkg::ToolchainPackager for CToolchainPackager {
     fn write_pkg(self: Box<Self>, f: fs::File) -> Result<()> {
         use std::os::unix::ffi::OsStringExt;
-        use pkg::ToolchainPackageBuilder as Builder;
 
         info!("Generating toolchain {}", self.executable.display());
-        let mut package_builder = Builder::new();
+        let mut package_builder = pkg::ToolchainPackageBuilder::new();
         package_builder.add_common()?;
         package_builder.add_executable_and_deps(self.executable.clone())?;
 

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1403,8 +1403,6 @@ struct RustToolchainPackager {
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 impl pkg::ToolchainPackager for RustToolchainPackager {
     fn write_pkg(self: Box<Self>, f: fs::File) -> Result<()> {
-        use walkdir::WalkDir;
-
         info!("Packaging Rust compiler for sysroot {}", self.sysroot.display());
         let RustToolchainPackager { sysroot } = *self;
 
@@ -1415,33 +1413,10 @@ impl pkg::ToolchainPackager for RustToolchainPackager {
         let sysroot_executable = bins_path.join("rustc").with_extension(EXE_EXTENSION);
         package_builder.add_executable_and_deps(sysroot_executable)?;
 
-        // Although by not following symlinks we could break a custom constructed toolchain with
-        // links everywhere, this is just a best-effort auto packaging
-        fn walk_and_add(path: &Path, package_builder: &mut pkg::ToolchainPackageBuilder) -> Result<()> {
-            for entry in WalkDir::new(path).follow_links(false) {
-                let entry = entry?;
-                let file_type = entry.file_type();
-                if file_type.is_dir() {
-                    continue
-                } else if file_type.is_symlink() {
-                    let metadata = fs::metadata(entry.path())?;
-                    if !metadata.file_type().is_file() {
-                        continue
-                    }
-                } else if !file_type.is_file() {
-                    // Device or other oddity
-                    continue
-                }
-                // It's either a file, or a symlink pointing to a file
-                package_builder.add_file(entry.path().to_owned())?
-            }
-            Ok(())
-        }
-
-        walk_and_add(&bins_path, &mut package_builder)?;
+        package_builder.add_dir_contents(&bins_path)?;
         if BINS_DIR != LIBS_DIR {
             let libs_path = sysroot.join(LIBS_DIR);
-            walk_and_add(&libs_path, &mut package_builder)?
+            package_builder.add_dir_contents(&libs_path)?
         }
 
         package_builder.into_compressed_tar(f)

--- a/src/dist/pkg.rs
+++ b/src/dist/pkg.rs
@@ -54,7 +54,7 @@ mod toolchain_imp {
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 mod toolchain_imp {
     use std::collections::BTreeMap;
-    use std::io::{Write, Read};
+    use std::io::Write;
     use std::fs;
     use std::path::{Component, Path, PathBuf};
     use std::process;


### PR DESCRIPTION
I mentioned to @luser that I had whipped up my own create-env system within sccache-dist, due to icecc-create-env not working well for me.

Not sure how well this works, but it can probably at least act as a starting point.