### PR TITLE
Remove openssl dependency for GCS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,8 +116,6 @@ tokio-reactor = "0.1"
 [features]
 default = ["s3"]
 all = ["redis", "s3", "memcached", "gcs", "azure"]
-# gcs requires openssl, which is a pain on Windows.
-all-windows = ["redis", "s3", "memcached", "azure"]
 azure = ["chrono", "hyper", "hyperx", "rust-crypto", "url"]
 s3 = ["chrono", "hyper", "hyperx", "reqwest", "rust-crypto", "simple-s3"]
 simple-s3 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,8 @@ void = { version = "1", optional = true }
 [patch.crates-io]
 # Waiting for https://github.com/tiny-http/tiny-http/pull/151
 tiny_http = { git = "https://github.com/aidanhs/tiny-http-sccache.git", rev = "a14fa0a" }
+# Waiting for https://github.com/Keats/jsonwebtoken/pull/74
+jsonwebtoken = { git = "https://github.com/Jake-Shadle/jsonwebtoken.git", rev = "2f469a61" }
 
 [dev-dependencies]
 assert_cmd = "0.9"
@@ -119,7 +121,7 @@ all-windows = ["redis", "s3", "memcached", "azure"]
 azure = ["chrono", "hyper", "hyperx", "rust-crypto", "url"]
 s3 = ["chrono", "hyper", "hyperx", "reqwest", "rust-crypto", "simple-s3"]
 simple-s3 = []
-gcs = ["chrono", "hyper", "jsonwebtoken", "openssl", "reqwest", "url"]
+gcs = ["chrono", "hyper", "jsonwebtoken", "reqwest", "url"]
 memcached = ["memcached-rs"]
 # Enable features that require unstable features of Nightly Rust.
 unstable = []
@@ -132,4 +134,3 @@ dist-tests = []
 
 [workspace]
 exclude = ["tests/test-crate"]
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,10 +16,10 @@ install:
 - cargo -V
 
 build_script:
-- cmd: cargo build %RELEASE% --verbose --features="all-windows %EXTRA_FEATURES%"
+- cmd: cargo build %RELEASE% --verbose --features="all %EXTRA_FEATURES%"
 
 test_script:
-- cmd: cargo test --all %RELEASE% --verbose --features="all-windows %EXTRA_FEATURES%"
+- cmd: cargo test --all %RELEASE% --verbose --features="all %EXTRA_FEATURES%"
 
 for:
 

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -19,6 +19,7 @@ use std::io;
 use std::rc::Rc;
 use std::time;
 
+use base64;
 use cache::{
     Cache,
     CacheRead,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,6 +50,7 @@ error_chain! {
         Json(serde_json::Error);
         Jwt(jwt::errors::Error) #[cfg(feature = "jsonwebtoken")];
         Openssl(openssl::error::ErrorStack) #[cfg(feature = "openssl")];
+        Base64Decode(base64::DecodeError);
         Bincode(bincode::Error);
         Memcached(memcached::proto::Error) #[cfg(feature = "memcached")];
         Redis(redis::RedisError) #[cfg(feature = "redis")];

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,6 +20,7 @@ use std::error;
 use std::io;
 use std::process;
 
+use base64;
 use bincode;
 use futures::Future;
 use futures::future;


### PR DESCRIPTION
This is a slight reimplementation of #272 that I think works slightly better.

* It doesn't add a dependency on `pem` which seems like overkill for just parsing a key out, at least if it's only going to be used for GCS specifically. This just uses a simple string split since the key format is not complicated.
* I opened a PR here https://github.com/Keats/jsonwebtoken/pull/74 to enable the key to be passed "as-is" rather than converting it to DER. It looks like a https://github.com/Keats/jsonwebtoken/issues/76 of jsonwebtoken coming, which might remove this API ambiguity, but for now pointing at the fork allows GCS to function properly, without OpenSSL.