### PR TITLE
Use trim_end instead of trim_right as the latter is being deprecated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ matrix:
     - os: osx
 
     # rustc version compat
-    - rust: 1.27.0 # oldest supported version, keep in sync with README.md
-    - rust: 1.27.0
+    - rust: 1.30.0 # oldest supported version, keep in sync with README.md
+    - rust: 1.30.0
       env: DIST_SCCACHE=1
     - rust: beta
     - rust: nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "sccache"
-version = "0.2.8-alpha.0"
+version = "0.2.9-alpha.0"
 dependencies = [
  "ar 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "arraydeque 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Table of Contents (ToC)
 Build Requirements
 ------------------
 
-Sccache is a [Rust](https://www.rust-lang.org/) program. Building it requires `cargo` (and thus `rustc`). sccache currently requires **Rust 1.27**.
+Sccache is a [Rust](https://www.rust-lang.org/) program. Building it requires `cargo` (and thus `rustc`). sccache currently requires **Rust 1.30**.
 
 We recommend you install Rust via [Rustup](https://rustup.rs/). The generated binaries can be built so that they are very [portable](#building-portable-binaries). By default `sccache` supports a local disk cache. To build `sccache` with support for `S3` and/or `Redis` cache backends, add `--features=all` or select a specific feature by passing `s3`, `gcs`, and/or `redis`. Refer the [Cargo Documentation](http://doc.crates.io/manifest.html#the-features-section) for details.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ for:
         target: x86_64-pc-windows-msvc
       - channel: nightly
         target: x86_64-pc-windows-msvc
-      - channel: 1.27.0 # Oldest supported version. Keep in sync with README.md.
+      - channel: 1.30.0 # Oldest supported version. Keep in sync with README.md.
         target: x86_64-pc-windows-msvc
         # Build a release build on master to make sure it builds.
       - channel: stable

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -349,7 +349,7 @@ impl Rust {
         let sysroot_and_libs = output.and_then(move |output| -> Result<_> {
             //debug!("output.and_then: {}", output);
             let outstr = String::from_utf8(output.stdout).chain_err(|| "Error parsing sysroot")?;
-            let sysroot = PathBuf::from(outstr.trim_right());
+            let sysroot = PathBuf::from(outstr.trim_end());
             let libs_path = sysroot.join(LIBS_DIR);
             let mut libs = fs::read_dir(&libs_path).chain_err(|| format!("Failed to list rustc sysroot: `{:?}`", libs_path))?.filter_map(|e| {
                 e.ok().and_then(|e| {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -183,7 +183,7 @@ fn test_msvc_deps(compiler: Compiler, tempdir: &Path) {
     // read_to_string should be safe because we're supplying all the filenames here,
     // and there are no absolute paths.
     f.read_to_string(&mut buf).expect("Failed to read dep file");
-    let lines: Vec<_> = buf.lines().map(|l| l.trim_right()).collect();
+    let lines: Vec<_> = buf.lines().map(|l| l.trim_end()).collect();
     let expected = format!("{output}: {input}\n{input}:\n", output=OUTPUT, input=INPUT);
     let expected_lines: Vec<_> = expected.lines().collect();
     assert_eq!(lines, expected_lines);


### PR DESCRIPTION
Rust 1.33 is deprecating trim_right in favour of trim_end. This patch
replaces instances of the trim_right with trim_end to avoid warnings.
Note, trim_end was introduced in 1.30, so this would bump the required
stable version (1.27 as of writing).