### PR TITLE
Add tests, remove unwraps, fix bugs, auto https

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libflate"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1310,7 +1310,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libflate 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libflate 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1361,7 +1361,7 @@ dependencies = [
  "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny_http 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny_http 0.6.0 (git+https://github.com/aidanhs/tiny-http-sccache.git?rev=a14fa0a)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1477,6 +1477,7 @@ dependencies = [
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1797,13 +1798,14 @@ dependencies = [
 [[package]]
 name = "tiny_http"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/aidanhs/tiny-http-sccache.git?rev=a14fa0a#a14fa0ab963be252c0c608e2516ef30252d6a7e2"
 dependencies = [
  "ascii 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "chunked_transfer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2408,7 +2410,7 @@ dependencies = [
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum libflate 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "7d4b4c7aff5bac19b956f693d0ea0eade8066deb092186ae954fa6ba14daab98"
+"checksum libflate 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "21138fc6669f438ed7ae3559d5789a5f0ba32f28c1f0608d1e452b0bb06ee936"
 "checksum libmount 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d9d45f88f32c57ebf3688ada41414dc700aab97ad58e26cbcda6af50da53559a"
 "checksum linked-hash-map 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bda158e0dabeb97ee8a401f4d17e479d6b891a14de0bba79d5cc2d4d325b5e48"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
@@ -2524,7 +2526,7 @@ dependencies = [
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
-"checksum tiny_http 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a442681f9f72e440be192700eeb2861e4174b9983f16f4877c93a134cb5e5f63"
+"checksum tiny_http 0.6.0 (git+https://github.com/aidanhs/tiny-http-sccache.git?rev=a14fa0a)" = "<none>"
 "checksum tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fbb6a6e9db2702097bfdfddcb09841211ad423b86c75b5ddaca1d62842ac492c"
 "checksum tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "881e9645b81c2ce95fcb799ded2c29ffb9f25ef5bef909089a420e5961dd8ccb"
 "checksum tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ rand = "0.5"
 redis = { version = "0.9.0", optional = true }
 regex = "1"
 # Exact dependency since we use the unstable async API
+# If updating this, make sure to update dev-dependencies
 reqwest = { version = "=0.8.8", features = ["unstable"], optional = true }
 retry = "0.4.0"
 ring = "0.13.2"
@@ -83,7 +84,12 @@ arraydeque = { version = "0.4", optional = true }
 crossbeam-utils = { version = "0.5", optional = true }
 libmount = { version = "0.1.10", optional = true }
 nix = { version = "0.11.0", optional = true }
-rouille = { version = "2.2", optional = true, default-features = false }
+rouille = { version = "2.2", optional = true, default-features = false, features = ["ssl"] }
+void = { version = "1", optional = true }
+
+[patch.crates-io]
+# Waiting for https://github.com/tiny-http/tiny-http/pull/151
+tiny_http = { git = "https://github.com/aidanhs/tiny-http-sccache.git", rev = "a14fa0a" }
 
 [dev-dependencies]
 assert_cmd = "0.9"
@@ -93,6 +99,8 @@ escargot = "0.3"
 itertools = "0.7"
 predicates = "0.9.0"
 selenium-rs = "0.1"
+# Must match the version of request in dependencies
+reqwest = { version = "=0.8.8" }
 
 [target.'cfg(unix)'.dependencies]
 daemonize = "0.3"
@@ -118,7 +126,7 @@ unstable = []
 # Enables distributed support in the sccache client
 dist-client = ["ar", "flate2", "hyper", "reqwest", "rust-crypto", "url"]
 # Enables the sccache-dist binary
-dist-server = ["arraydeque", "crossbeam-utils", "jsonwebtoken", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille"]
+dist-server = ["arraydeque", "crossbeam-utils", "jsonwebtoken", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille", "void"]
 # Enables dist tests with external requirements
 dist-tests = []
 

--- a/scripts/extratest.sh
+++ b/scripts/extratest.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o xtrace
+
+#CARGO="cargo --color=always"
+CARGO="cargo"
+
+gnutarget=x86_64-unknown-linux-gnu
+wintarget=x86_64-pc-windows-gnu
+
+gnutarget() {
+    unset OPENSSL_DIR
+    export OPENSSL_STATIC=1
+    target=$gnutarget
+}
+wintarget() {
+    export OPENSSL_DIR=$(pwd)/openssl-win
+    export OPENSSL_STATIC=1
+    target=$wintarget
+}
+
+# all-windows doesn't work as redis-rs build.rs has issues (checks for cfg!(unix))
+
+if [ "$1" = checkall ]; then
+    $CARGO check --target $target --all-targets --features 'all dist-client dist-server dist-tests'
+    $CARGO check --target $target --all-targets --features 'all dist-client dist-server'
+    $CARGO check --target $target --all-targets --features 'all dist-client dist-tests'
+    $CARGO check --target $target --all-targets --features 'all dist-server dist-tests'
+    $CARGO check --target $target --all-targets --features 'all dist-client'
+    $CARGO check --target $target --all-targets --features 'all dist-server'
+    $CARGO check --target $target --all-targets --features 'all dist-tests'
+    $CARGO check --target $target --all-targets --features 'all'
+    $CARGO check --target $target --all-targets --features 'dist-client dist-server dist-tests'
+    $CARGO check --target $target --all-targets --features 'dist-client dist-server'
+    $CARGO check --target $target --all-targets --features 'dist-client dist-tests'
+    $CARGO check --target $target --all-targets --features 'dist-server dist-tests'
+    $CARGO check --target $target --all-targets --features 'dist-client'
+    $CARGO check --target $target --all-targets --features 'dist-server'
+    $CARGO check --target $target --all-targets --features 'dist-tests'
+    $CARGO check --target $target --all-targets --features ''
+    $CARGO check --target $target --all-targets --no-default-features --features 'all dist-client dist-server dist-tests'
+    $CARGO check --target $target --all-targets --no-default-features --features 'all dist-client dist-server'
+    $CARGO check --target $target --all-targets --no-default-features --features 'all dist-client dist-tests'
+    $CARGO check --target $target --all-targets --no-default-features --features 'all dist-server dist-tests'
+    $CARGO check --target $target --all-targets --no-default-features --features 'all dist-client'
+    $CARGO check --target $target --all-targets --no-default-features --features 'all dist-server'
+    $CARGO check --target $target --all-targets --no-default-features --features 'all dist-tests'
+    $CARGO check --target $target --all-targets --no-default-features --features 'all'
+    $CARGO check --target $target --all-targets --no-default-features --features 'dist-client dist-server dist-tests'
+    $CARGO check --target $target --all-targets --no-default-features --features 'dist-client dist-server'
+    $CARGO check --target $target --all-targets --no-default-features --features 'dist-client dist-tests'
+    $CARGO check --target $target --all-targets --no-default-features --features 'dist-server dist-tests'
+    $CARGO check --target $target --all-targets --no-default-features --features 'dist-client'
+    $CARGO check --target $target --all-targets --no-default-features --features 'dist-server'
+    $CARGO check --target $target --all-targets --no-default-features --features 'dist-tests'
+    $CARGO check --target $target --all-targets --no-default-features --features ''
+    wintarget
+    $CARGO check --target $target --all-targets --features 'dist-client'
+    #$CARGO check --target $target --all-targets --features 'all-windows dist-client'
+    #$CARGO check --target $target --all-targets --features 'all-windows'
+    $CARGO check --target $target --all-targets --features ''
+
+
+elif [ "$1" = test ]; then
+    # Musl tests segfault due to https://github.com/mozilla/sccache/issues/256#issuecomment-399254715
+    gnutarget
+    VERBOSE=
+    NOCAPTURE=
+    NORUN=
+    TESTTHREADS=
+    #VERBOSE="--verbose"
+    #NORUN=--no-run
+    #NOCAPTURE=--nocapture
+    TESTTHREADS="--test-threads 1"
+
+    # Since integration tests start up the sccache server they must be run sequentially. This only matters
+    # if you have multiple test functions in one file.
+
+    set +x
+    if ! which docker; then
+        echo -e "WARNING: =====\n\ndocker not present, some tests will fail\n\n=====\n\n\n\n\n"
+        sleep 5
+    fi
+    if ! which icecc-create-env; then
+        echo -e "WARNING: =====\n\nicecc-create-env not present, some tests will fail\n\n=====\n\n\n\n\n"
+        sleep 5
+    fi
+    set -x
+
+    RUST_BACKTRACE=1 $CARGO test $NORUN --target $target --features 'all dist-client dist-server dist-tests' $VERBOSE -- $NOCAPTURE $TESTTHREADS test_dist_nobuilder
+
+else
+    echo invalid command
+    exit 1
+fi

--- a/src/bin/sccache-dist/build.rs
+++ b/src/bin/sccache-dist/build.rs
@@ -18,26 +18,54 @@ use libmount::Overlay;
 use lru_disk_cache::Error as LruError;
 use nix;
 use sccache::dist::{
-    BuildResult, CompileCommand, InputsReader, OutputData, TcCache, Toolchain,
+    BuildResult, CompileCommand, InputsReader, OutputData, ProcessOutput, TcCache, Toolchain,
     BuilderIncoming,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map};
 use std::fs;
 use std::io;
 use std::iter;
 use std::path::{self, Path, PathBuf};
-use std::process::{Command, Output, Stdio};
+use std::process::{ChildStdin, Command, Output, Stdio};
 use std::sync::{Mutex};
 use tar;
 
 use errors::*;
 
-fn check_output(output: &Output) {
-    if !output.status.success() {
-        error!("===========\n{}\n==========\n\n\n\n=========\n{}\n===============\n\n\n",
-            String::from_utf8_lossy(&output.stdout), String::from_utf8_lossy(&output.stderr));
-        panic!()
+trait CommandExt {
+    fn check_stdout_trim(&mut self) -> Result<String>;
+    fn check_piped(&mut self, pipe: &mut FnMut(&mut ChildStdin) -> Result<()>) -> Result<()>;
+    fn check_run(&mut self) -> Result<()>;
+}
+
+impl CommandExt for Command {
+    fn check_stdout_trim(&mut self) -> Result<String> {
+        let output = self.output().chain_err(|| "Failed to start command")?;
+        check_output(&output)?;
+        let stdout = String::from_utf8(output.stdout).chain_err(|| "Output from listing containers not UTF8")?;
+        Ok(stdout.trim().to_owned())
     }
+    // Should really take a FnOnce/FnBox
+    fn check_piped(&mut self, pipe: &mut FnMut(&mut ChildStdin) -> Result<()>) -> Result<()> {
+        let mut process = self.stdin(Stdio::piped()).spawn().chain_err(|| "Failed to start command")?;
+        let mut stdin = process.stdin.take().expect("Requested piped stdin but not present");
+        pipe(&mut stdin).chain_err(|| "Failed to pipe input to process")?;
+        let output = process.wait_with_output().chain_err(|| "Failed to wait for process to return")?;
+        check_output(&output)
+    }
+    fn check_run(&mut self) -> Result<()> {
+        let output = self.output().chain_err(|| "Failed to start command")?;
+        check_output(&output)
+    }
+}
+
+fn check_output(output: &Output) -> Result<()> {
+    if !output.status.success() {
+        warn!("===========\n{}\n==========\n\n\n\n=========\n{}\n===============\n\n\n",
+            String::from_utf8_lossy(&output.stdout), String::from_utf8_lossy(&output.stderr));
+        bail!("Command failed with status {}", output.status)
+    }
+    Ok(())
 }
 
 fn join_suffix<P: AsRef<Path>>(path: &Path, suffix: P) -> PathBuf {
@@ -76,24 +104,30 @@ impl OverlayBuilder {
             dir,
             toolchain_dir_map: Mutex::new(HashMap::new()),
         };
-        ret.cleanup();
-        fs::create_dir(&ret.dir).unwrap();
-        fs::create_dir(ret.dir.join("builds")).unwrap();
-        fs::create_dir(ret.dir.join("toolchains")).unwrap();
+        ret.cleanup()?;
+        fs::create_dir(&ret.dir).chain_err(|| "Failed to create base directory for builder")?;
+        fs::create_dir(ret.dir.join("builds")).chain_err(|| "Failed to create builder builds directory")?;
+        fs::create_dir(ret.dir.join("toolchains")).chain_err(|| "Failed to create builder toolchains directory")?;
         Ok(ret)
     }
 
-    fn cleanup(&self) {
+    fn cleanup(&self) -> Result<()> {
         if self.dir.exists() {
-            fs::remove_dir_all(&self.dir).unwrap()
+            fs::remove_dir_all(&self.dir).chain_err(|| "Failed to clean up builder directory")?
         }
+        Ok(())
     }
 
     fn prepare_overlay_dirs(&self, tc: &Toolchain, tccache: &Mutex<TcCache>) -> Result<OverlaySpec> {
         let (toolchain_dir, id) = {
             let mut toolchain_dir_map = self.toolchain_dir_map.lock().unwrap();
             // Create the toolchain dir (if necessary) while we have an exclusive lock
-            if !toolchain_dir_map.contains_key(tc) {
+            if toolchain_dir_map.contains_key(tc) {
+                // TODO: use if let when sccache can use NLL
+                let entry = toolchain_dir_map.get_mut(tc).expect("Key missing after checking");
+                entry.1 += 1;
+                entry.clone()
+            } else {
                 trace!("Creating toolchain directory for {}", tc.archive_id);
                 let toolchain_dir = self.dir.join("toolchains").join(&tc.archive_id);
                 fs::create_dir(&toolchain_dir)?;
@@ -102,14 +136,14 @@ impl OverlayBuilder {
                 let toolchain_rdr = match tccache.get(tc) {
                     Ok(rdr) => rdr,
                     Err(LruError::FileNotInCache) => bail!("expected toolchain {}, but not available", tc.archive_id),
-                    Err(e) => return Err(Error::with_chain(e, "failed to get toolchain from cache")),
+                    Err(e) => return Err(Error::from(e).chain_err(|| "failed to get toolchain from cache")),
                 };
                 tar::Archive::new(GzDecoder::new(toolchain_rdr)).unpack(&toolchain_dir)?;
-                assert!(toolchain_dir_map.insert(tc.clone(), (toolchain_dir, 0)).is_none())
+
+                let entry = (toolchain_dir, 1);
+                assert!(toolchain_dir_map.insert(tc.clone(), entry.clone()).is_none());
+                entry
             }
-            let entry = toolchain_dir_map.get_mut(tc).unwrap();
-            entry.1 += 1;
-            entry.clone()
         };
 
         trace!("Creating build directory for {}-{}", tc.archive_id, id);
@@ -118,7 +152,7 @@ impl OverlayBuilder {
         Ok(OverlaySpec { build_dir, toolchain_dir })
     }
 
-    fn perform_build(bubblewrap: &Path, compile_command: CompileCommand, inputs_rdr: InputsReader, output_paths: Vec<String>, overlay: &OverlaySpec) -> BuildResult {
+    fn perform_build(bubblewrap: &Path, compile_command: CompileCommand, inputs_rdr: InputsReader, output_paths: Vec<String>, overlay: &OverlaySpec) -> Result<BuildResult> {
         trace!("Compile environment: {:?}", compile_command.env_vars);
         trace!("Compile command: {:?} {:?}", compile_command.executable, compile_command.arguments);
 
@@ -126,40 +160,47 @@ impl OverlayBuilder {
 
             // Now mounted filesystems will be automatically unmounted when this thread dies
             // (and tmpfs filesystems will be completely destroyed)
-            nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNS).unwrap();
+            nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNS)
+                .chain_err(|| "Failed to enter a new Linux namespace")?;
             // Make sure that all future mount changes are private to this namespace
             // TODO: shouldn't need to add these annotations
             let source: Option<&str> = None;
             let fstype: Option<&str> = None;
             let data: Option<&str> = None;
-            nix::mount::mount(source, "/", fstype, nix::mount::MsFlags::MS_REC | nix::mount::MsFlags::MS_PRIVATE, data).unwrap();
+            // Turn / into a 'slave', so it receives mounts from real root, but doesn't propogate back
+            nix::mount::mount(source, "/", fstype, nix::mount::MsFlags::MS_REC | nix::mount::MsFlags::MS_PRIVATE, data)
+                .chain_err(|| "Failed to turn / into a slave")?;
 
             let work_dir = overlay.build_dir.join("work");
             let upper_dir = overlay.build_dir.join("upper");
             let target_dir = overlay.build_dir.join("target");
-            fs::create_dir(&work_dir).unwrap();
-            fs::create_dir(&upper_dir).unwrap();
-            fs::create_dir(&target_dir).unwrap();
+            fs::create_dir(&work_dir).chain_err(|| "Failed to create overlay work directory")?;
+            fs::create_dir(&upper_dir).chain_err(|| "Failed to create overlay upper directory")?;
+            fs::create_dir(&target_dir).chain_err(|| "Failed to create overlay target directory")?;
 
             let () = Overlay::writable(
                 iter::once(overlay.toolchain_dir.as_path()),
                 upper_dir,
                 work_dir,
                 &target_dir,
-            ).mount().unwrap();
+            // This error is unfortunately not Send
+            ).mount().map_err(|e| Error::from(e.to_string())).chain_err(|| "Failed to mount overlay FS")?;
 
             trace!("copying in inputs");
             // Note that we don't unpack directly into the upperdir since there overlayfs has some
             // special marker files that we don't want to create by accident (or malicious intent)
-            tar::Archive::new(inputs_rdr).unpack(&target_dir).unwrap();
+            tar::Archive::new(inputs_rdr).unpack(&target_dir).chain_err(|| "Failed to unpack inputs to overlay")?;
 
             let CompileCommand { executable, arguments, env_vars, cwd } = compile_command;
             let cwd = Path::new(&cwd);
 
             trace!("creating output directories");
-            fs::create_dir_all(join_suffix(&target_dir, cwd)).unwrap();
+            fs::create_dir_all(join_suffix(&target_dir, cwd)).chain_err(|| "Failed to create cwd")?;
             for path in output_paths.iter() {
-                fs::create_dir_all(join_suffix(&target_dir, cwd.join(Path::new(path).parent().unwrap()))).unwrap();
+                // If it doesn't have a parent, nothing needs creating
+                let output_parent = if let Some(p) = Path::new(path).parent() { p } else { continue };
+                fs::create_dir_all(join_suffix(&target_dir, cwd.join(output_parent)))
+                    .chain_err(|| "Failed to create an output directory")?;
             }
 
             trace!("performing compile");
@@ -199,7 +240,7 @@ impl OverlayBuilder {
             cmd.arg("--");
             cmd.arg(executable);
             cmd.args(arguments);
-            let compile_output = cmd.output().unwrap();
+            let compile_output = cmd.output().chain_err(|| "Failed to retrieve output from compile")?;
             trace!("compile_output: {:?}", compile_output);
 
             let mut outputs = vec![];
@@ -208,28 +249,36 @@ impl OverlayBuilder {
                 let abspath = join_suffix(&target_dir, cwd.join(&path)); // Resolve in case it's relative since we copy it from the root level
                 match fs::File::open(abspath) {
                     Ok(mut file) => {
-                        let output = OutputData::from_reader(file);
+                        let output = OutputData::try_from_reader(file)
+                            .chain_err(|| "Failed to read output file")?;
                         outputs.push((path, output))
                     },
                     Err(e) => {
                         if e.kind() == io::ErrorKind::NotFound {
                             debug!("Missing output path {:?}", path)
                         } else {
-                            panic!(e)
+                            return Err(Error::from(e).chain_err(|| "Failed to open output file"))
                         }
                     },
                 }
             }
-            BuildResult { output: compile_output.into(), outputs }
+            let compile_output = ProcessOutput::try_from(compile_output)
+                .chain_err(|| "Failed to convert compilation exit status")?;
+            Ok(BuildResult { output: compile_output, outputs })
 
-        }).join().unwrap() })
+        // Bizarrely there's no way to actually get any information from a thread::Result::Err
+        }).join().unwrap_or_else(|_e| Err(Error::from("Build thread exited unsuccessfully"))) })
     }
 
+    // Failing during cleanup is pretty unexpected, but we can still return the successful compile
+    // TODO: if too many of these fail, we should mark this builder as faulty
     fn finish_overlay(&self, _tc: &Toolchain, overlay: OverlaySpec) {
         // TODO: collect toolchain directories
 
         let OverlaySpec { build_dir, toolchain_dir: _ } = overlay;
-        fs::remove_dir_all(build_dir).unwrap();
+        if let Err(e) = fs::remove_dir_all(&build_dir) {
+            error!("Failed to remove build directory {}: {}", build_dir.display(), e);
+        }
     }
 }
 
@@ -243,11 +292,27 @@ impl BuilderIncoming for OverlayBuilder {
         debug!("Finishing with overlay");
         self.finish_overlay(&tc, overlay);
         debug!("Returning result");
-        Ok(res)
+        res.chain_err(|| "Compilation execution failed")
     }
 }
 
 const BASE_DOCKER_IMAGE: &str = "aidanhs/busybox";
+// Make sure sh doesn't exec the final command, since we need it to do
+// init duties (reaping zombies). Also, because we kill -9 -1, that kills
+// the sleep (it's not a builtin) so it needs to be a loop.
+const DOCKER_SHELL_INIT: &str = "while true; do /busybox sleep 365d && /busybox true; done";
+
+// Check the diff and clean up the FS
+fn docker_diff(cid: &str) -> Result<String> {
+    Command::new("docker").args(&["diff", cid]).check_stdout_trim()
+        .chain_err(|| "Failed to Docker diff container")
+}
+
+// Force remove the container
+fn docker_rm(cid: &str) -> Result<()> {
+    Command::new("docker").args(&["rm", "-f", &cid]).check_run()
+        .chain_err(|| "Failed to force delete container")
+}
 
 pub struct DockerBuilder {
     image_map: Mutex<HashMap<Toolchain, String>>,
@@ -258,128 +323,114 @@ impl DockerBuilder {
     // TODO: this should accept a unique string, e.g. inode of the tccache directory
     // having locked a pidfile, or at minimum should loudly detect other running
     // instances - pidfile in /tmp
-    pub fn new() -> Self {
+    pub fn new() -> Result<Self> {
         info!("Creating docker builder");
 
         let ret = Self {
             image_map: Mutex::new(HashMap::new()),
             container_lists: Mutex::new(HashMap::new()),
         };
-        ret.cleanup();
-        ret
+        ret.cleanup()?;
+        Ok(ret)
     }
 
     // TODO: this should really reclaim, and should check in the image map and container lists, so
     // that when things are removed from there it becomes a form of GC
-    fn cleanup(&self) {
+    fn cleanup(&self) -> Result<()> {
         info!("Performing initial Docker cleanup");
 
-        let containers = {
-            let output = Command::new("docker").args(&["ps", "-a", "--format", "{{.ID}} {{.Image}}"]).output().unwrap();
-            check_output(&output);
-            let stdout = String::from_utf8(output.stdout).unwrap();
-            stdout.trim().to_owned()
-        };
+        let containers = Command::new("docker").args(&["ps", "-a", "--format", "{{.ID}} {{.Image}}"]).check_stdout_trim()
+            .chain_err(|| "Unable to list all Docker containers")?;
         if containers != "" {
             let mut containers_to_rm = vec![];
             for line in containers.split(|c| c == '\n') {
                 let mut iter = line.splitn(2, ' ');
-                let container_id = iter.next().unwrap();
-                let image_name = iter.next().unwrap();
-                if iter.next() != None { panic!() }
+                let container_id = iter.next().ok_or_else(|| Error::from("Malformed container listing - no container ID"))?;
+                let image_name = iter.next().ok_or_else(|| Error::from("Malformed container listing - no image name"))?;
+                if iter.next() != None { bail!("Malformed container listing - third field on row") }
                 if image_name.starts_with("sccache-builder-") {
                     containers_to_rm.push(container_id)
                 }
             }
             if !containers_to_rm.is_empty() {
-                let output = Command::new("docker").args(&["rm", "-f"]).args(containers_to_rm).output().unwrap();
-                check_output(&output)
+                Command::new("docker").args(&["rm", "-f"]).args(containers_to_rm).check_run()
+                    .chain_err(|| "Failed to start command to remove old containers")?;
             }
         }
 
-        let images = {
-            let output = Command::new("docker").args(&["images", "--format", "{{.ID}} {{.Repository}}"]).output().unwrap();
-            check_output(&output);
-            let stdout = String::from_utf8(output.stdout).unwrap();
-            stdout.trim().to_owned()
-        };
+        let images = Command::new("docker").args(&["images", "--format", "{{.ID}} {{.Repository}}"]).check_stdout_trim()
+            .chain_err(|| "Failed to list all docker images")?;
         if images != "" {
             let mut images_to_rm = vec![];
             for line in images.split(|c| c == '\n') {
                 let mut iter = line.splitn(2, ' ');
-                let image_id = iter.next().unwrap();
-                let image_name = iter.next().unwrap();
-                if iter.next() != None { panic!() }
+                let image_id = iter.next().ok_or_else(|| Error::from("Malformed image listing - no image ID"))?;
+                let image_name = iter.next().ok_or_else(|| Error::from("Malformed image listing - no image name"))?;
+                if iter.next() != None { bail!("Malformed image listing - third field on row") }
                 if image_name.starts_with("sccache-builder-") {
                     images_to_rm.push(image_id)
                 }
             }
             if !images_to_rm.is_empty() {
-                let output = Command::new("docker").args(&["rmi"]).args(images_to_rm).output().unwrap();
-                check_output(&output)
+                Command::new("docker").args(&["rmi"]).args(images_to_rm).check_run()
+                    .chain_err(|| "Failed to remove image")?
             }
         }
 
         info!("Completed initial Docker cleanup");
+        Ok(())
     }
 
     // If we have a spare running container, claim it and remove it from the available list,
     // otherwise try and create a new container (possibly creating the Docker image along
     // the way)
-    fn get_container(&self, tc: &Toolchain, tccache: &Mutex<TcCache>) -> String {
+    fn get_container(&self, tc: &Toolchain, tccache: &Mutex<TcCache>) -> Result<String> {
         let container = {
             let mut map = self.container_lists.lock().unwrap();
             map.entry(tc.clone()).or_insert_with(Vec::new).pop()
         };
         match container {
-            Some(cid) => cid,
+            Some(cid) => Ok(cid),
             None => {
                 // TODO: can improve parallelism (of creating multiple images at a time) by using another
                 // (more fine-grained) mutex around the entry value and checking if its empty a second time
                 let image = {
                     let mut map = self.image_map.lock().unwrap();
-                    map.entry(tc.clone()).or_insert_with(|| {
-                        info!("Creating Docker image for {:?} (may block requests)", tc);
-                        Self::make_image(tc, tccache)
-                    }).clone()
+                    match map.entry(tc.clone()) {
+                        hash_map::Entry::Occupied(e) => e.get().clone(),
+                        hash_map::Entry::Vacant(e) => {
+                            info!("Creating Docker image for {:?} (may block requests)", tc);
+                            let image = Self::make_image(tc, tccache)?;
+                            e.insert(image.clone());
+                            image
+                        },
+                    }
                 };
                 Self::start_container(&image)
             },
         }
     }
 
-    fn finish_container(&self, tc: &Toolchain, cid: String) {
-        // TODO: collect images
-
+    fn clean_container(&self, cid: &str) -> Result<()> {
         // Clean up any running processes
-        let output = Command::new("docker").args(&["exec", &cid, "/busybox", "kill", "-9", "-1"]).output().unwrap();
-        check_output(&output);
+        Command::new("docker").args(&["exec", &cid, "/busybox", "kill", "-9", "-1"]).check_run()
+            .chain_err(|| "Failed to run kill on all processes in container")?;
 
-        // Check the diff and clean up the FS
-        fn dodiff(cid: &str) -> String {
-            let output = Command::new("docker").args(&["diff", cid]).output().unwrap();
-            check_output(&output);
-            let stdout = String::from_utf8(output.stdout).unwrap();
-            stdout.trim().to_owned()
-        }
-        let diff = dodiff(&cid);
+        let diff = docker_diff(&cid)?;
         if diff != "" {
-            let mut shoulddelete = false;
             let mut lastpath = None;
             for line in diff.split(|c| c == '\n') {
                 let mut iter = line.splitn(2, ' ');
-                let changetype = iter.next().unwrap();
-                let changepath = iter.next().unwrap();
-                if iter.next() != None { panic!() }
+                let changetype = iter.next().ok_or_else(|| Error::from("Malformed container diff - no change type"))?;
+                let changepath = iter.next().ok_or_else(|| Error::from("Malformed container diff - no change path"))?;
+                if iter.next() != None { bail!("Malformed container diff - third field on row") }
                 // TODO: If files are created in this dir, it gets marked as modified.
                 // A similar thing applies to /root or /build etc
                 if changepath == "/tmp" {
                     continue
                 }
                 if changetype != "A" {
-                    warn!("Deleting container {}: path {} had a non-A changetype of {}", &cid, changepath, changetype);
-                    shoulddelete = true;
-                    break
+                    bail!("Path {} had a non-A changetype of {}", changepath, changetype);
                 }
                 // Docker diff paths are in alphabetical order and we do `rm -rf`, so we might be able to skip
                 // calling Docker more than necessary (since it's slow)
@@ -389,80 +440,88 @@ impl DockerBuilder {
                     }
                 }
                 lastpath = Some(changepath.clone());
-                let output = Command::new("docker").args(&["exec", &cid, "/busybox", "rm", "-rf", changepath]).output().unwrap();
-                check_output(&output);
+                if let Err(e) = Command::new("docker").args(&["exec", &cid, "/busybox", "rm", "-rf", changepath]).check_run() {
+                    // We do a final check anyway, so just continue
+                    warn!("Failed to remove added path in a container: {}", e)
+                }
             }
 
-            let newdiff = dodiff(&cid);
+            let newdiff = docker_diff(&cid)?;
             // See note about changepath == "/tmp" above
-            if !shoulddelete && newdiff != "" && newdiff != "C /tmp" {
-                warn!("Deleted files, but container still has a diff: {:?}", newdiff);
-                shoulddelete = true
-            }
-
-            if shoulddelete {
-                let output = Command::new("docker").args(&["rm", "-f", &cid]).output().unwrap();
-                check_output(&output);
-                return
+            if newdiff != "" && newdiff != "C /tmp" {
+                bail!("Attempted to delete files, but container still has a diff: {:?}", newdiff);
             }
         }
 
-        // Good as new, add it back to the container list
-        trace!("Reclaimed container");
-        self.container_lists.lock().unwrap().get_mut(tc).unwrap().push(cid);
+        Ok(())
     }
 
-    fn make_image(tc: &Toolchain, tccache: &Mutex<TcCache>) -> String {
-        let cid = {
-            let output = Command::new("docker").args(&["create", BASE_DOCKER_IMAGE, "/busybox", "true"]).output().unwrap();
-            check_output(&output);
-            let stdout = String::from_utf8(output.stdout).unwrap();
-            stdout.trim().to_owned()
-        };
+    // Failing during cleanup is pretty unexpected, but we can still return the successful compile
+    // TODO: if too many of these fail, we should mark this builder as faulty
+    fn finish_container(&self, tc: &Toolchain, cid: String) {
+        // TODO: collect images
+
+        if let Err(e) = self.clean_container(&cid) {
+            info!("Failed to clean container {}: {}", cid, e);
+            if let Err(e) = docker_rm(&cid) {
+                warn!("Failed to remove container {} after failed clean: {}", cid, e);
+            }
+            return
+        }
+
+        // Good as new, add it back to the container list
+        if let Some(entry) = self.container_lists.lock().unwrap().get_mut(tc) {
+            debug!("Reclaimed container {}", cid);
+            entry.push(cid)
+        } else {
+            warn!("Was ready to reclaim container {} but toolchain went missing", cid);
+            if let Err(e) = docker_rm(&cid) {
+                warn!("Failed to remove container {}: {}", cid, e);
+            }
+        }
+    }
+
+    fn make_image(tc: &Toolchain, tccache: &Mutex<TcCache>) -> Result<String> {
+        let cid = Command::new("docker").args(&["create", BASE_DOCKER_IMAGE, "/busybox", "true"]).check_stdout_trim()
+            .chain_err(|| "Failed to create docker container")?;
 
         let mut tccache = tccache.lock().unwrap();
-        let toolchain_rdr = match tccache.get(tc) {
+        let mut toolchain_rdr = match tccache.get(tc) {
             Ok(rdr) => rdr,
-            Err(LruError::FileNotInCache) => panic!("expected toolchain, but not available"),
-            Err(e) => panic!("{}", e),
+            Err(LruError::FileNotInCache) => bail!("Expected to find toolchain {}, but not available", tc.archive_id),
+            Err(e) => return Err(Error::from(e).chain_err(|| format!("Failed to use toolchain {}", tc.archive_id))),
         };
 
         trace!("Copying in toolchain");
-        let mut process = Command::new("docker").args(&["cp", "-", &format!("{}:/", cid)]).stdin(Stdio::piped()).spawn().unwrap();
-        io::copy(&mut {toolchain_rdr}, &mut process.stdin.take().unwrap()).unwrap();
-        let output = process.wait_with_output().unwrap();
-        check_output(&output);
+        Command::new("docker").args(&["cp", "-", &format!("{}:/", cid)])
+            .check_piped(&mut |stdin| { io::copy(&mut toolchain_rdr, stdin)?; Ok(()) })
+            .chain_err(|| "Failed to copy toolchain tar into container")?;
+        drop(toolchain_rdr);
 
         let imagename = format!("sccache-builder-{}", &tc.archive_id);
-        let output = Command::new("docker").args(&["commit", &cid, &imagename]).output().unwrap();
-        check_output(&output);
+        Command::new("docker").args(&["commit", &cid, &imagename]).check_run()
+            .chain_err(|| "Failed to commit container after build")?;
 
-        let output = Command::new("docker").args(&["rm", "-f", &cid]).output().unwrap();
-        check_output(&output);
+        Command::new("docker").args(&["rm", "-f", &cid]).check_run()
+            .chain_err(|| "Failed to remove temporary build container")?;
 
-        imagename
+        Ok(imagename)
     }
 
-    fn start_container(image: &str) -> String {
-        // Make sure sh doesn't exec the final command, since we need it to do
-        // init duties (reaping zombies). Also, because we kill -9 -1, that kills
-        // the sleep (it's not a builtin) so it needs to be a loop.
-        let output = Command::new("docker")
-            .args(&["run", "-d", image, "/busybox", "sh", "-c", "while true; do /busybox sleep 365d && /busybox true; done"]).output().unwrap();
-        check_output(&output);
-        let stdout = String::from_utf8(output.stdout).unwrap();
-        stdout.trim().to_owned()
+    fn start_container(image: &str) -> Result<String> {
+        Command::new("docker").args(&["run", "-d", image, "/busybox", "sh", "-c", DOCKER_SHELL_INIT]).check_stdout_trim()
+            .chain_err(|| "Failed to run container")
     }
 
-    fn perform_build(compile_command: CompileCommand, inputs_rdr: InputsReader, output_paths: Vec<String>, cid: &str) -> BuildResult {
+    fn perform_build(compile_command: CompileCommand, mut inputs_rdr: InputsReader, output_paths: Vec<String>, cid: &str) -> Result<BuildResult> {
         trace!("Compile environment: {:?}", compile_command.env_vars);
         trace!("Compile command: {:?} {:?}", compile_command.executable, compile_command.arguments);
 
         trace!("copying in inputs");
-        let mut process = Command::new("docker").args(&["cp", "-", &format!("{}:/", cid)]).stdin(Stdio::piped()).spawn().unwrap();
-        io::copy(&mut {inputs_rdr}, &mut process.stdin.take().unwrap()).unwrap();
-        let output = process.wait_with_output().unwrap();
-        check_output(&output);
+        Command::new("docker").args(&["cp", "-", &format!("{}:/", cid)])
+            .check_piped(&mut |stdin| { io::copy(&mut inputs_rdr, stdin)?; Ok(()) })
+            .chain_err(|| "Failed to copy inputs tar into container")?;
+        drop(inputs_rdr);
 
         let CompileCommand { executable, arguments, env_vars, cwd } = compile_command;
         let cwd = Path::new(&cwd);
@@ -472,10 +531,12 @@ impl DockerBuilder {
         let mut cmd = Command::new("docker");
         cmd.args(&["exec", cid, "/busybox", "mkdir", "-p"]).arg(cwd);
         for path in output_paths.iter() {
-            cmd.arg(cwd.join(Path::new(path).parent().unwrap()));
+            // If it doesn't have a parent, nothing needs creating
+            let output_parent = if let Some(p) = Path::new(path).parent() { p } else { continue };
+            cmd.arg(cwd.join(output_parent));
         }
-        let output = cmd.output().unwrap();
-        check_output(&output);
+        cmd.check_run()
+            .chain_err(|| "Failed to create directories required for compile in container")?;
 
         trace!("performing compile");
         // TODO: likely shouldn't perform the compile as root in the container
@@ -497,7 +558,7 @@ impl DockerBuilder {
         cmd.arg(cwd);
         cmd.arg(executable);
         cmd.args(arguments);
-        let compile_output = cmd.output().unwrap();
+        let compile_output = cmd.output().chain_err(|| "Failed to start executing compile")?;
         trace!("compile_output: {:?}", compile_output);
 
         let mut outputs = vec![];
@@ -505,15 +566,20 @@ impl DockerBuilder {
         for path in output_paths {
             let abspath = cwd.join(&path); // Resolve in case it's relative since we copy it from the root level
             // TODO: this isn't great, but cp gives it out as a tar
-            let output = Command::new("docker").args(&["exec", cid, "/busybox", "cat"]).arg(abspath).output().unwrap();
+            let output = Command::new("docker").args(&["exec", cid, "/busybox", "cat"]).arg(abspath).output()
+                .chain_err(|| "Failed to start command to retrieve output file")?;
             if output.status.success() {
-                outputs.push((path, OutputData::from_reader(&*output.stdout)))
+                let output = OutputData::try_from_reader(&*output.stdout)
+                    .expect("Failed to read compress output stdout");
+                outputs.push((path, output))
             } else {
                 debug!("Missing output path {:?}", path)
             }
         }
 
-        BuildResult { output: compile_output.into(), outputs }
+        let compile_output = ProcessOutput::try_from(compile_output)
+            .chain_err(|| "Failed to convert compilation exit status")?;
+        Ok(BuildResult { output: compile_output, outputs })
     }
 }
 
@@ -522,9 +588,11 @@ impl BuilderIncoming for DockerBuilder {
     // From Server
     fn run_build(&self, tc: Toolchain, command: CompileCommand, outputs: Vec<String>, inputs_rdr: InputsReader, tccache: &Mutex<TcCache>) -> Result<BuildResult> {
         debug!("Finding container");
-        let cid = self.get_container(&tc, tccache);
+        let cid = self.get_container(&tc, tccache)
+            .chain_err(|| "Failed to get a container for build")?;
         debug!("Performing build with container {}", cid);
-        let res = Self::perform_build(command, inputs_rdr, outputs, &cid);
+        let res = Self::perform_build(command, inputs_rdr, outputs, &cid)
+            .chain_err(|| "Failed to perform build")?;
         debug!("Finishing with container {}", cid);
         self.finish_container(&tc, cid);
         debug!("Returning result");

--- a/src/bin/sccache-dist/token_check.rs
+++ b/src/bin/sccache-dist/token_check.rs
@@ -1,0 +1,336 @@
+use base64;
+use jwt;
+use openssl;
+use reqwest;
+use sccache::dist::http::{ClientAuthCheck, ClientVisibleMsg};
+use serde_json;
+use std::collections::HashMap;
+use std::result::Result as StdResult;
+use std::sync::Mutex;
+use std::time::{UNIX_EPOCH, Duration, Instant, SystemTime};
+
+use errors::*;
+
+// https://auth0.com/docs/jwks
+#[derive(Debug)]
+#[derive(Serialize, Deserialize)]
+pub struct Jwks {
+    pub keys: Vec<Jwk>,
+}
+
+#[derive(Debug)]
+#[derive(Serialize, Deserialize)]
+pub struct Jwk {
+    pub kid: String,
+    kty: String,
+    n: String,
+    e: String,
+}
+
+impl Jwk {
+    // https://github.com/lawliet89/biscuit/issues/96#issuecomment-399149872
+    pub fn to_der_pkcs1(&self) -> Result<Vec<u8>> {
+        if self.kty != "RSA" {
+            bail!("Cannot handle non-RSA JWK")
+        }
+
+        // JWK is big-endian, openssl bignum from_slice is big-endian
+        let n = base64::decode_config(&self.n, base64::URL_SAFE).chain_err(|| "Failed to base64 decode n")?;
+        let e = base64::decode_config(&self.e, base64::URL_SAFE).chain_err(|| "Failed to base64 decode e")?;
+        let n_bn = openssl::bn::BigNum::from_slice(&n).chain_err(|| "Failed to create openssl bignum from n")?;
+        let e_bn = openssl::bn::BigNum::from_slice(&e).chain_err(|| "Failed to create openssl bignum from e")?;
+        let pubkey = openssl::rsa::Rsa::from_public_components(n_bn, e_bn)
+            .chain_err(|| "Failed to create pubkey from n and e")?;
+        let der: Vec<u8> = pubkey.public_key_to_der_pkcs1()
+            .chain_err(|| "Failed to convert public key to der pkcs1")?;
+        Ok(der)
+    }
+}
+
+// Check a token is equal to a fixed string
+pub struct EqCheck {
+    s: String,
+}
+
+impl ClientAuthCheck for EqCheck {
+    fn check(&self, token: &str) -> StdResult<(), ClientVisibleMsg> {
+        if self.s == token {
+            Ok(())
+        } else {
+            warn!("User token {} != expected token {}", token, self.s);
+            Err(ClientVisibleMsg::from_nonsensitive("Fixed token mismatch".to_owned()))
+        }
+    }
+}
+
+impl EqCheck {
+    pub fn new(s: String) -> Self {
+        Self { s }
+    }
+}
+
+// https://infosec.mozilla.org/guidelines/iam/openid_connect#session-handling
+const MOZ_SESSION_TIMEOUT: Duration = Duration::from_secs(60 * 15);
+const MOZ_USERINFO_ENDPOINT: &str = "https://auth.mozilla.auth0.com/userinfo";
+
+// Mozilla-specific check by forwarding the token onto the auth0 userinfo endpoint
+pub struct MozillaCheck {
+    auth_cache: Mutex<HashMap<String, Instant>>, // token, token_expiry
+    client: reqwest::Client,
+    required_groups: Vec<String>,
+}
+
+impl ClientAuthCheck for MozillaCheck {
+    fn check(&self, token: &str) -> StdResult<(), ClientVisibleMsg> {
+        self.check_mozilla(token)
+            .map_err(|e| {
+                warn!("Mozilla token validation failed: {}", e);
+                ClientVisibleMsg::from_nonsensitive("Failed to validate Mozilla OAuth token".to_owned())
+            })
+    }
+}
+
+impl MozillaCheck {
+    pub fn new(required_groups: Vec<String>) -> Self {
+        Self {
+            auth_cache: Mutex::new(HashMap::new()),
+            client: reqwest::Client::new(),
+            required_groups,
+        }
+    }
+
+    fn check_mozilla(&self, token: &str) -> Result<()> {
+        // azp == client_id
+        // {
+        //   "iss": "https://auth.mozilla.auth0.com/",
+        //   "sub": "ad|Mozilla-LDAP|asayers",
+        //   "aud": [
+        //     "sccache",
+        //     "https://auth.mozilla.auth0.com/userinfo"
+        //   ],
+        //   "iat": 1541103283,
+        //   "exp": 1541708083,
+        //   "azp": "F1VVD6nRTckSVrviMRaOdLBWIk1AvHYo",
+        //   "scope": "openid"
+        // }
+        #[derive(Deserialize)]
+        struct MozillaToken {
+            exp: u64,
+            sub: String,
+        }
+        // We don't really do any validation here (just forwarding on) so it's ok to unsafely decode
+        let unsafe_token = jwt::dangerous_unsafe_decode::<MozillaToken>(token).chain_err(|| "Unable to decode jwt")?;
+        let user = unsafe_token.claims.sub;
+        trace!("Validating token for user {} with mozilla", user);
+        if UNIX_EPOCH + Duration::from_secs(unsafe_token.claims.exp) < SystemTime::now() {
+            bail!("JWT expired")
+        }
+        // If the token is cached and not expired, return it
+        {
+            let mut auth_cache = self.auth_cache.lock().unwrap();
+            if let Some(cached_at) = auth_cache.get(token) {
+                if cached_at.elapsed() < MOZ_SESSION_TIMEOUT {
+                    return Ok(())
+                }
+            }
+            auth_cache.remove(token);
+        }
+
+        debug!("User {} not in cache, validating via auth0 endpoint", user);
+        // Retrieve the groups from the auth0 /userinfo endpoint, which Mozilla rules populate with groups
+        // https://github.com/mozilla-iam/auth0-deploy/blob/6889f1dde12b84af50bb4b2e2f00d5e80d5be33f/rules/CIS-Claims-fixups.js#L158-L168
+        let url = reqwest::Url::parse(MOZ_USERINFO_ENDPOINT).expect("Failed to parse MOZ_USERINFO_ENDPOINT");
+        let header = reqwest::header::Authorization(reqwest::header::Bearer { token: token.to_owned() });
+        let mut res = self.client.get(url.clone()).header(header).send()
+            .chain_err(|| "Failed to make request to mozilla userinfo")?;
+        let res_text = res.text()
+            .chain_err(|| "Failed to interpret response from mozilla userinfo as string")?;
+        if !res.status().is_success() {
+            bail!("JWT forwarded to {} returned {}: {}", url, res.status(), res_text)
+        }
+
+        // The API didn't return a HTTP error code, let's check the response
+        let () = check_mozilla_profile(&user, &self.required_groups, &res_text)
+            .chain_err(|| format!("Validation of the user profile failed for {}", user))?;
+
+        // Validation success, cache the token
+        debug!("Validation for user {} succeeded, caching", user);
+        {
+            let mut auth_cache = self.auth_cache.lock().unwrap();
+            auth_cache.insert(token.to_owned(), Instant::now());
+        }
+        Ok(())
+    }
+}
+
+fn check_mozilla_profile(user: &str, required_groups: &[String], profile: &str) -> Result<()> {
+    #[derive(Deserialize)]
+    struct UserInfo {
+        sub: String,
+        #[serde(rename = "https://sso.mozilla.com/claim/groups")]
+        groups: Vec<String>,
+    }
+    let profile: UserInfo = serde_json::from_str(profile)
+        .chain_err(|| format!("Could not parse profile: {}", profile))?;
+    if user != profile.sub {
+        bail!("User {} retrieved in profile is different to desired user {}", profile.sub, user)
+    }
+    for group in required_groups.iter() {
+        if !profile.groups.contains(group) {
+            bail!("User {} is not a member of required group {}", user, group)
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_auth_verify_check_mozilla_profile() {
+    // A successful response
+    let profile =  r#"{
+        "sub": "ad|Mozilla-LDAP|asayers",
+        "https://sso.mozilla.com/claim/groups": [
+            "everyone",
+            "hris_dept_firefox",
+            "hris_individual_contributor",
+            "hris_nonmanagers",
+            "hris_is_staff",
+            "hris_workertype_contractor"
+        ],
+        "https://sso.mozilla.com/claim/README_FIRST": "Please refer to https://github.com/mozilla-iam/person-api in order to query Mozilla IAM CIS user profile data"
+    }"#;
+
+    // If the user has been deactivated since the token was issued. Note this may be partnered with an error code
+    // response so may never reach validation
+    let profile_fail = r#"{
+        "error": "unauthorized",
+        "error_description": "user is blocked"
+    }"#;
+
+    assert!(check_mozilla_profile("ad|Mozilla-LDAP|asayers", &["hris_dept_firefox".to_owned()], profile).is_ok());
+    assert!(check_mozilla_profile("ad|Mozilla-LDAP|asayers", &[], profile).is_ok());
+    assert!(check_mozilla_profile("ad|Mozilla-LDAP|asayers", &["hris_the_ceo".to_owned()], profile).is_err());
+
+    assert!(check_mozilla_profile("ad|Mozilla-LDAP|asayers", &[], profile_fail).is_err());
+}
+
+// Don't check a token is valid (it may not even be a JWT) just forward it to
+// an API and check for success
+pub struct ProxyTokenCheck {
+    client: reqwest::Client,
+    maybe_auth_cache: Option<Mutex<(HashMap<String, Instant>, Duration)>>,
+    url: String,
+}
+
+impl ClientAuthCheck for ProxyTokenCheck {
+    fn check(&self, token: &str) -> StdResult<(), ClientVisibleMsg> {
+        match self.check_token_with_forwarding(token) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                warn!("Proxying token validation failed: {}", e);
+                Err(ClientVisibleMsg::from_nonsensitive("Validation with token forwarding failed".to_owned()))
+            },
+        }
+    }
+}
+
+impl ProxyTokenCheck {
+    pub fn new(url: String, cache_secs: Option<u64>) -> Self {
+        let maybe_auth_cache: Option<Mutex<(HashMap<String, Instant>, Duration)>> =
+            cache_secs.map(|secs| Mutex::new((HashMap::new(), Duration::from_secs(secs))));
+        Self {
+            client: reqwest::Client::new(),
+            maybe_auth_cache,
+            url,
+        }
+    }
+
+    fn check_token_with_forwarding(&self, token: &str) -> Result<()> {
+        #[derive(Deserialize)]
+        struct Token {
+            exp: u64,
+        }
+        let unsafe_token = jwt::dangerous_unsafe_decode::<Token>(token).chain_err(|| "Unable to decode jwt")?;
+        trace!("Validating token by forwarding to {}", self.url);
+        if UNIX_EPOCH + Duration::from_secs(unsafe_token.claims.exp) < SystemTime::now() {
+            bail!("JWT expired")
+        }
+        // If the token is cached and not cache has not expired, return it
+        if let Some(ref auth_cache) = self.maybe_auth_cache {
+            let mut auth_cache = auth_cache.lock().unwrap();
+            let (ref mut auth_cache, cache_duration) = *auth_cache;
+            if let Some(cached_at) = auth_cache.get(token) {
+                if cached_at.elapsed() < cache_duration {
+                    return Ok(())
+                }
+            }
+            auth_cache.remove(token);
+        }
+        // Make a request to another API, which as a side effect should actually check the token
+        let header = reqwest::header::Authorization(reqwest::header::Bearer { token: token.to_owned() });
+        let res = self.client.get(&self.url).header(header).send()
+            .chain_err(|| "Failed to make request to proxying url")?;
+        if !res.status().is_success() {
+            bail!("JWT forwarded to {} returned {}", self.url, res.status());
+        }
+        // Cache the token
+        if let Some(ref auth_cache) = self.maybe_auth_cache {
+            let mut auth_cache = auth_cache.lock().unwrap();
+            let (ref mut auth_cache, _) = *auth_cache;
+            auth_cache.insert(token.to_owned(), Instant::now());
+        }
+        Ok(())
+    }
+}
+
+// Check a JWT is valid
+pub struct ValidJWTCheck {
+    audience: String,
+    issuer: String,
+    kid_to_pkcs1: HashMap<String, Vec<u8>>,
+}
+
+impl ClientAuthCheck for ValidJWTCheck {
+    fn check(&self, token: &str) -> StdResult<(), ClientVisibleMsg> {
+        match self.check_jwt_validity(token) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                warn!("JWT validation failed: {}", e);
+                Err(ClientVisibleMsg::from_nonsensitive("JWT could not be validated".to_owned()))
+            },
+        }
+    }
+}
+
+impl ValidJWTCheck {
+    pub fn new(audience: String, issuer: String, jwks_url: &str) -> Result<Self> {
+        let mut res = reqwest::get(jwks_url)
+            .chain_err(|| "Failed to make request to JWKs url")?;
+        if !res.status().is_success() {
+            bail!("Could not retrieve JWKs, HTTP error: {}", res.status())
+        }
+        let jwks: Jwks = res.json()
+            .chain_err(|| "Failed to parse JWKs json")?;
+        let kid_to_pkcs1 = jwks.keys.into_iter()
+            .map(|k| k.to_der_pkcs1().map(|pkcs1| (k.kid, pkcs1)))
+            .collect::<Result<_>>()
+            .chain_err(|| "Failed to convert JWKs into pkcs1")?;
+        Ok(Self { audience, issuer, kid_to_pkcs1})
+    }
+
+    fn check_jwt_validity(&self, token: &str) -> Result<()> {
+        let header = jwt::decode_header(token).chain_err(|| "Could not decode jwt header")?;
+        trace!("Validating JWT in scheduler");
+        // Prepare validation
+        let kid = header.kid.chain_err(|| "No kid found")?;
+        let pkcs1 = self.kid_to_pkcs1.get(&kid).chain_err(|| "kid not found in jwks")?;
+        let mut validation = jwt::Validation::new(header.alg);
+        validation.set_audience(&self.audience);
+        validation.iss = Some(self.issuer.clone());
+        #[derive(Deserialize)]
+        struct Claims {}
+        // Decode the JWT, discarding any claims - we just care about validity
+        let _tokendata = jwt::decode::<Claims>(token, pkcs1, &validation)
+            .chain_err(|| "Unable to validate and decode jwt")?;
+        Ok(())
+    }
+}

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -172,9 +172,12 @@ pub fn parse() -> Result<Command> {
     } else if dist_auth {
         Ok(Command::DistAuth)
     } else if package_toolchain {
-        let mut values = matches.values_of_os("package-toolchain").unwrap();
+        let mut values = matches.values_of_os("package-toolchain").expect("Parsed package-toolchain but no values");
         assert!(values.len() == 2);
-        let (executable, out) = (values.next().unwrap(), values.next().unwrap());
+        let (executable, out) = (
+            values.next().expect("package-toolchain missing value 1"),
+            values.next().expect("package-toolchain missing value 2")
+        );
         Ok(Command::PackageToolchain(executable.into(), out.into()))
     } else if let Some(mut args) = cmd {
         if let Some(exe) = args.next() {

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -348,7 +348,8 @@ impl pkg::InputsPackager for CInputsPackager {
         let CInputsPackager { input_path, mut path_transformer, preprocessed_input } = *{self};
 
         let input_path = pkg::simplify_path(&input_path)?;
-        let dist_input_path = path_transformer.to_dist(&input_path).unwrap();
+        let dist_input_path = path_transformer.to_dist(&input_path)
+            .chain_err(|| format!("unable to transform input path {}", input_path.display()))?;
 
         let mut builder = tar::Builder::new(wtr);
 

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -524,7 +524,7 @@ pub fn generate_compile_commands(path_transformer: &mut dist::PathTransformer,
             executable: path_transformer.to_dist(&executable)?,
             arguments: arguments,
             env_vars: dist::osstring_tuples_to_strings(env_vars)?,
-            cwd: path_transformer.to_dist_assert_abs(cwd)?,
+            cwd: path_transformer.to_dist_abs(cwd)?,
         })
     })();
 
@@ -1044,11 +1044,12 @@ mod test {
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));
         let mut path_transformer = dist::PathTransformer::new();
-        let (command, _, cacheable) = generate_compile_commands(&mut path_transformer,
-                                                                &compiler,
-                                                                &parsed_args,
-                                                                f.tempdir.path(),
-                                                                &[]).unwrap();
+        let (command, dist_command, cacheable) = generate_compile_commands(&mut path_transformer,
+                                                                           &compiler,
+                                                                           &parsed_args,
+                                                                           f.tempdir.path(),
+                                                                           &[]).unwrap();
+        assert!(dist_command.is_some());
         let _ = command.execute(&creator).wait();
         assert_eq!(Cacheable::Yes, cacheable);
         // Ensure that we ran all processes.

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -1049,6 +1049,7 @@ mod test {
                                                                            &parsed_args,
                                                                            f.tempdir.path(),
                                                                            &[]).unwrap();
+        #[cfg(feature = "dist-client")]
         assert!(dist_command.is_some());
         let _ = command.execute(&creator).wait();
         assert_eq!(Cacheable::Yes, cacheable);

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -1051,6 +1051,8 @@ mod test {
                                                                            &[]).unwrap();
         #[cfg(feature = "dist-client")]
         assert!(dist_command.is_some());
+        #[cfg(not(feature = "dist-client"))]
+        assert!(dist_command.is_none());
         let _ = command.execute(&creator).wait();
         assert_eq!(Cacheable::Yes, cacheable);
         // Ensure that we ran all processes.

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -890,6 +890,7 @@ mod test {
                                                                            &parsed_args,
                                                                            f.tempdir.path(),
                                                                            &[]).unwrap();
+        #[cfg(feature = "dist-client")]
         assert!(dist_command.is_some());
         let _ = command.execute(&creator).wait();
         assert_eq!(Cacheable::Yes, cacheable);
@@ -923,6 +924,7 @@ mod test {
                                                                            &parsed_args,
                                                                            f.tempdir.path(),
                                                                            &[]).unwrap();
+        #[cfg(feature = "dist-client")]
         assert!(dist_command.is_some());
         let _ = command.execute(&creator).wait();
         assert_eq!(Cacheable::No, cacheable);

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -892,6 +892,8 @@ mod test {
                                                                            &[]).unwrap();
         #[cfg(feature = "dist-client")]
         assert!(dist_command.is_some());
+        #[cfg(not(feature = "dist-client"))]
+        assert!(dist_command.is_none());
         let _ = command.execute(&creator).wait();
         assert_eq!(Cacheable::Yes, cacheable);
         // Ensure that we ran all processes.
@@ -926,6 +928,8 @@ mod test {
                                                                            &[]).unwrap();
         #[cfg(feature = "dist-client")]
         assert!(dist_command.is_some());
+        #[cfg(not(feature = "dist-client"))]
+        assert!(dist_command.is_none());
         let _ = command.execute(&creator).wait();
         assert_eq!(Cacheable::No, cacheable);
         // Ensure that we ran all processes.

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -885,11 +885,12 @@ mod test {
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));
         let mut path_transformer = dist::PathTransformer::new();
-        let (command, _, cacheable) = generate_compile_commands(&mut path_transformer,
-                                                                &compiler,
-                                                                &parsed_args,
-                                                                f.tempdir.path(),
-                                                                &[]).unwrap();
+        let (command, dist_command, cacheable) = generate_compile_commands(&mut path_transformer,
+                                                                           &compiler,
+                                                                           &parsed_args,
+                                                                           f.tempdir.path(),
+                                                                           &[]).unwrap();
+        assert!(dist_command.is_some());
         let _ = command.execute(&creator).wait();
         assert_eq!(Cacheable::Yes, cacheable);
         // Ensure that we ran all processes.
@@ -917,11 +918,12 @@ mod test {
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));
         let mut path_transformer = dist::PathTransformer::new();
-        let (command, _, cacheable) = generate_compile_commands(&mut path_transformer,
-                                                                &compiler,
-                                                                &parsed_args,
-                                                                f.tempdir.path(),
-                                                                &[]).unwrap();
+        let (command, dist_command, cacheable) = generate_compile_commands(&mut path_transformer,
+                                                                           &compiler,
+                                                                           &parsed_args,
+                                                                           f.tempdir.path(),
+                                                                           &[]).unwrap();
+        assert!(dist_command.is_some());
         let _ = command.execute(&creator).wait();
         assert_eq!(Cacheable::No, cacheable);
         // Ensure that we ran all processes.

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -11,46 +11,26 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![allow(unused)]
-
 #[cfg(feature = "dist-client")]
 pub use self::client::Client;
 #[cfg(feature = "dist-server")]
-pub use self::server::{Scheduler, ClientAuthCheck, ServerAuthCheck};
+pub use self::server::{Scheduler, ClientAuthCheck, ClientVisibleMsg, ServerAuthCheck};
 #[cfg(feature = "dist-server")]
 pub use self::server::Server;
 
-//#[allow(unused)]
 mod common {
     use bincode;
+    #[cfg(feature = "dist-client")]
     use futures::{Future, Stream};
     use reqwest;
     use serde;
-    use std::net::{IpAddr, SocketAddr};
-    use dist::{JobId, CompileCommand};
+    #[cfg(feature = "dist-server")]
+    use std::collections::HashMap;
+    use std::fmt;
+
+    use dist;
 
     use errors::*;
-
-    const SCHEDULER_PORT: u16 = 10500;
-    const SERVER_PORT: u16 = 10501;
-
-    // TODO: move this into the config module
-    pub struct Cfg;
-
-    impl Cfg {
-        pub fn scheduler_listen_addr() -> SocketAddr {
-            let ip_addr = "0.0.0.0".parse().unwrap();
-            SocketAddr::new(ip_addr, SCHEDULER_PORT)
-        }
-        pub fn scheduler_connect_addr(scheduler_addr: IpAddr) -> SocketAddr {
-            SocketAddr::new(scheduler_addr, SCHEDULER_PORT)
-        }
-
-        pub fn server_listen_addr() -> SocketAddr {
-            let ip_addr = "0.0.0.0".parse().unwrap();
-            SocketAddr::new(ip_addr, SERVER_PORT)
-        }
-    }
 
     // Note that content-length is necessary due to https://github.com/tiny-http/tiny-http/issues/147
     pub trait ReqwestRequestBuilderExt {
@@ -60,7 +40,7 @@ mod common {
     }
     impl ReqwestRequestBuilderExt for reqwest::RequestBuilder {
         fn bincode<T: serde::Serialize + ?Sized>(&mut self, bincode: &T) -> Result<&mut Self> {
-            let bytes = bincode::serialize(bincode)?;
+            let bytes = bincode::serialize(bincode).chain_err(|| "Failed to serialize body to bincode")?;
             Ok(self.bytes(bytes))
         }
         fn bytes(&mut self, bytes: Vec<u8>) -> &mut Self {
@@ -74,7 +54,7 @@ mod common {
     }
     impl ReqwestRequestBuilderExt for reqwest::unstable::async::RequestBuilder {
         fn bincode<T: serde::Serialize + ?Sized>(&mut self, bincode: &T) -> Result<&mut Self> {
-            let bytes = bincode::serialize(bincode)?;
+            let bytes = bincode::serialize(bincode).chain_err(|| "Failed to serialize body to bincode")?;
             Ok(self.bytes(bytes))
         }
         fn bytes(&mut self, bytes: Vec<u8>) -> &mut Self {
@@ -91,13 +71,14 @@ mod common {
         let mut res = req.send()?;
         let status = res.status();
         let mut body = vec![];
-        res.copy_to(&mut body).unwrap();
+        res.copy_to(&mut body).chain_err(|| "error reading response body")?;
         if !status.is_success() {
             Err(format!("Error {} (Headers={:?}): {}", status.as_u16(), res.headers(), String::from_utf8_lossy(&body)).into())
         } else {
             bincode::deserialize(&body).map_err(Into::into)
         }
     }
+    #[cfg(feature = "dist-client")]
     pub fn bincode_req_fut<T: serde::de::DeserializeOwned + 'static>(req: &mut reqwest::unstable::async::RequestBuilder) -> SFuture<T> {
         Box::new(req.send().map_err(Into::into)
             .and_then(|res| {
@@ -120,20 +101,93 @@ mod common {
     #[derive(Eq, PartialEq)]
     #[serde(deny_unknown_fields)]
     pub struct JobJwt {
-        pub job_id: JobId,
+        pub job_id: dist::JobId,
     }
 
     #[derive(Clone, Debug, Serialize, Deserialize)]
     #[serde(deny_unknown_fields)]
+    pub enum AllocJobHttpResponse {
+        Success { job_alloc: dist::JobAlloc, need_toolchain: bool, cert_digest: Vec<u8> },
+        Fail { msg: String },
+    }
+    impl AllocJobHttpResponse {
+        #[cfg(feature = "dist-server")]
+        pub fn from_alloc_job_result(res: dist::AllocJobResult, certs: &HashMap<dist::ServerId, (Vec<u8>, Vec<u8>)>) -> Self {
+            match res {
+                dist::AllocJobResult::Success { job_alloc, need_toolchain } => {
+                    if let Some((digest, _)) = certs.get(&job_alloc.server_id) {
+                        AllocJobHttpResponse::Success { job_alloc, need_toolchain, cert_digest: digest.to_owned() }
+                    } else {
+                        AllocJobHttpResponse::Fail { msg: format!("missing certificates for server {}", job_alloc.server_id.addr()) }
+                    }
+                },
+                dist::AllocJobResult::Fail { msg } => AllocJobHttpResponse::Fail { msg },
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct ServerCertificateHttpResponse {
+        pub cert_digest: Vec<u8>,
+        pub cert_pem: Vec<u8>,
+    }
+
+    #[derive(Clone, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
     pub struct HeartbeatServerHttpRequest {
         pub jwt_key: Vec<u8>,
         pub num_cpus: usize,
+        pub server_nonce: dist::ServerNonce,
+        pub cert_digest: Vec<u8>,
+        pub cert_pem: Vec<u8>,
+    }
+    // cert_pem is quite long so elide it (you can retrieve it by hitting the server url anyway)
+    impl fmt::Debug for HeartbeatServerHttpRequest {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            let HeartbeatServerHttpRequest { jwt_key, num_cpus, server_nonce, cert_digest, cert_pem } = self;
+            write!(f, "HeartbeatServerHttpRequest {{ jwt_key: {:?}, num_cpus: {:?}, server_nonce: {:?}, cert_digest: {:?}, cert_pem: [...{} bytes...] }}", jwt_key, num_cpus, server_nonce, cert_digest, cert_pem.len())
+        }
     }
     #[derive(Clone, Debug, Serialize, Deserialize)]
     #[serde(deny_unknown_fields)]
     pub struct RunJobHttpRequest {
-        pub command: CompileCommand,
+        pub command: dist::CompileCommand,
         pub outputs: Vec<String>,
+    }
+}
+
+pub mod urls {
+    use dist::{JobId, ServerId};
+    use reqwest;
+
+    pub fn scheduler_alloc_job(scheduler_url: &reqwest::Url) -> reqwest::Url {
+        scheduler_url.join("/api/v1/scheduler/alloc_job").expect("failed to create alloc job url")
+    }
+    pub fn scheduler_server_certificate(scheduler_url: &reqwest::Url, server_id: ServerId) -> reqwest::Url {
+        scheduler_url.join(&format!("/api/v1/scheduler/server_certificate/{}", server_id.addr())).expect("failed to create server certificate url")
+    }
+    pub fn scheduler_heartbeat_server(scheduler_url: &reqwest::Url) -> reqwest::Url {
+        scheduler_url.join("/api/v1/scheduler/heartbeat_server").expect("failed to create heartbeat url")
+    }
+    pub fn scheduler_job_state(scheduler_url: &reqwest::Url, job_id: JobId) -> reqwest::Url {
+        scheduler_url.join(&format!("/api/v1/scheduler/job_state/{}", job_id)).expect("failed to create job state url")
+    }
+    pub fn scheduler_status(scheduler_url: &reqwest::Url) -> reqwest::Url {
+        scheduler_url.join("/api/v1/scheduler/status").expect("failed to create alloc job url")
+    }
+
+    pub fn server_assign_job(server_id: ServerId, job_id: JobId) -> reqwest::Url {
+        let url = format!("https://{}/api/v1/distserver/assign_job/{}", server_id.addr(), job_id);
+        reqwest::Url::parse(&url).expect("failed to create assign job url")
+    }
+    pub fn server_submit_toolchain(server_id: ServerId, job_id: JobId) -> reqwest::Url {
+        let url = format!("https://{}/api/v1/distserver/submit_toolchain/{}", server_id.addr(), job_id);
+        reqwest::Url::parse(&url).expect("failed to create submit toolchain url")
+    }
+    pub fn server_run_job(server_id: ServerId, job_id: JobId) -> reqwest::Url {
+        let url = format!("https://{}/api/v1/distserver/run_job/{}", server_id.addr(), job_id);
+        reqwest::Url::parse(&url).expect("failed to create run job url")
     }
 }
 
@@ -144,44 +198,110 @@ mod server {
     use flate2::read::ZlibDecoder as ZlibReadDecoder;
     use jwt;
     use num_cpus;
+    use openssl;
     use rand::{self, RngCore};
     use reqwest;
     use rouille;
     use serde;
     use serde_json;
     use std;
+    use std::collections::HashMap;
     use std::io::Read;
-    use std::net::{IpAddr, SocketAddr};
+    use std::net::SocketAddr;
+    use std::result::Result as StdResult;
     use std::sync::atomic;
+    use std::sync::Mutex;
     use std::thread;
     use std::time::Duration;
+    use void::Void;
 
     use dist::{
         self,
 
-        ServerId, JobId, Toolchain,
+        ServerId, ServerNonce, JobId, Toolchain,
         ToolchainReader, InputsReader,
+        JobAuthorizer,
 
         AllocJobResult,
         AssignJobResult,
         HeartbeatServerResult,
         RunJobResult,
-        StatusResult,
+        SchedulerStatusResult,
         SubmitToolchainResult,
         UpdateJobStateResult, JobState,
     };
     use super::common::{
-        Cfg,
         ReqwestRequestBuilderExt,
         bincode_req,
 
         JobJwt,
+        AllocJobHttpResponse,
+        ServerCertificateHttpResponse,
         HeartbeatServerHttpRequest,
         RunJobHttpRequest,
     };
+    use super::urls;
     use errors::*;
 
-    pub type ClientAuthCheck = Box<Fn(&str) -> bool + Send + Sync>;
+    fn create_https_cert_and_privkey(addr: SocketAddr) -> Result<(Vec<u8>, Vec<u8>, Vec<u8>)> {
+        let rsa_key = openssl::rsa::Rsa::<openssl::pkey::Private>::generate(2048)
+            .chain_err(|| "failed to generate rsa privkey")?;
+        let privkey_pem = rsa_key.private_key_to_pem()
+            .chain_err(|| "failed to create pem from rsa privkey")?;
+        let privkey: openssl::pkey::PKey<openssl::pkey::Private> = openssl::pkey::PKey::from_rsa(rsa_key)
+            .chain_err(|| "failed to create openssl pkey from rsa privkey")?;
+        let mut builder = openssl::x509::X509::builder()
+            .chain_err(|| "failed to create x509 builder")?;
+
+        // Populate the certificate with the necessary parts, mostly from mkcert in openssl
+        builder.set_version(2)
+            .chain_err(|| "failed to set x509 version")?;
+        let serial_number = openssl::bn::BigNum::from_u32(0).and_then(|bn| bn.to_asn1_integer())
+            .chain_err(|| "failed to create openssl asn1 0")?;
+        builder.set_serial_number(serial_number.as_ref())
+            .chain_err(|| "failed to set x509 serial number")?;
+        let not_before = openssl::asn1::Asn1Time::days_from_now(0)
+            .chain_err(|| "failed to create openssl not before asn1")?;
+        builder.set_not_before(not_before.as_ref())
+            .chain_err(|| "failed to set not before on x509")?;
+        let not_after = openssl::asn1::Asn1Time::days_from_now(365)
+            .chain_err(|| "failed to create openssl not after asn1")?;
+        builder.set_not_after(not_after.as_ref())
+            .chain_err(|| "failed to set not after on x509")?;
+        builder.set_pubkey(privkey.as_ref())
+            .chain_err(|| "failed to set pubkey for x509")?;
+
+        // Add the SubjectAlternativeName
+        let extension = openssl::x509::extension::SubjectAlternativeName::new()
+            .ip(&addr.ip().to_string())
+            .build(&builder.x509v3_context(None, None))
+            .chain_err(|| "failed to build SAN extension for x509")?;
+        builder.append_extension(extension)
+            .chain_err(|| "failed to append SAN extension for x509")?;
+
+        // Finish the certificate
+        builder.sign(&privkey, openssl::hash::MessageDigest::sha1())
+            .chain_err(|| "failed to sign x509 with sha1")?;
+        let cert: openssl::x509::X509 = builder.build();
+        let cert_pem = cert.to_pem()
+            .chain_err(|| "failed to create pem from x509")?;
+        let cert_digest = cert.digest(openssl::hash::MessageDigest::sha1())
+            .chain_err(|| "failed to create digest of x509 certificate")?
+            .as_ref().to_owned();
+
+        Ok((cert_digest, cert_pem, privkey_pem))
+    }
+
+    // Messages that are non-sensitive and can be sent to the client
+    #[derive(Debug)]
+    pub struct ClientVisibleMsg(String);
+    impl ClientVisibleMsg {
+        pub fn from_nonsensitive(s: String) -> Self { ClientVisibleMsg(s) }
+    }
+
+    pub trait ClientAuthCheck: Send + Sync {
+        fn check(&self, token: &str) -> StdResult<(), ClientVisibleMsg>;
+    }
     pub type ServerAuthCheck = Box<Fn(&str) -> Option<ServerId> + Send + Sync>;
 
     const JWT_KEY_LENGTH: usize = 256 / 8;
@@ -253,18 +373,6 @@ mod server {
         }
     }
 
-    // Based on rouille::Response::json
-    pub fn bincode_response<T>(content: &T) -> rouille::Response where T: serde::Serialize {
-        let data = bincode::serialize(content).unwrap();
-
-        rouille::Response {
-            status_code: 200,
-            headers: vec![("Content-Type".into(), "application/octet-stream".into())],
-            data: rouille::ResponseBody::from_data(data),
-            upgrade: None,
-        }
-    }
-
     // Based on try_or_400 in rouille, but with logging
     #[derive(Serialize)]
     pub struct ErrJson<'a> {
@@ -278,7 +386,7 @@ mod server {
             ErrJson { description: err.description(), cause }
         }
         fn into_data(self) -> String {
-            serde_json::to_string(&self).unwrap()
+            serde_json::to_string(&self).expect("infallible serialization for ErrJson failed")
         }
     }
     macro_rules! try_or_err_and_log {
@@ -309,13 +417,16 @@ mod server {
     macro_rules! try_or_500_log {
         ($reqid:expr, $result:expr) => { try_or_err_and_log!($reqid, 500, $result) };
     }
-    fn make_401(short_err: &str) -> rouille::Response {
+    fn make_401_with_body(short_err: &str, body: ClientVisibleMsg) -> rouille::Response {
         rouille::Response {
             status_code: 401,
             headers: vec![("WWW-Authenticate".into(), format!("Bearer error=\"{}\"", short_err).into())],
-            data: rouille::ResponseBody::empty(),
+            data: rouille::ResponseBody::from_data(body.0),
             upgrade: None,
         }
+    }
+    fn make_401(short_err: &str) -> rouille::Response {
+        make_401_with_body(short_err, ClientVisibleMsg(String::new()))
     }
     fn bearer_http_auth(request: &rouille::Request) -> Option<&str> {
         let header = request.header("Authorization")?;
@@ -329,50 +440,105 @@ mod server {
 
         split.next()
     }
-    macro_rules! try_jwt_or_401 {
-        ($request:ident, $key:expr, $valid_claims:expr) => {{
-            let claims: Result<_> = match bearer_http_auth($request) {
-                Some(token) => {
-                    jwt::decode(&token, $key, &JWT_VALIDATION)
-                        .map_err(Into::into)
-                        .and_then(|res| {
-                            fn identical_t<T>(_: &T, _: &T) {}
-                            let valid_claims = $valid_claims;
-                            identical_t(&res.claims, &valid_claims);
-                            if res.claims == valid_claims { Ok(()) } else { Err("invalid claims".into()) }
-                        })
-                },
-                None => Err("no Authorization header".into()),
+
+    // Based on rouille::Response::json
+    pub fn bincode_response<T>(content: &T) -> rouille::Response where T: serde::Serialize {
+        let data = bincode::serialize(content).chain_err(|| "Failed to serialize response body");
+        let data = try_or_500_log!("bincode body serialization", data);
+
+        rouille::Response {
+            status_code: 200,
+            headers: vec![("Content-Type".into(), "application/octet-stream".into())],
+            data: rouille::ResponseBody::from_data(data),
+            upgrade: None,
+        }
+    }
+
+    // Verification of job auth in a request
+    macro_rules! job_auth_or_401 {
+        ($request:ident, $job_authorizer:expr, $job_id:expr) => {{
+            let verify_result = match bearer_http_auth($request) {
+                Some(token) => $job_authorizer.verify_token($job_id, token),
+                None => Err("no Authorization header".to_owned()),
             };
-            match claims {
+            match verify_result {
                 Ok(()) => (),
                 Err(err) => {
+                    let err = Error::from(err);
                     let json = ErrJson::from_err(&err);
-                    let mut res = make_401("invalid_jwt");
-                    res.data = rouille::ResponseBody::from_data(json.into_data());
-                    return res
+                    return make_401_with_body("invalid_jwt", ClientVisibleMsg(json.into_data()))
                 },
             }
         }};
     }
+    // Generation and verification of job auth
+    struct JWTJobAuthorizer {
+        server_key: Vec<u8>,
+    }
+    impl JWTJobAuthorizer {
+        fn new(server_key: Vec<u8>) -> Box<Self> {
+            Box::new(Self { server_key })
+        }
+    }
+    impl dist::JobAuthorizer for JWTJobAuthorizer {
+        fn generate_token(&self, job_id: JobId) -> StdResult<String, String> {
+            let claims = JobJwt { job_id };
+            jwt::encode(&JWT_HEADER, &claims, &self.server_key)
+                .map_err(|e| format!("Failed to create JWT for job: {}", e))
+        }
+        fn verify_token(&self, job_id: JobId, token: &str) -> StdResult<(), String> {
+            let valid_claims = JobJwt { job_id };
+            jwt::decode(&token, &self.server_key, &JWT_VALIDATION)
+                .map_err(|e| format!("JWT decode failed: {}", e))
+                .and_then(|res| {
+                    fn identical_t<T>(_: &T, _: &T) {}
+                    identical_t(&res.claims, &valid_claims);
+                    if res.claims == valid_claims { Ok(()) } else { Err("mismatched claims".to_owned()) }
+                })
+        }
+    }
+
+    #[test]
+    fn test_job_token_verification() {
+        let ja = JWTJobAuthorizer::new(vec![1,2,2]);
+
+        let job_id = JobId(55);
+        let token = ja.generate_token(job_id).unwrap();
+
+        let job_id2 = JobId(56);
+        let token2 = ja.generate_token(job_id2).unwrap();
+
+        let ja2 = JWTJobAuthorizer::new(vec![1,2,3]);
+
+        // Check tokens are deterministic
+        assert_eq!(token, ja.generate_token(job_id).unwrap());
+        // Check token verification works
+        assert!(ja.verify_token(job_id, &token).is_ok());
+        assert!(ja.verify_token(job_id, &token2).is_err());
+        assert!(ja.verify_token(job_id2, &token).is_err());
+        assert!(ja.verify_token(job_id2, &token2).is_ok());
+        // Check token verification with a different key fails
+        assert!(ja2.verify_token(job_id, &token).is_err());
+        assert!(ja2.verify_token(job_id2, &token2).is_err());
+    }
 
     pub struct Scheduler<S> {
+        public_addr: SocketAddr,
         handler: S,
         // Is this client permitted to use the scheduler?
-        check_client_auth: ClientAuthCheck,
+        check_client_auth: Box<ClientAuthCheck>,
         // Do we believe the server is who they appear to be?
         check_server_auth: ServerAuthCheck,
     }
 
     impl<S: dist::SchedulerIncoming + 'static> Scheduler<S> {
-        pub fn new(handler: S, check_client_auth: ClientAuthCheck, check_server_auth: ServerAuthCheck) -> Self {
-            Self { handler, check_client_auth, check_server_auth }
+        pub fn new(public_addr: SocketAddr, handler: S, check_client_auth: Box<ClientAuthCheck>, check_server_auth: ServerAuthCheck) -> Self {
+            Self { public_addr, handler, check_client_auth, check_server_auth }
         }
 
-        pub fn start(self) -> ! {
-            let Self { handler, check_client_auth, check_server_auth } = self;
-            let requester = SchedulerRequester { client: reqwest::Client::new() };
-            let addr = Cfg::scheduler_listen_addr();
+        pub fn start(self) -> Result<Void> {
+            let Self { public_addr, handler, check_client_auth, check_server_auth } = self;
+            let requester = SchedulerRequester { client: Mutex::new(reqwest::Client::new()) };
 
             macro_rules! check_server_auth_or_401 {
                 ($request:ident) => {{
@@ -384,20 +550,65 @@ mod server {
                 };
             }
 
-            info!("Scheduler listening for clients on {}", addr);
+            fn maybe_update_certs(client: &mut reqwest::Client, certs: &mut HashMap<ServerId, (Vec<u8>, Vec<u8>)>, server_id: ServerId, cert_digest: Vec<u8>, cert_pem: Vec<u8>) -> Result<()> {
+                if let Some((saved_cert_digest, _)) = certs.get(&server_id) {
+                    if saved_cert_digest == &cert_digest {
+                        return Ok(())
+                    }
+                }
+                info!("Adding new certificate for {} to scheduler", server_id.addr());
+                let mut client_builder = reqwest::ClientBuilder::new();
+                // Add all the certificates we know about
+                client_builder.add_root_certificate(reqwest::Certificate::from_pem(&cert_pem)
+                    .chain_err(|| "failed to interpret pem as certificate")?);
+                for (_, cert_pem) in certs.values() {
+                    client_builder.add_root_certificate(reqwest::Certificate::from_pem(cert_pem).expect("previously valid cert"));
+                }
+                // Finish the clients
+                let new_client = client_builder.build().chain_err(|| "failed to create a HTTP client")?;
+                // Use the updated certificates
+                *client = new_client;
+                certs.insert(server_id, (cert_digest, cert_pem));
+                Ok(())
+            }
+
+            info!("Scheduler listening for clients on {}", public_addr);
             let request_count = atomic::AtomicUsize::new(0);
-            let server = rouille::Server::new(addr, move |request| {
+            // From server_id -> cert_digest, cert_pem
+            let server_certificates: Mutex<HashMap<ServerId, (Vec<u8>, Vec<u8>)>> = Default::default();
+
+            let server = rouille::Server::new(public_addr, move |request| {
                 let req_id = request_count.fetch_add(1, atomic::Ordering::SeqCst);
                 trace!("Req {} ({}): {:?}", req_id, request.remote_addr(), request);
                 let response = (|| router!(request,
                     (POST) (/api/v1/scheduler/alloc_job) => {
-                        if !bearer_http_auth(request).map_or(false, &*check_client_auth) {
-                            return make_401("invalid_bearer_token")
+                        let bearer_auth = match bearer_http_auth(request) {
+                            Some(s) => s,
+                            None => return make_401("no_bearer_auth"),
+                        };
+                        match check_client_auth.check(bearer_auth) {
+                            Ok(()) => (),
+                            Err(client_msg) => {
+                                warn!("Bearer auth failed: {:?}", client_msg);
+                                return make_401_with_body("bearer_auth_failed", client_msg)
+                            },
                         }
                         let toolchain = try_or_400_log!(req_id, bincode_input(request));
                         trace!("Req {}: alloc_job: {:?}", req_id, toolchain);
 
-                        let res: AllocJobResult = try_or_500_log!(req_id, handler.handle_alloc_job(&requester, toolchain));
+                        let alloc_job_res: AllocJobResult = try_or_500_log!(req_id, handler.handle_alloc_job(&requester, toolchain));
+                        let certs = server_certificates.lock().unwrap();
+                        let res = AllocJobHttpResponse::from_alloc_job_result(alloc_job_res, &certs);
+                        bincode_response(&res)
+                    },
+                    (GET) (/api/v1/scheduler/server_certificate/{server_id: ServerId}) => {
+                        let certs = server_certificates.lock().unwrap();
+                        let (cert_digest, cert_pem) = try_or_500_log!(req_id, certs.get(&server_id)
+                            .ok_or_else(|| Error::from("server cert not available")));
+                        let res = ServerCertificateHttpResponse {
+                            cert_digest: cert_digest.clone(),
+                            cert_pem: cert_pem.clone(),
+                        };
                         bincode_response(&res)
                     },
                     (POST) (/api/v1/scheduler/heartbeat_server) => {
@@ -405,12 +616,18 @@ mod server {
                         let heartbeat_server = try_or_400_log!(req_id, bincode_input(request));
                         trace!("Req {}: heartbeat_server: {:?}", req_id, heartbeat_server);
 
-                        let HeartbeatServerHttpRequest { num_cpus, jwt_key } = heartbeat_server;
-                        let generate_job_auth = Box::new(move |job_id| {
-                            let claims = JobJwt { job_id };
-                            jwt::encode(&JWT_HEADER, &claims, &jwt_key).unwrap()
-                        });
-                        let res: HeartbeatServerResult = handler.handle_heartbeat_server(server_id, num_cpus, generate_job_auth).unwrap();
+                        let HeartbeatServerHttpRequest { num_cpus, jwt_key, server_nonce, cert_digest, cert_pem } = heartbeat_server;
+                        try_or_500_log!(req_id, maybe_update_certs(
+                            &mut requester.client.lock().unwrap(),
+                            &mut server_certificates.lock().unwrap(),
+                            server_id, cert_digest, cert_pem
+                        ));
+                        let job_authorizer = JWTJobAuthorizer::new(jwt_key);
+                        let res: HeartbeatServerResult = try_or_500_log!(req_id, handler.handle_heartbeat_server(
+                            server_id, server_nonce,
+                            num_cpus,
+                            job_authorizer
+                        ));
                         bincode_response(&res)
                     },
                     (POST) (/api/v1/scheduler/job_state/{job_id: JobId}) => {
@@ -418,71 +635,98 @@ mod server {
                         let job_state = try_or_400_log!(req_id, bincode_input(request));
                         trace!("Req {}: job state: {:?}", req_id, job_state);
 
-                        let res: UpdateJobStateResult = handler.handle_update_job_state(job_id, server_id, job_state).unwrap();
+                        let res: UpdateJobStateResult = try_or_500_log!(req_id, handler.handle_update_job_state(
+                            job_id, server_id, job_state
+                        ));
                         bincode_response(&res)
                     },
                     (GET) (/api/v1/scheduler/status) => {
-                        let res: StatusResult = handler.handle_status().unwrap();
+                        let res: SchedulerStatusResult = try_or_500_log!(req_id, handler.handle_status());
                         bincode_response(&res)
                     },
                     _ => {
                         warn!("Unknown request {:?}", request);
                         rouille::Response::empty_404()
                     },
-                )) ();
+                ))();
                 trace!("Res {}: {:?}", req_id, response);
                 response
-            }).unwrap();
+            }).map_err(|e| Error::with_boxed_chain(e, ErrorKind::Msg("Failed to start http server for sccache scheduler".to_owned())))?;
             server.run();
 
-            unreachable!()
+            panic!("Rouille server terminated")
         }
     }
 
     struct SchedulerRequester {
-        client: reqwest::Client,
+        client: Mutex<reqwest::Client>,
     }
 
     impl dist::SchedulerOutgoing for SchedulerRequester {
         fn do_assign_job(&self, server_id: ServerId, job_id: JobId, tc: Toolchain, auth: String) -> Result<AssignJobResult> {
-            let url = format!("http://{}/api/v1/distserver/assign_job/{}", server_id.addr(), job_id);
-            bincode_req(self.client.post(&url).bearer_auth(auth).bincode(&tc)?)
+            let url = urls::server_assign_job(server_id, job_id);
+            let mut req = self.client.lock().unwrap().post(url);
+            bincode_req(req.bearer_auth(auth).bincode(&tc)?)
+                .chain_err(|| "POST to scheduler assign_job failed")
         }
     }
 
     pub struct Server<S> {
-        scheduler_addr: SocketAddr,
+        public_addr: SocketAddr,
+        scheduler_url: reqwest::Url,
         scheduler_auth: String,
-        handler: S,
+        // HTTPS pieces all the builders will use for connection encryption
+        cert_digest: Vec<u8>,
+        cert_pem: Vec<u8>,
+        privkey_pem: Vec<u8>,
+        // Key used to sign any requests relating to jobs
         jwt_key: Vec<u8>,
+        // Randomly generated nonce to allow the scheduler to detect server restarts
+        server_nonce: ServerNonce,
+        handler: S,
     }
 
     impl<S: dist::ServerIncoming + 'static> Server<S> {
-        pub fn new(scheduler_addr: IpAddr, scheduler_auth: String, handler: S) -> Self {
+        pub fn new(public_addr: SocketAddr, scheduler_url: reqwest::Url, scheduler_auth: String, handler: S) -> Result<Self> {
+            let (cert_digest, cert_pem, privkey_pem) = create_https_cert_and_privkey(public_addr)
+                .chain_err(|| "failed to create HTTPS certificate for server")?;
             let mut jwt_key = vec![0; JWT_KEY_LENGTH];
-            let mut rng = rand::OsRng::new().unwrap();
+            let mut rng = rand::OsRng::new().chain_err(|| "Failed to initialise a random number generator")?;
             rng.fill_bytes(&mut jwt_key);
-            Self {
-                scheduler_addr: Cfg::scheduler_connect_addr(scheduler_addr),
+            let server_nonce = ServerNonce::from_rng(&mut rng);
+
+            Ok(Self {
+                public_addr,
+                scheduler_url,
                 scheduler_auth,
+                cert_digest,
+                cert_pem,
+                privkey_pem,
                 jwt_key,
+                server_nonce,
                 handler,
-            }
+            })
         }
 
-        pub fn start(self) -> ! {
-            let Self { scheduler_addr, scheduler_auth, jwt_key, handler } = self;
-            let requester = ServerRequester { client: reqwest::Client::new(), scheduler_addr, scheduler_auth: scheduler_auth.clone() };
-            let addr = Cfg::server_listen_addr();
+        pub fn start(self) -> Result<Void> {
+            let Self { public_addr, scheduler_url, scheduler_auth, cert_digest, cert_pem, privkey_pem, jwt_key, server_nonce, handler } = self;
+            let heartbeat_req = HeartbeatServerHttpRequest {
+                num_cpus: num_cpus::get(),
+                jwt_key: jwt_key.clone(),
+                server_nonce,
+                cert_digest,
+                cert_pem: cert_pem.clone(),
+            };
+            let job_authorizer = JWTJobAuthorizer::new(jwt_key);
+            let heartbeat_url = urls::scheduler_heartbeat_server(&scheduler_url);
+            let requester = ServerRequester { client: reqwest::Client::new(), scheduler_url, scheduler_auth: scheduler_auth.clone() };
 
             // TODO: detect if this panics
-            let heartbeat_req = HeartbeatServerHttpRequest { num_cpus: num_cpus::get(), jwt_key: jwt_key.clone() };
             thread::spawn(move || {
-                let url = format!("http://{}:{}/api/v1/scheduler/heartbeat_server", scheduler_addr.ip(), scheduler_addr.port());
                 let client = reqwest::Client::new();
                 loop {
                     trace!("Performing heartbeat");
-                    match bincode_req(client.post(&url).bearer_auth(scheduler_auth.clone()).bincode(&heartbeat_req).unwrap()) {
+                    match bincode_req(client.post(heartbeat_url.clone()).bearer_auth(scheduler_auth.clone()).bincode(&heartbeat_req).expect("failed to serialize heartbeat")) {
                         Ok(HeartbeatServerResult { is_new }) => {
                             trace!("Heartbeat success is_new={}", is_new);
                             // TODO: if is_new, terminate all running jobs
@@ -496,37 +740,40 @@ mod server {
                 }
             });
 
-            info!("Server listening for clients on {}", addr);
+            info!("Server listening for clients on {}", public_addr);
             let request_count = atomic::AtomicUsize::new(0);
-            let server = rouille::Server::new(addr, move |request| {
+
+            let server = rouille::Server::new_ssl(public_addr, move |request| {
                 let req_id = request_count.fetch_add(1, atomic::Ordering::SeqCst);
                 trace!("Req {} ({}): {:?}", req_id, request.remote_addr(), request);
                 let response = (|| router!(request,
                     (POST) (/api/v1/distserver/assign_job/{job_id: JobId}) => {
-                        try_jwt_or_401!(request, &jwt_key, JobJwt { job_id });
+                        job_auth_or_401!(request, &job_authorizer, job_id);
                         let toolchain = try_or_400_log!(req_id, bincode_input(request));
                         trace!("Req {}: assign_job({}): {:?}", req_id, job_id, toolchain);
 
-                        let res: AssignJobResult = try_or_500_log!(req_id, handler.handle_assign_job(job_id, toolchain));
+                        let res: AssignJobResult = try_or_500_log!(req_id, handler.handle_assign_job(&requester, job_id, toolchain));
                         bincode_response(&res)
                     },
                     (POST) (/api/v1/distserver/submit_toolchain/{job_id: JobId}) => {
-                        try_jwt_or_401!(request, &jwt_key, JobJwt { job_id });
+                        job_auth_or_401!(request, &job_authorizer, job_id);
                         trace!("Req {}: submit_toolchain({})", req_id, job_id);
 
-                        let mut body = request.data().unwrap();
+                        let mut body = request.data().expect("body was already read in submit_toolchain");
                         let toolchain_rdr = ToolchainReader(Box::new(body));
                         let res: SubmitToolchainResult = try_or_500_log!(req_id, handler.handle_submit_toolchain(&requester, job_id, toolchain_rdr));
                         bincode_response(&res)
                     },
                     (POST) (/api/v1/distserver/run_job/{job_id: JobId}) => {
-                        try_jwt_or_401!(request, &jwt_key, JobJwt { job_id });
+                        job_auth_or_401!(request, &job_authorizer, job_id);
 
-                        let mut body = request.data().unwrap();
-                        let bincode_length = body.read_u32::<BigEndian>().unwrap() as u64;
+                        let mut body = request.data().expect("body was already read in run_job");
+                        let bincode_length = try_or_500_log!(req_id, body.read_u32::<BigEndian>()
+                            .chain_err(|| "failed to read run job input length")) as u64;
 
                         let mut bincode_reader = body.take(bincode_length);
-                        let runjob = bincode::deserialize_from(&mut bincode_reader).unwrap();
+                        let runjob = try_or_500_log!(req_id, bincode::deserialize_from(&mut bincode_reader)
+                            .chain_err(|| "failed to deserialize run job request"));
                         trace!("Req {}: run_job({}): {:?}", req_id, job_id, runjob);
                         let RunJobHttpRequest { command, outputs } = runjob;
                         let body = bincode_reader.into_inner();
@@ -543,23 +790,24 @@ mod server {
                 ))();
                 trace!("Res {}: {:?}", req_id, response);
                 response
-            }).unwrap();
+            }, cert_pem, privkey_pem).map_err(|e| Error::with_boxed_chain(e, ErrorKind::Msg("Failed to start http server for sccache server".to_owned())))?;
             server.run();
 
-            unreachable!()
+            panic!("Rouille server terminated")
         }
     }
 
     struct ServerRequester {
         client: reqwest::Client,
-        scheduler_addr: SocketAddr,
+        scheduler_url: reqwest::Url,
         scheduler_auth: String,
     }
 
     impl dist::ServerOutgoing for ServerRequester {
         fn do_update_job_state(&self, job_id: JobId, state: JobState) -> Result<UpdateJobStateResult> {
-            let url = format!("http://{}/api/v1/scheduler/job_state/{}", self.scheduler_addr, job_id);
-            bincode_req(self.client.post(&url).bearer_auth(self.scheduler_auth.clone()).bincode(&state)?)
+            let url = urls::scheduler_job_state(&self.scheduler_url, job_id);
+            bincode_req(self.client.post(url).bearer_auth(self.scheduler_auth.clone()).bincode(&state)?)
+                .chain_err(|| "POST to scheduler job_state failed")
         }
     }
 }
@@ -573,13 +821,13 @@ mod client {
     use dist::pkg::{InputsPackager, ToolchainPackager};
     use flate2::Compression;
     use flate2::write::ZlibEncoder as ZlibWriteEncoder;
-    use futures::{Future, Stream};
+    use futures::Future;
     use futures_cpupool::CpuPool;
     use reqwest;
-    use std::fs;
+    use std::collections::HashMap;
     use std::io::Write;
-    use std::net::{IpAddr, SocketAddr};
     use std::path::Path;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use super::super::cache;
     use tokio_core;
@@ -590,80 +838,153 @@ mod client {
         AllocJobResult, JobAlloc, RunJobResult, SubmitToolchainResult,
     };
     use super::common::{
-        Cfg,
         ReqwestRequestBuilderExt,
         bincode_req,
         bincode_req_fut,
 
+        AllocJobHttpResponse,
+        ServerCertificateHttpResponse,
         RunJobHttpRequest,
     };
+    use super::urls;
     use errors::*;
 
     const REQUEST_TIMEOUT_SECS: u64 = 600;
 
     pub struct Client {
         auth_token: String,
-        scheduler_addr: SocketAddr,
+        scheduler_url: reqwest::Url,
+        // cert_digest -> cert_pem
+        server_certs: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
         // TODO: this should really only use the async client, but reqwest async bodies are extremely limited
         // and only support owned bytes, which means the whole toolchain would end up in memory
-        client: reqwest::Client,
-        client_async: reqwest::unstable::async::Client,
+        client: Arc<Mutex<reqwest::Client>>,
+        client_async: Arc<Mutex<reqwest::unstable::async::Client>>,
+        handle: tokio_core::reactor::Handle,
         pool: CpuPool,
-        tc_cache: cache::ClientToolchains,
+        tc_cache: Arc<cache::ClientToolchains>,
     }
 
     impl Client {
-        pub fn new(handle: &tokio_core::reactor::Handle, pool: &CpuPool, scheduler_addr: IpAddr, cache_dir: &Path, cache_size: u64, toolchain_configs: &[config::DistToolchainConfig], auth_token: String) -> Self {
+        pub fn new(handle: tokio_core::reactor::Handle, pool: &CpuPool, scheduler_url: reqwest::Url, cache_dir: &Path, cache_size: u64, toolchain_configs: &[config::DistToolchainConfig], auth_token: String) -> Result<Self> {
             let timeout = Duration::new(REQUEST_TIMEOUT_SECS, 0);
-            let client = reqwest::ClientBuilder::new().timeout(timeout).build().unwrap();
-            let client_async = reqwest::unstable::async::ClientBuilder::new().timeout(timeout).build(handle).unwrap();
-            Self {
+            let client = reqwest::ClientBuilder::new().timeout(timeout).build()
+                .chain_err(|| "failed to create a HTTP client")?;
+            let client_async = reqwest::unstable::async::ClientBuilder::new().timeout(timeout).build(&handle)
+                .chain_err(|| "failed to create an async HTTP client")?;
+            let client_toolchains = cache::ClientToolchains::new(cache_dir, cache_size, toolchain_configs)
+                .chain_err(|| "failed to initialise client toolchains")?;
+            Ok(Self {
                 auth_token,
-                scheduler_addr: Cfg::scheduler_connect_addr(scheduler_addr),
-                client,
-                client_async,
+                scheduler_url,
+                server_certs: Default::default(),
+                client: Arc::new(Mutex::new(client)),
+                client_async: Arc::new(Mutex::new(client_async)),
+                handle,
                 pool: pool.clone(),
-                tc_cache: cache::ClientToolchains::new(cache_dir, cache_size, toolchain_configs),
+                tc_cache: Arc::new(client_toolchains),
+            })
+        }
+
+        fn update_certs(client: &mut reqwest::Client, client_async: &mut reqwest::unstable::async::Client, handle: tokio_core::reactor::Handle, certs: &mut HashMap<Vec<u8>, Vec<u8>>, cert_digest: Vec<u8>, cert_pem: Vec<u8>) -> Result<()> {
+            let mut client_builder = reqwest::ClientBuilder::new();
+            let mut client_async_builder = reqwest::unstable::async::ClientBuilder::new();
+            // Add all the certificates we know about
+            client_builder.add_root_certificate(reqwest::Certificate::from_pem(&cert_pem)
+                .chain_err(|| "failed to interpret pem as certificate")?);
+            client_async_builder.add_root_certificate(reqwest::Certificate::from_pem(&cert_pem)
+                .chain_err(|| "failed to interpret pem as certificate")?);
+            for cert_pem in certs.values() {
+                client_builder.add_root_certificate(reqwest::Certificate::from_pem(cert_pem).expect("previously valid cert"));
+                client_async_builder.add_root_certificate(reqwest::Certificate::from_pem(cert_pem).expect("previously valid cert"));
             }
+            // Finish the clients
+            let timeout = Duration::new(REQUEST_TIMEOUT_SECS, 0);
+            let new_client = client_builder.timeout(timeout).build()
+                .chain_err(|| "failed to create a HTTP client")?;
+            let new_client_async = client_async_builder.timeout(timeout).build(&handle)
+                .chain_err(|| "failed to create an async HTTP client")?;
+            // Use the updated certificates
+            *client = new_client;
+            *client_async = new_client_async;
+            certs.insert(cert_digest, cert_pem);
+            Ok(())
         }
     }
 
     impl dist::Client for Client {
         fn do_alloc_job(&self, tc: Toolchain) -> SFuture<AllocJobResult> {
-            let url = format!("http://{}/api/v1/scheduler/alloc_job", self.scheduler_addr);
-            Box::new(f_res(self.client_async.post(&url).bearer_auth(self.auth_token.clone()).bincode(&tc).map(bincode_req_fut)).and_then(|r| r))
+            let scheduler_url = self.scheduler_url.clone();
+            let url = urls::scheduler_alloc_job(&scheduler_url);
+            let mut req = self.client_async.lock().unwrap().post(url);
+            ftry!(req.bearer_auth(self.auth_token.clone()).bincode(&tc));
+
+            let client = self.client.clone();
+            let client_async = self.client_async.clone();
+            let handle = self.handle.clone();
+            let server_certs = self.server_certs.clone();
+            Box::new(bincode_req_fut(&mut req).map_err(|e| e.chain_err(|| "POST to scheduler alloc_job failed")).and_then(move |res| {
+                match res {
+                    AllocJobHttpResponse::Success { job_alloc, need_toolchain, cert_digest } => {
+                        let server_id = job_alloc.server_id;
+                        let alloc_job_res = f_ok(AllocJobResult::Success { job_alloc, need_toolchain });
+                        if server_certs.lock().unwrap().contains_key(&cert_digest) {
+                            return alloc_job_res
+                        }
+                        info!("Need to request new certificate for server {}", server_id.addr());
+                        let url = urls::scheduler_server_certificate(&scheduler_url, server_id);
+                        let mut req = client_async.lock().unwrap().get(url);
+                        Box::new(bincode_req_fut(&mut req).map_err(|e| e.chain_err(|| "GET to scheduler server_certificate failed"))
+                            .and_then(move |res: ServerCertificateHttpResponse| {
+                                ftry!(Self::update_certs(
+                                    &mut client.lock().unwrap(), &mut client_async.lock().unwrap(),
+                                    handle,
+                                    &mut server_certs.lock().unwrap(),
+                                    res.cert_digest, res.cert_pem,
+                                ));
+                                alloc_job_res
+                            }))
+                    },
+                    AllocJobHttpResponse::Fail { msg } => {
+                        f_ok(AllocJobResult::Fail { msg })
+                    },
+                }
+            }))
         }
         fn do_submit_toolchain(&self, job_alloc: JobAlloc, tc: Toolchain) -> SFuture<SubmitToolchainResult> {
-            if let Some(toolchain_file) = self.tc_cache.get_toolchain(&tc) {
-                let url = format!("http://{}/api/v1/distserver/submit_toolchain/{}", job_alloc.server_id.addr(), job_alloc.job_id);
-                let mut req = self.client.post(&url);
+            match self.tc_cache.get_toolchain(&tc) {
+                Ok(Some(toolchain_file)) => {
+                    let url = urls::server_submit_toolchain(job_alloc.server_id, job_alloc.job_id);
+                    let mut req = self.client.lock().unwrap().post(url);
 
-                Box::new(self.pool.spawn_fn(move || {
-                    req.bearer_auth(job_alloc.auth.clone()).body(toolchain_file);
-                    bincode_req(&mut req)
-                }))
-            } else {
-                f_err("couldn't find toolchain locally")
+                    Box::new(self.pool.spawn_fn(move || {
+                        req.bearer_auth(job_alloc.auth.clone()).body(toolchain_file);
+                        bincode_req(&mut req)
+                    }))
+                },
+                Ok(None) => f_err("couldn't find toolchain locally"),
+                Err(e) => f_err(e),
             }
         }
         fn do_run_job(&self, job_alloc: JobAlloc, command: CompileCommand, outputs: Vec<String>, inputs_packager: Box<InputsPackager>) -> SFuture<(RunJobResult, PathTransformer)> {
-            let url = format!("http://{}/api/v1/distserver/run_job/{}", job_alloc.server_id.addr(), job_alloc.job_id);
-            let mut req = self.client.post(&url);
+            let url = urls::server_run_job(job_alloc.server_id, job_alloc.job_id);
+            let mut req = self.client.lock().unwrap().post(url);
 
             Box::new(self.pool.spawn_fn(move || {
-                let bincode = bincode::serialize(&RunJobHttpRequest { command, outputs }).unwrap();
+                let bincode = bincode::serialize(&RunJobHttpRequest { command, outputs })
+                    .chain_err(|| "failed to serialize run job request")?;
                 let bincode_length = bincode.len();
 
                 let mut body = vec![];
-                body.write_u32::<BigEndian>(bincode_length as u32).unwrap();
-                body.write(&bincode).unwrap();
+                body.write_u32::<BigEndian>(bincode_length as u32).expect("Infallible write of bincode length to vec failed");
+                body.write(&bincode).expect("Infallible write of bincode body to vec failed");
                 let path_transformer;
                 {
                     let mut compressor = ZlibWriteEncoder::new(&mut body, Compression::fast());
                     path_transformer = inputs_packager.write_inputs(&mut compressor).chain_err(|| "Could not write inputs for compilation")?;
-                    compressor.flush().unwrap();
+                    compressor.flush().chain_err(|| "failed to flush compressor")?;
                     trace!("Compressed inputs from {} -> {}", compressor.total_in(), compressor.total_out());
-                    compressor.finish().unwrap();
+                    compressor.finish().chain_err(|| "failed to finish compressor")?;
                 }
 
                 req.bearer_auth(job_alloc.auth.clone()).bytes(body);
@@ -671,11 +992,11 @@ mod client {
             }))
         }
 
-        fn put_toolchain(&self, compiler_path: &Path, weak_key: &str, toolchain_packager: Box<ToolchainPackager>) -> Result<(Toolchain, Option<String>)> {
-            self.tc_cache.put_toolchain(compiler_path, weak_key, toolchain_packager)
-        }
-        fn may_dist(&self) -> bool {
-            true
+        fn put_toolchain(&self, compiler_path: &Path, weak_key: &str, toolchain_packager: Box<ToolchainPackager>) -> SFuture<(Toolchain, Option<String>)> {
+            let compiler_path = compiler_path.to_owned();
+            let weak_key = weak_key.to_owned();
+            let tc_cache = self.tc_cache.clone();
+            Box::new(self.pool.spawn_fn(move || tc_cache.put_toolchain(&compiler_path, &weak_key, toolchain_packager)))
         }
     }
 }

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -479,6 +479,7 @@ pub enum AllocJobResult {
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AssignJobResult {
+    pub state: JobState,
     pub need_toolchain: bool,
 }
 
@@ -597,7 +598,7 @@ pub trait SchedulerIncoming: Send + Sync {
 pub trait ServerIncoming: Send + Sync {
     type Error: ::std::error::Error;
     // From Scheduler
-    fn handle_assign_job(&self, requester: &ServerOutgoing, job_id: JobId, tc: Toolchain) -> ExtResult<AssignJobResult, Self::Error>;
+    fn handle_assign_job(&self, job_id: JobId, tc: Toolchain) -> ExtResult<AssignJobResult, Self::Error>;
     // From Client
     fn handle_submit_toolchain(&self, requester: &ServerOutgoing, job_id: JobId, tc_rdr: ToolchainReader) -> ExtResult<SubmitToolchainResult, Self::Error>;
     // From Client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,8 @@ extern crate toml;
 #[cfg(any(feature = "azure", feature = "gcs", feature = "dist-client"))]
 extern crate url;
 extern crate uuid;
+#[cfg(feature = "void")]
+extern crate void;
 extern crate walkdir;
 extern crate which;
 #[cfg(windows)]
@@ -145,6 +147,9 @@ pub fn main() {
         },
         Err(e) => {
             println!("sccache: {}", e);
+            for e in e.iter().skip(1) {
+                println!("caused by: {}", e);
+            }
             cmdline::get_app().print_help().unwrap();
             println!("");
             1

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -1,0 +1,202 @@
+#![cfg(all(feature = "dist-client", feature = "dist-server"))]
+
+extern crate assert_cmd;
+#[macro_use]
+extern crate error_chain;
+#[macro_use]
+extern crate log;
+extern crate sccache;
+extern crate serde_json;
+extern crate tempdir;
+
+use assert_cmd::prelude::*;
+use sccache::config::HTTPUrl;
+use harness::{
+    sccache_command,
+    start_local_daemon, stop_local_daemon,
+    get_stats,
+    write_json_cfg, write_source,
+};
+use sccache::dist::{
+    AssignJobResult,
+    CompileCommand,
+    InputsReader,
+    JobId,
+    JobState,
+    RunJobResult,
+    ServerIncoming,
+    ServerOutgoing,
+    SubmitToolchainResult,
+    Toolchain,
+    ToolchainReader,
+};
+use std::ffi::OsStr;
+use std::path::Path;
+use tempdir::TempDir;
+
+use sccache::errors::*;
+
+mod harness;
+
+fn basic_compile(tmpdir: &Path, sccache_cfg_path: &Path, sccache_cached_cfg_path: &Path) {
+    let envs: Vec<(_, &OsStr)> = vec![
+        ("RUST_BACKTRACE", "1".as_ref()),
+        ("RUST_LOG", "sccache=trace".as_ref()),
+        ("SCCACHE_CONF", sccache_cfg_path.as_ref()),
+        ("SCCACHE_CACHED_CONF", sccache_cached_cfg_path.as_ref()),
+    ];
+    let source_file = "x.c";
+    let obj_file = "x.o";
+    write_source(tmpdir, source_file, "int x() { return 5; }");
+    sccache_command()
+        .args(&["gcc", "-c"]).arg(tmpdir.join(source_file)).arg("-o").arg(tmpdir.join(obj_file))
+        .envs(envs)
+        .assert()
+        .success();
+}
+
+pub fn dist_test_sccache_client_cfg(tmpdir: &Path, scheduler_url: HTTPUrl) -> sccache::config::FileConfig {
+    let mut sccache_cfg = harness::sccache_client_cfg(tmpdir);
+    sccache_cfg.cache.disk.as_mut().unwrap().size = 0;
+    sccache_cfg.dist.scheduler_url = Some(scheduler_url);
+    sccache_cfg
+}
+
+#[test]
+#[cfg_attr(not(feature = "dist-tests"), ignore)]
+fn test_dist_basic() {
+    let tmpdir = TempDir::new("sccache_dist_test").unwrap();
+    let tmpdir = tmpdir.path();
+    let sccache_dist = harness::sccache_dist_path();
+
+    let mut system = harness::DistSystem::new(&sccache_dist, tmpdir);
+    system.add_scheduler();
+    system.add_server();
+
+    let sccache_cfg = dist_test_sccache_client_cfg(tmpdir, system.scheduler_url());
+    let sccache_cfg_path = tmpdir.join("sccache-cfg.json");
+    write_json_cfg(tmpdir, "sccache-cfg.json", &sccache_cfg);
+    let sccache_cached_cfg_path = tmpdir.join("sccache-cached-cfg");
+
+    stop_local_daemon();
+    start_local_daemon(&sccache_cfg_path, &sccache_cached_cfg_path);
+    basic_compile(tmpdir, &sccache_cfg_path, &sccache_cached_cfg_path);
+
+    get_stats(|info| {
+        assert_eq!(1, info.stats.dist_compiles);
+        assert_eq!(0, info.stats.dist_errors);
+        assert_eq!(1, info.stats.compile_requests);
+        assert_eq!(1, info.stats.requests_executed);
+        assert_eq!(0, info.stats.cache_hits);
+        assert_eq!(1, info.stats.cache_misses);
+    });
+}
+
+#[test]
+#[cfg_attr(not(feature = "dist-tests"), ignore)]
+fn test_dist_restartedserver() {
+    let tmpdir = TempDir::new("sccache_dist_test").unwrap();
+    let tmpdir = tmpdir.path();
+    let sccache_dist = harness::sccache_dist_path();
+
+    let mut system = harness::DistSystem::new(&sccache_dist, tmpdir);
+    system.add_scheduler();
+    let server_handle = system.add_server();
+
+    let sccache_cfg = dist_test_sccache_client_cfg(tmpdir, system.scheduler_url());
+    let sccache_cfg_path = tmpdir.join("sccache-cfg.json");
+    write_json_cfg(tmpdir, "sccache-cfg.json", &sccache_cfg);
+    let sccache_cached_cfg_path = tmpdir.join("sccache-cached-cfg");
+
+    stop_local_daemon();
+    start_local_daemon(&sccache_cfg_path, &sccache_cached_cfg_path);
+    basic_compile(tmpdir, &sccache_cfg_path, &sccache_cached_cfg_path);
+
+    system.restart_server(&server_handle);
+    basic_compile(tmpdir, &sccache_cfg_path, &sccache_cached_cfg_path);
+
+    get_stats(|info| {
+        assert_eq!(2, info.stats.dist_compiles);
+        assert_eq!(0, info.stats.dist_errors);
+        assert_eq!(2, info.stats.compile_requests);
+        assert_eq!(2, info.stats.requests_executed);
+        assert_eq!(0, info.stats.cache_hits);
+        assert_eq!(2, info.stats.cache_misses);
+    });
+}
+
+#[test]
+#[cfg_attr(not(feature = "dist-tests"), ignore)]
+fn test_dist_nobuilder() {
+    let tmpdir = TempDir::new("sccache_dist_test").unwrap();
+    let tmpdir = tmpdir.path();
+    let sccache_dist = harness::sccache_dist_path();
+
+    let mut system = harness::DistSystem::new(&sccache_dist, tmpdir);
+    system.add_scheduler();
+
+    let sccache_cfg = dist_test_sccache_client_cfg(tmpdir, system.scheduler_url());
+    let sccache_cfg_path = tmpdir.join("sccache-cfg.json");
+    write_json_cfg(tmpdir, "sccache-cfg.json", &sccache_cfg);
+    let sccache_cached_cfg_path = tmpdir.join("sccache-cached-cfg");
+
+    stop_local_daemon();
+    start_local_daemon(&sccache_cfg_path, &sccache_cached_cfg_path);
+    basic_compile(tmpdir, &sccache_cfg_path, &sccache_cached_cfg_path);
+
+    get_stats(|info| {
+        assert_eq!(0, info.stats.dist_compiles);
+        assert_eq!(1, info.stats.dist_errors);
+        assert_eq!(1, info.stats.compile_requests);
+        assert_eq!(1, info.stats.requests_executed);
+        assert_eq!(0, info.stats.cache_hits);
+        assert_eq!(1, info.stats.cache_misses);
+    });
+}
+
+struct FailingServer;
+impl ServerIncoming for FailingServer {
+    type Error = Error;
+    fn handle_assign_job(&self, requester: &ServerOutgoing, job_id: JobId, _tc: Toolchain) -> Result<AssignJobResult> {
+        let need_toolchain = false;
+        requester.do_update_job_state(job_id, JobState::Ready).chain_err(|| "Updating job state failed")?;
+        Ok(AssignJobResult { need_toolchain })
+    }
+    fn handle_submit_toolchain(&self, _requester: &ServerOutgoing, _job_id: JobId, _tc_rdr: ToolchainReader) -> Result<SubmitToolchainResult> {
+        panic!("should not have submitted toolchain")
+    }
+    fn handle_run_job(&self, requester: &ServerOutgoing, job_id: JobId, _command: CompileCommand, _outputs: Vec<String>, _inputs_rdr: InputsReader) -> Result<RunJobResult> {
+        requester.do_update_job_state(job_id, JobState::Started).chain_err(|| "Updating job state failed")?;
+        bail!("internal build failure")
+    }
+}
+
+#[test]
+#[cfg_attr(not(feature = "dist-tests"), ignore)]
+fn test_dist_failingserver() {
+    let tmpdir = TempDir::new("sccache_dist_test").unwrap();
+    let tmpdir = tmpdir.path();
+    let sccache_dist = harness::sccache_dist_path();
+
+    let mut system = harness::DistSystem::new(&sccache_dist, tmpdir);
+    system.add_scheduler();
+    system.add_custom_server(FailingServer);
+
+    let sccache_cfg = dist_test_sccache_client_cfg(tmpdir, system.scheduler_url());
+    let sccache_cfg_path = tmpdir.join("sccache-cfg.json");
+    write_json_cfg(tmpdir, "sccache-cfg.json", &sccache_cfg);
+    let sccache_cached_cfg_path = tmpdir.join("sccache-cached-cfg");
+
+    stop_local_daemon();
+    start_local_daemon(&sccache_cfg_path, &sccache_cached_cfg_path);
+    basic_compile(tmpdir, &sccache_cfg_path, &sccache_cached_cfg_path);
+
+    get_stats(|info| {
+        assert_eq!(0, info.stats.dist_compiles);
+        assert_eq!(1, info.stats.dist_errors);
+        assert_eq!(1, info.stats.compile_requests);
+        assert_eq!(1, info.stats.requests_executed);
+        assert_eq!(0, info.stats.cache_hits);
+        assert_eq!(1, info.stats.cache_misses);
+    });
+}

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -157,10 +157,10 @@ fn test_dist_nobuilder() {
 struct FailingServer;
 impl ServerIncoming for FailingServer {
     type Error = Error;
-    fn handle_assign_job(&self, requester: &ServerOutgoing, job_id: JobId, _tc: Toolchain) -> Result<AssignJobResult> {
+    fn handle_assign_job(&self, _job_id: JobId, _tc: Toolchain) -> Result<AssignJobResult> {
         let need_toolchain = false;
-        requester.do_update_job_state(job_id, JobState::Ready).chain_err(|| "Updating job state failed")?;
-        Ok(AssignJobResult { need_toolchain })
+        let state = JobState::Ready;
+        Ok(AssignJobResult { need_toolchain, state })
     }
     fn handle_submit_toolchain(&self, _requester: &ServerOutgoing, _job_id: JobId, _tc_rdr: ToolchainReader) -> Result<SubmitToolchainResult> {
         panic!("should not have submitted toolchain")

--- a/tests/harness/Dockerfile.sccache-dist
+++ b/tests/harness/Dockerfile.sccache-dist
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04 as bwrap-build
+RUN apt-get update && \
+    apt-get install -y wget xz-utils gcc libcap-dev make && \
+    apt-get clean
+RUN wget -q -O - https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz | \
+    tar -xJ
+RUN cd /bubblewrap-0.3.1 && \
+    ./configure --disable-man && \
+    make
+
+FROM aidanhs/ubuntu-docker:18.04-17.03.2-ce
+RUN apt-get update && \
+    apt-get install libcap2 libssl1.0.0 && \
+    apt-get clean
+COPY --from=bwrap-build /bubblewrap-0.3.1/bwrap /bwrap

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -1,0 +1,538 @@
+extern crate assert_cmd;
+extern crate bincode;
+extern crate env_logger;
+extern crate escargot;
+#[cfg(feature = "dist-server")]
+extern crate nix;
+extern crate predicates;
+#[cfg(feature = "dist-server")]
+extern crate reqwest;
+extern crate sccache;
+extern crate serde;
+extern crate serde_json;
+extern crate uuid;
+#[cfg(feature = "dist-server")]
+extern crate void;
+
+#[cfg(feature = "dist-server")]
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::net::{self, IpAddr, SocketAddr};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::str;
+use std::thread;
+use std::time::{Duration, Instant};
+#[cfg(any(feature = "dist-client", feature = "dist-server"))]
+use sccache::config::HTTPUrl;
+use sccache::dist::{self, SchedulerStatusResult, ServerId};
+use sccache::server::ServerInfo;
+
+use self::assert_cmd::prelude::*;
+use self::escargot::CargoBuild;
+#[cfg(feature = "dist-server")]
+use self::nix::{
+    sys::{
+        signal::Signal,
+        wait::{WaitPidFlag, WaitStatus},
+    },
+    unistd::{ForkResult, Pid},
+};
+use self::predicates::prelude::*;
+use self::serde::Serialize;
+use self::uuid::Uuid;
+
+#[cfg(feature = "dist-server")]
+macro_rules! matches {
+    ($expression:expr, $($pattern:tt)+) => {
+        match $expression {
+            $($pattern)+ => true,
+            _ => false
+        }
+    }
+}
+
+const CONTAINER_NAME_PREFIX: &str = "sccache_dist_test";
+const DIST_IMAGE: &str = "sccache_dist_test_image";
+const DIST_DOCKERFILE: &str = include_str!("Dockerfile.sccache-dist");
+const DIST_IMAGE_BWRAP_PATH: &str = "/bwrap";
+const MAX_STARTUP_WAIT: Duration = Duration::from_secs(5);
+
+const DIST_SERVER_TOKEN: &str = "THIS IS THE TEST TOKEN";
+
+const CONFIGS_CONTAINER_PATH: &str = "/sccache-bits";
+const BUILD_DIR_CONTAINER_PATH: &str = "/sccache-bits/build-dir";
+const SCHEDULER_PORT: u16 = 10500;
+const SERVER_PORT: u16 = 12345; // arbitrary
+
+const TC_CACHE_SIZE: u64 = 1 * 1024 * 1024 * 1024; // 1 gig
+
+pub fn start_local_daemon(cfg_path: &Path, cached_cfg_path: &Path) {
+    // Don't run this with run() because on Windows `wait_with_output`
+    // will hang because the internal server process is not detached.
+    sccache_command()
+        .arg("--start-server")
+        .env("SCCACHE_CONF", cfg_path)
+        .env("SCCACHE_CACHED_CONF", cached_cfg_path)
+        .status()
+        .unwrap()
+        .success();
+}
+pub fn stop_local_daemon() {
+    trace!("sccache --stop-server");
+    drop(sccache_command()
+         .arg("--stop-server")
+         .stdout(Stdio::null())
+         .stderr(Stdio::null())
+         .status());
+}
+
+pub fn get_stats<F: 'static + Fn(ServerInfo)>(f: F) {
+    sccache_command()
+        .args(&["--show-stats", "--stats-format=json"])
+        .assert()
+        .success()
+        .stdout(predicate::function(move |output: &[u8]| {
+            let s = str::from_utf8(output).expect("Output not UTF-8");
+            f(serde_json::from_str(s).expect("Failed to parse JSON stats"));
+            true
+        }));
+}
+
+#[allow(unused)]
+pub fn zero_stats() {
+    trace!("sccache --zero-stats");
+    drop(sccache_command()
+         .arg("--zero-stats")
+         .stdout(Stdio::null())
+         .stderr(Stdio::null())
+         .status());
+}
+
+pub fn write_json_cfg<T: Serialize>(path: &Path, filename: &str, contents: &T) {
+    let p = path.join(filename);
+    let mut f = fs::File::create(&p).unwrap();
+    f.write_all(&serde_json::to_vec(contents).unwrap()).unwrap();
+}
+
+pub fn write_source(path: &Path, filename: &str, contents: &str) {
+    let p = path.join(filename);
+    let mut f = fs::File::create(&p).unwrap();
+    f.write_all(contents.as_bytes()).unwrap();
+}
+
+// Alter an sccache command to override any environment variables that could adversely
+// affect test execution
+fn blankslate_sccache(mut cmd: Command) -> Command {
+    cmd
+        .env("SCCACHE_CONF", "nonexistent_conf_path")
+        .env("SCCACHE_CACHED_CONF", "nonexistent_cached_conf_path");
+    cmd
+}
+
+#[cfg(not(feature = "dist-client"))]
+pub fn sccache_command() -> Command {
+    blankslate_sccache(CargoBuild::new()
+        .bin("sccache")
+        .current_release()
+        .current_target()
+        .run()
+        .unwrap()
+        .command())
+}
+
+#[cfg(feature = "dist-client")]
+pub fn sccache_command() -> Command {
+    blankslate_sccache(CargoBuild::new()
+        .bin("sccache")
+        // This should just inherit from the feature list we're compiling with to avoid recompilation
+        // https://github.com/assert-rs/assert_cmd/issues/44#issuecomment-418485128
+        .arg("--features").arg("dist-client dist-server")
+        .current_release()
+        .current_target()
+        .run()
+        .unwrap()
+        .command())
+}
+
+#[cfg(feature = "dist-server")]
+pub fn sccache_dist_path() -> PathBuf {
+    CargoBuild::new()
+        .bin("sccache-dist")
+        // This should just inherit from the feature list we're compiling with to avoid recompilation
+        // https://github.com/assert-rs/assert_cmd/issues/44#issuecomment-418485128
+        .arg("--features").arg("dist-client dist-server")
+        .current_release()
+        .current_target()
+        .run()
+        .unwrap()
+        .path()
+        .to_owned()
+}
+
+pub fn sccache_client_cfg(tmpdir: &Path) -> sccache::config::FileConfig {
+    let cache_relpath = "client-cache";
+    let dist_cache_relpath = "client-dist-cache";
+    fs::create_dir(tmpdir.join(cache_relpath)).unwrap();
+    fs::create_dir(tmpdir.join(dist_cache_relpath)).unwrap();
+
+    let mut disk_cache: sccache::config::DiskCacheConfig = Default::default();
+    disk_cache.dir = tmpdir.join(cache_relpath);
+    sccache::config::FileConfig {
+        cache: sccache::config::CacheConfigs {
+            azure: None,
+            disk: Some(disk_cache),
+            gcs: None,
+            memcached: None,
+            redis: None,
+            s3: None,
+        },
+        dist: sccache::config::DistConfig {
+            auth: Default::default(), // dangerously_insecure
+            scheduler_url: None,
+            cache_dir: tmpdir.join(dist_cache_relpath),
+            toolchains: vec![],
+            toolchain_cache_size: TC_CACHE_SIZE,
+        },
+    }
+}
+#[cfg(feature = "dist-server")]
+fn sccache_scheduler_cfg() -> sccache::config::scheduler::Config {
+    sccache::config::scheduler::Config {
+        public_addr: SocketAddr::from(([0, 0, 0, 0], SCHEDULER_PORT)),
+        client_auth: sccache::config::scheduler::ClientAuth::Insecure,
+        server_auth: sccache::config::scheduler::ServerAuth::Token { token: DIST_SERVER_TOKEN.to_owned() },
+    }
+}
+#[cfg(feature = "dist-server")]
+fn sccache_server_cfg(tmpdir: &Path, scheduler_url: HTTPUrl, server_ip: IpAddr) -> sccache::config::server::Config {
+    let relpath = "server-cache";
+    fs::create_dir(tmpdir.join(relpath)).unwrap();
+
+    sccache::config::server::Config {
+        builder: sccache::config::server::BuilderType::Overlay {
+            build_dir: BUILD_DIR_CONTAINER_PATH.into(),
+            bwrap_path: DIST_IMAGE_BWRAP_PATH.into(),
+        },
+        cache_dir: Path::new(CONFIGS_CONTAINER_PATH).join(relpath),
+        public_addr: SocketAddr::new(server_ip, SERVER_PORT),
+        scheduler_url,
+        scheduler_auth: sccache::config::server::SchedulerAuth::Token { token: DIST_SERVER_TOKEN.to_owned() },
+        toolchain_cache_size: TC_CACHE_SIZE,
+    }
+}
+
+// TODO: this is copied from the sccache-dist binary - it's not clear where would be a better place to put the
+// code so that it can be included here
+#[cfg(feature = "dist-server")]
+fn create_server_token(server_id: ServerId, auth_token: &str) -> String {
+    format!("{} {}", server_id.addr(), auth_token)
+}
+
+#[cfg(feature = "dist-server")]
+pub enum ServerHandle {
+    Container { cid: String, url: HTTPUrl },
+    Process { pid: Pid, url: HTTPUrl },
+}
+
+#[cfg(feature = "dist-server")]
+pub struct DistSystem {
+    sccache_dist: PathBuf,
+    tmpdir: PathBuf,
+
+    scheduler_name: Option<String>,
+    server_names: Vec<String>,
+    server_pids: Vec<Pid>,
+}
+
+#[cfg(feature = "dist-server")]
+impl DistSystem {
+    pub fn new(sccache_dist: &Path, tmpdir: &Path) -> Self {
+        // Make sure the docker image is available, building it if necessary
+        let mut child = Command::new("docker")
+            .args(&["build", "-q", "-t", DIST_IMAGE, "-"])
+            .stdin(Stdio::piped())
+            .spawn().unwrap();
+        child.stdin.as_mut().unwrap().write_all(DIST_DOCKERFILE.as_bytes()).unwrap();
+        let output = child.wait_with_output().unwrap();
+        check_output(&output);
+
+        let tmpdir = tmpdir.join("distsystem");
+        fs::create_dir(&tmpdir).unwrap();
+
+        Self {
+            sccache_dist: sccache_dist.to_owned(),
+            tmpdir,
+
+            scheduler_name: None,
+            server_names: vec![],
+            server_pids: vec![],
+        }
+    }
+
+    pub fn add_scheduler(&mut self) {
+        let scheduler_cfg_relpath = "scheduler-cfg.json";
+        let scheduler_cfg_path = self.tmpdir.join(scheduler_cfg_relpath);
+        let scheduler_cfg_container_path = Path::new(CONFIGS_CONTAINER_PATH).join(scheduler_cfg_relpath);
+        let scheduler_cfg = sccache_scheduler_cfg();
+        fs::File::create(&scheduler_cfg_path).unwrap().write_all(&serde_json::to_vec(&scheduler_cfg).unwrap()).unwrap();
+
+        // Create the scheduler
+        let scheduler_name = make_container_name("scheduler");
+        let output = Command::new("docker")
+            .args(&[
+                "run",
+                "--name", &scheduler_name,
+                "-e", "RUST_LOG=sccache=trace",
+                "-e", "RUST_BACKTRACE=1",
+                "-v", &format!("{}:/sccache-dist", self.sccache_dist.to_str().unwrap()),
+                "-v", &format!("{}:{}", self.tmpdir.to_str().unwrap(), CONFIGS_CONTAINER_PATH),
+                "-d",
+                DIST_IMAGE,
+                "bash", "-c", &format!(r#"
+                    set -o errexit &&
+                    exec /sccache-dist scheduler --config {cfg}
+                "#, cfg=scheduler_cfg_container_path.to_str().unwrap()),
+            ]).output().unwrap();
+        self.scheduler_name = Some(scheduler_name);
+
+        check_output(&output);
+
+        let scheduler_url = self.scheduler_url();
+        wait_for_http(scheduler_url, Duration::from_millis(100), MAX_STARTUP_WAIT);
+        wait_for(|| {
+            let status = self.scheduler_status();
+            if matches!(self.scheduler_status(), SchedulerStatusResult { num_servers: 0 }) { Ok(()) } else { Err(format!("{:?}", status)) }
+        }, Duration::from_millis(100), MAX_STARTUP_WAIT);
+    }
+
+    pub fn add_server(&mut self) -> ServerHandle {
+        let server_cfg_relpath = format!("server-cfg-{}.json", self.server_names.len());
+        let server_cfg_path = self.tmpdir.join(&server_cfg_relpath);
+        let server_cfg_container_path = Path::new(CONFIGS_CONTAINER_PATH).join(server_cfg_relpath);
+
+        let server_name = make_container_name("server");
+        let output = Command::new("docker")
+            .args(&[
+                "run",
+                // Important for the bubblewrap builder
+                "--privileged",
+                "--name", &server_name,
+                "-e", "RUST_LOG=sccache=debug",
+                "-e", "RUST_BACKTRACE=1",
+                "-v", &format!("{}:/sccache-dist", self.sccache_dist.to_str().unwrap()),
+                "-v", &format!("{}:{}", self.tmpdir.to_str().unwrap(), CONFIGS_CONTAINER_PATH),
+                "-d",
+                DIST_IMAGE,
+                "bash", "-c", &format!(r#"
+                    set -o errexit &&
+                    while [ ! -f {cfg}.ready ]; do sleep 0.1; done &&
+                    exec /sccache-dist server --config {cfg}
+                "#, cfg=server_cfg_container_path.to_str().unwrap()),
+            ]).output().unwrap();
+        self.server_names.push(server_name.clone());
+
+        check_output(&output);
+
+        let server_ip = self.container_ip(&server_name);
+        let server_cfg = sccache_server_cfg(&self.tmpdir, self.scheduler_url(), server_ip);
+        fs::File::create(&server_cfg_path).unwrap().write_all(&serde_json::to_vec(&server_cfg).unwrap()).unwrap();
+        fs::File::create(format!("{}.ready", server_cfg_path.to_str().unwrap())).unwrap();
+
+        let url = HTTPUrl::from_url(reqwest::Url::parse(&format!("https://{}:{}", server_ip, SERVER_PORT)).unwrap());
+        let handle = ServerHandle::Container { cid: server_name, url };
+        self.wait_server_ready(&handle);
+        handle
+    }
+
+    pub fn add_custom_server<S: dist::ServerIncoming + 'static>(&mut self, handler: S) -> ServerHandle {
+        let server_addr = {
+            let ip = self.host_interface_ip();
+            let listener = net::TcpListener::bind(SocketAddr::from((ip, 0))).unwrap();
+            listener.local_addr().unwrap()
+        };
+        let token = create_server_token(ServerId::new(server_addr), DIST_SERVER_TOKEN);
+        let server = dist::http::Server::new(server_addr, self.scheduler_url().to_url(), token, handler).unwrap();
+        let pid = match nix::unistd::fork().unwrap() {
+            ForkResult::Parent { child } => {
+                self.server_pids.push(child);
+                child
+            },
+            ForkResult::Child => {
+                env::set_var("RUST_LOG", "sccache=trace");
+                env_logger::try_init().unwrap();
+                void::unreachable(server.start().unwrap())
+            },
+        };
+
+        let url = HTTPUrl::from_url(reqwest::Url::parse(&format!("https://{}", server_addr)).unwrap());
+        let handle = ServerHandle::Process { pid, url };
+        self.wait_server_ready(&handle);
+        handle
+    }
+
+    pub fn restart_server(&mut self, handle: &ServerHandle) {
+        match handle {
+            ServerHandle::Container { cid, url: _ } => {
+                let output = Command::new("docker").args(&["restart", cid]).output().unwrap();
+                check_output(&output);
+            },
+            ServerHandle::Process { pid: _, url: _ } => {
+                // TODO: pretty easy, just no need yet
+                panic!("restart not yet implemented for pids")
+            },
+        }
+        self.wait_server_ready(handle)
+    }
+
+    pub fn wait_server_ready(&mut self, handle: &ServerHandle) {
+        let url = match handle {
+            ServerHandle::Container { cid: _, url } |
+            ServerHandle::Process { pid: _, url } => url.clone(),
+        };
+        wait_for_http(url, Duration::from_millis(100), MAX_STARTUP_WAIT);
+        wait_for(|| {
+            let status = self.scheduler_status();
+            if matches!(self.scheduler_status(), SchedulerStatusResult { num_servers: 1 }) { Ok(()) } else { Err(format!("{:?}", status)) }
+        }, Duration::from_millis(100), MAX_STARTUP_WAIT);
+    }
+
+    pub fn scheduler_url(&self) -> HTTPUrl {
+        let ip = self.container_ip(self.scheduler_name.as_ref().unwrap());
+        let url = format!("http://{}:{}", ip, SCHEDULER_PORT);
+        HTTPUrl::from_url(reqwest::Url::parse(&url).unwrap())
+    }
+
+    fn scheduler_status(&self) -> SchedulerStatusResult {
+        let res = reqwest::get(dist::http::urls::scheduler_status(&self.scheduler_url().to_url())).unwrap();
+        assert!(res.status().is_success());
+        bincode::deserialize_from(res).unwrap()
+    }
+
+    fn container_ip(&self, name: &str) -> IpAddr {
+        let output = Command::new("docker")
+            .args(&["inspect", "--format", "{{ .NetworkSettings.IPAddress }}", name])
+            .output().unwrap();
+        check_output(&output);
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        stdout.trim().to_owned().parse().unwrap()
+    }
+
+    // The interface that the host sees on the docker network (typically 'docker0')
+    fn host_interface_ip(&self) -> IpAddr {
+        let output = Command::new("docker")
+            .args(&["inspect", "--format", "{{ .NetworkSettings.Gateway }}", self.scheduler_name.as_ref().unwrap()])
+            .output().unwrap();
+        check_output(&output);
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        stdout.trim().to_owned().parse().unwrap()
+    }
+}
+
+// If you want containers to hang around (e.g. for debugging), commend out the "rm -f" lines
+#[cfg(feature = "dist-server")]
+impl Drop for DistSystem {
+    fn drop(&mut self) {
+        let mut did_err = false;
+
+        // Panicking halfway through drop would either abort (if it's a double panic) or leave us with
+        // resources that aren't yet cleaned up. Instead, do as much as possible then decide what to do
+        // at the end - panic (if not already doing so) or let the panic continue
+        macro_rules! droperr {
+            ($e:expr) => {
+                match $e {
+                    Ok(()) => (),
+                    Err(e) => {
+                        did_err = true;
+                        eprintln!("Error with {}: {}", stringify!($e), e)
+                    },
+                }
+            }
+        }
+
+        let mut logs = vec![];
+        let mut outputs = vec![];
+        let mut exits = vec![];
+
+        if let Some(scheduler_name) = self.scheduler_name.as_ref() {
+            droperr!(Command::new("docker").args(&["logs", scheduler_name]).output().map(|o| logs.push((scheduler_name, o))));
+            droperr!(Command::new("docker").args(&["kill", scheduler_name]).output().map(|o| outputs.push((scheduler_name, o))));
+            droperr!(Command::new("docker").args(&["rm", "-f", scheduler_name]).output().map(|o| outputs.push((scheduler_name, o))));
+        }
+        for server_name in self.server_names.iter() {
+            droperr!(Command::new("docker").args(&["logs", server_name]).output().map(|o| logs.push((server_name, o))));
+            droperr!(Command::new("docker").args(&["kill", server_name]).output().map(|o| outputs.push((server_name, o))));
+            droperr!(Command::new("docker").args(&["rm", "-f", server_name]).output().map(|o| outputs.push((server_name, o))));
+        }
+        for &pid in self.server_pids.iter() {
+            droperr!(nix::sys::signal::kill(pid, Signal::SIGINT));
+            thread::sleep(Duration::from_millis(100));
+            let mut killagain = true; // Default to trying to kill again, e.g. if there was an error waiting on the pid
+            droperr!(nix::sys::wait::waitpid(pid, Some(WaitPidFlag::WNOHANG)).map(|ws| if ws != WaitStatus::StillAlive { killagain = false; exits.push(ws) }));
+            if killagain {
+                eprintln!("SIGINT didn't kill process, trying SIGKILL");
+                droperr!(nix::sys::signal::kill(pid, Signal::SIGKILL));
+                droperr!(nix::sys::wait::waitpid(pid, Some(WaitPidFlag::WNOHANG))
+                    .map_err(|e| e.to_string())
+                    .and_then(|ws| if ws == WaitStatus::StillAlive { Err("process alive after sigkill".to_owned()) } else { exits.push(ws); Ok(()) }));
+            }
+        }
+
+        for (container, Output { status, stdout, stderr }) in logs {
+            println!("LOGS == ({}) ==\n> {} <:\n## STDOUT\n{}\n\n## STDERR\n{}\n====",
+                status, container, String::from_utf8_lossy(&stdout), String::from_utf8_lossy(&stderr));
+        }
+        for (container, Output { status, stdout, stderr }) in outputs {
+            println!("OUTPUTS == ({}) ==\n> {} <:\n## STDOUT\n{}\n\n## STDERR\n{}\n====",
+                status, container, String::from_utf8_lossy(&stdout), String::from_utf8_lossy(&stderr));
+        }
+        for exit in exits {
+            println!("EXIT: {:?}", exit)
+        }
+
+        if did_err && !thread::panicking() {
+            panic!("Encountered failures during dist system teardown")
+        }
+    }
+}
+
+fn make_container_name(tag: &str) -> String {
+    format!("{}_{}_{}", CONTAINER_NAME_PREFIX, tag, Uuid::new_v4().hyphenated())
+}
+
+fn check_output(output: &Output) {
+    if !output.status.success() {
+        println!("[BEGIN OUTPUT]\n===========\n{}\n==========\n\n\n\n=========\n{}\n===============\n[FIN OUTPUT]\n\n",
+            String::from_utf8_lossy(&output.stdout), String::from_utf8_lossy(&output.stderr));
+        panic!()
+    }
+}
+
+#[cfg(feature = "dist-server")]
+fn wait_for_http(url: HTTPUrl, interval: Duration, max_wait: Duration) {
+    // TODO: after upgrading to reqwest >= 0.9, use 'danger_accept_invalid_certs' and stick with that rather than tcp
+    wait_for(|| {
+        //match reqwest::get(url.to_url()) {
+        match net::TcpStream::connect(url.to_url()) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
+    }, interval, max_wait)
+}
+
+fn wait_for<F: Fn() -> Result<(), String>>(f: F, interval: Duration, max_wait: Duration) {
+    let start = Instant::now();
+    let mut lasterr;
+    loop {
+        match f() {
+            Ok(()) => return,
+            Err(e) => lasterr = e,
+        }
+        if start.elapsed() > max_wait {
+            break
+        }
+        thread::sleep(interval)
+    }
+    panic!("wait timed out, last error result: {}", lasterr)
+}

--- a/tests/oauth.rs
+++ b/tests/oauth.rs
@@ -56,7 +56,7 @@ fn config_with_dist_auth(tmpdir: &Path, auth_config: sccache::config::DistAuth) 
         cache: Default::default(),
         dist: sccache::config::DistConfig {
             auth: auth_config,
-            scheduler_addr: None,
+            scheduler_url: None,
             cache_dir: tmpdir.join("unused-cache"),
             toolchains: vec![],
             toolchain_cache_size: 0,


### PR DESCRIPTION
 - Vast majority of unwraps removed
 - Tests for the dist system added (uses docker)
 - Script added to check the major combinations of features (I've heavily used it for the past few months, thought it might be useful)
 - Servers will auto-configure themselves to use https, informing the scheduler of certificates that clients should then use
 - Due to a bug in tiny-http, sccache currently uses a patch version
 - `scheduler_addr` no longer exists - the setting is now `scheduler_url`, to more accurately reflect the acceptance of http and https urls (though `ip:port` socket addresses are accepted and interpreted as HTTP for backwards compatibility and simplicity)

Fixes:
 - Ports are actually now configured in config files - fixes https://github.com/mozilla/sccache/issues/315
 - Server restarts are correctly registered in scheduler (+test) - fixes https://github.com/mozilla/sccache/issues/319
 - Toolchains now support being used for multiple binaries (+test) - fixes https://github.com/mozilla/sccache/issues/318