### PR TITLE
Update default cache dir on MacOS in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Some notes about using `sccache` with [Jenkins](https://jenkins.io) are [here](d
 Storage Options
 ---------------
 
-Sccache defaults to using local disk storage. You can set the `SCCACHE_DIR` environment variable to change the disk cache location. By default it will use a sensible location for the current platform: `~/.cache/sccache` on Linux, `%LOCALAPPDATA%\Mozilla\sccache` on Windows, and `~/Library/Caches/sccache` on OS X.
+Sccache defaults to using local disk storage. You can set the `SCCACHE_DIR` environment variable to change the disk cache location. By default it will use a sensible location for the current platform: `~/.cache/sccache` on Linux, `%LOCALAPPDATA%\Mozilla\sccache` on Windows, and `~/Library/Caches/Mozilla.sccache` on MacOS.
 
 If you want to use S3 storage for the sccache cache, you need to set the `SCCACHE_BUCKET` environment variable to the name of the S3 bucket to use. You can use `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to set the S3 credentials and if you need to override the default endpoint you can set `SCCACHE_ENDPOINT`. To connect to a minio storage for example you can set `SCCACHE_ENDPOINT=<ip>:<port>`.
 


### PR DESCRIPTION
Details on how the default value is constructed:
- https://github.com/mozilla/sccache/blob/06b999976d71a44eec94863acd326aa03783c495/src/config.rs#L51
- https://docs.rs/directories/1.0.2/directories/struct.ProjectDirs.html