### PR TITLE
Record cache hits, misses, and errors per language kind, closes #327

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -76,6 +76,15 @@ pub enum CompilerKind {
     Rust,
 }
 
+impl CompilerKind {
+    pub fn lang_kind(&self) -> String {
+        match self {
+            CompilerKind::C(_) => "C/C++",
+            CompilerKind::Rust => "Rust",
+        }.to_string()
+    }
+}
+
 /// An interface to a compiler for argument parsing.
 pub trait Compiler<T>: Send + 'static
 where

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -87,8 +87,8 @@ fn test_dist_basic() {
         assert_eq!(0, info.stats.dist_errors);
         assert_eq!(1, info.stats.compile_requests);
         assert_eq!(1, info.stats.requests_executed);
-        assert_eq!(0, info.stats.cache_hits);
-        assert_eq!(1, info.stats.cache_misses);
+        assert_eq!(0, info.stats.cache_hits.all());
+        assert_eq!(1, info.stats.cache_misses.all());
     });
 }
 
@@ -120,8 +120,8 @@ fn test_dist_restartedserver() {
         assert_eq!(0, info.stats.dist_errors);
         assert_eq!(2, info.stats.compile_requests);
         assert_eq!(2, info.stats.requests_executed);
-        assert_eq!(0, info.stats.cache_hits);
-        assert_eq!(2, info.stats.cache_misses);
+        assert_eq!(0, info.stats.cache_hits.all());
+        assert_eq!(2, info.stats.cache_misses.all());
     });
 }
 
@@ -149,8 +149,8 @@ fn test_dist_nobuilder() {
         assert_eq!(1, info.stats.dist_errors);
         assert_eq!(1, info.stats.compile_requests);
         assert_eq!(1, info.stats.requests_executed);
-        assert_eq!(0, info.stats.cache_hits);
-        assert_eq!(1, info.stats.cache_misses);
+        assert_eq!(0, info.stats.cache_hits.all());
+        assert_eq!(1, info.stats.cache_misses.all());
     });
 }
 
@@ -196,7 +196,7 @@ fn test_dist_failingserver() {
         assert_eq!(1, info.stats.dist_errors);
         assert_eq!(1, info.stats.compile_requests);
         assert_eq!(1, info.stats.requests_executed);
-        assert_eq!(0, info.stats.cache_hits);
-        assert_eq!(1, info.stats.cache_misses);
+        assert_eq!(0, info.stats.cache_hits.all());
+        assert_eq!(1, info.stats.cache_misses.all());
     });
 }

--- a/tests/sccache_cargo.rs
+++ b/tests/sccache_cargo.rs
@@ -126,7 +126,7 @@ fn test_rust_cargo_cmd(cmd: &str) {
     sccache_command()
         .args(&["--show-stats", "--stats-format=json"])
         .assert()
-        .stdout(predicates::str::contains(r#""cache_hits":1"#).from_utf8())
+        .stdout(predicates::str::contains(r#""cache_hits":{"counts":{"Rust":1}}"#).from_utf8())
         .success();
     stop();
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -117,8 +117,9 @@ fn test_basic_compile(compiler: Compiler, tempdir: &Path) {
     get_stats(|info| {
         assert_eq!(1, info.stats.compile_requests);
         assert_eq!(1, info.stats.requests_executed);
-        assert_eq!(0, info.stats.cache_hits);
-        assert_eq!(1, info.stats.cache_misses);
+        assert_eq!(0, info.stats.cache_hits.all());
+        assert_eq!(1, info.stats.cache_misses.all());
+        assert_eq!(&1, info.stats.cache_misses.get("C/C++").unwrap());
     });
     trace!("compile");
     fs::remove_file(&out_file).unwrap();
@@ -133,8 +134,10 @@ fn test_basic_compile(compiler: Compiler, tempdir: &Path) {
     get_stats(|info| {
         assert_eq!(2, info.stats.compile_requests);
         assert_eq!(2, info.stats.requests_executed);
-        assert_eq!(1, info.stats.cache_hits);
-        assert_eq!(1, info.stats.cache_misses);
+        assert_eq!(1, info.stats.cache_hits.all());
+        assert_eq!(1, info.stats.cache_misses.all());
+        assert_eq!(&1, info.stats.cache_hits.get("C/C++").unwrap());
+        assert_eq!(&1, info.stats.cache_misses.get("C/C++").unwrap());
     });
 }
 
@@ -229,8 +232,9 @@ int main(int argc, char** argv) {
         .assert()
         .success();
     get_stats(|info| {
-        assert_eq!(0, info.stats.cache_hits);
-        assert_eq!(1, info.stats.cache_misses);
+        assert_eq!(0, info.stats.cache_hits.all());
+        assert_eq!(1, info.stats.cache_misses.all());
+        assert_eq!(&1, info.stats.cache_misses.get("C/C++").unwrap());
     });
     // Compile the same source again to ensure we can get a cache hit.
     trace!("compile source.c (2)");
@@ -241,8 +245,10 @@ int main(int argc, char** argv) {
         .assert()
         .success();
     get_stats(|info| {
-        assert_eq!(1, info.stats.cache_hits);
-        assert_eq!(1, info.stats.cache_misses);
+        assert_eq!(1, info.stats.cache_hits.all());
+        assert_eq!(1, info.stats.cache_misses.all());
+        assert_eq!(&1, info.stats.cache_hits.get("C/C++").unwrap());
+        assert_eq!(&1, info.stats.cache_misses.get("C/C++").unwrap());
     });
     // Now write out a slightly different source file that will preprocess to the same thing,
     // modulo line numbers. This should not be a cache hit because line numbers are important
@@ -265,8 +271,10 @@ int main(int argc, char** argv) {
         .assert()
         .success();
     get_stats(|info| {
-        assert_eq!(1, info.stats.cache_hits);
-        assert_eq!(2, info.stats.cache_misses);
+        assert_eq!(1, info.stats.cache_hits.all());
+        assert_eq!(2, info.stats.cache_misses.all());
+        assert_eq!(&1, info.stats.cache_hits.get("C/C++").unwrap());
+        assert_eq!(&2, info.stats.cache_misses.get("C/C++").unwrap());
     });
 }
 


### PR DESCRIPTION
This splits out the `cache_hits`, `cache_misses`, and `cache_errors` metrics
to be recorded per language "kind" (Rust or C/C++ at this point), the
printed output will look like this:

Cache hits                              236
Cache hits (Rust)                       156
Cache hits (C/C++)                       80

Many of the other stats could be split by language kind if we find that useful,
but this will give us a better indication for situations where caching rust
fails altogether, for instance.