### PR TITLE
Fix parsing dep info containing escaped spaces.

### DIFF
--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1931,6 +1931,19 @@ bar.rs:
                    parse_dep_info(&deps, ""));
     }
 
+
+    #[test]
+    fn test_parse_dep_info_with_escaped_spaces() {
+        let deps = r#"foo: baz.rs abc\ def.rs
+
+baz.rs:
+
+abc def.rs:
+"#;
+        assert_eq!(pathvec!["abc def.rs", "baz.rs"],
+                   parse_dep_info(&deps, ""));
+    }
+
     #[cfg(not(windows))]
     #[test]
     fn test_parse_dep_info_cwd() {


### PR DESCRIPTION
Previously, a `dep-info` output like

```text
some\ directory/file.rs
```

would be parsed as `["some\\", "directory/file.rs"]`.

This fixes the `parse_dep_info` function so it will correctly return `["some directory/file.rs"]`.