### PR TITLE
Generate and upload sha256 checksums

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,7 @@ script:
   #- if [[ "${DIST_SCCACHE}" = "1" ]]; then RUST_BACKTRACE=1 cargo test --all --verbose --features="all dist-tests ${EXTRA_FEATURES}" test_dist_ -- --test-threads 1; fi
 
 before_deploy:
-  - name="sccache-$TRAVIS_TAG-$TARGET"
-  - mkdir $name
-  - cp target/$TARGET/release/sccache $name/
-  - cp README.md LICENSE $name/
-  - tar czvf $name.tar.gz $name
+  - "./scripts/prep_deploy.sh"
 
 deploy:
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,9 @@ deploy:
   api_key:
     secure: rF9ZCpzIJ+pYqxvS20omuTfQ5bN/W81malxwEyRobZc1OrcYK3Gdmq9wwxayx75PgDlXJvIMkuBrkRq1Mc1VprKOLmlg8yPjVm+5G1JySrpZ0yhs2+838gUJkdWESKtZRZ8xhKz2H1tK1a9WMXzWrW/hIBIWA2aZqC7hUTRvIyENE8hDec+7kTQCuNXkcsCL4mF9G77IPQhGR6CYj6Sg5j0u4NsIBiYnd3C218BUkZS15nE37Zj2o3C/ekQsUfAi8e3ALE6WEU+KDRccWT3/F8FMItxlJ5c2Wt4lUL5FC4+b5Vtz6sLBklKc8kex+ClFga5Hq6FDwBnotL8XsBZGiWPssdcZYVWtjHsXT1XeQOrtgdN+VN0IXP7/QzsEHSIADw9RE5S0F9RTKO+ghPL5YU1t7ZbWRqMy+AQDbFreIRftGWHyaRzmmxdea+XdhTMzv8Xyccakek+2HmrkvxC5KBtVVQUcjtf/mdEfF696N+DN4A+dkai15uk8C5vPGWDZF3SDlIOY23dOnMzMkC6qEFrzFjCwJ6mRKUhYI7mU4weMLekKq0dJa7xQuGNP7yuwQ4I+S/X00ukAcvNCLmWWjRRBxxeTVQJDwRdSepbzSkFqP6noopnOw6EIo6YV1EY9ipoX1ahaFVC8480uFFQI1BjVefTvFcflbCiSCerQECU=
   file_glob: true
-  file: sccache-$TRAVIS_TAG-$TARGET.tar.gz
+  file:
+    - sccache-$TRAVIS_TAG-$TARGET.tar.gz
+    - sccache-$TRAVIS_TAG-$TARGET.tar.gz.sha256
   on:
     condition: $DEPLOY = 1
     tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,10 +61,13 @@ for:
           Copy-Item README.md "${NAME}/"
           7z a -ttar "${NAME}.tar" "${NAME}"
           7z a "${NAME}.tar.gz" "${NAME}.tar"
-          Push-AppveyorArtifact "${NAME}.tar.gz"
+          $hash = Get-FileHash "${NAME}.tar.gz" -Algorithm SHA256
+          $hash.Hash > "${NAME}.tar.gz.sha256"
+          Push-AppveyorArtifact "${NAME}.tar.gz" -DeploymentName windep
+          Push-AppveyorArtifact "${NAME}.tar.gz.sha256" -DeploymentName windep
 
   deploy:
-    artifact: /.*\.tar.gz/
+    artifact: windep
     auth_token:
       secure: NKcPr8KYJE2osDxfO1xBDQHQRgJrhgItv2op6KKZSfLB01rq08M3243XdN3J5aaJ
     description: ''

--- a/scripts/prep_deploy.sh
+++ b/scripts/prep_deploy.sh
@@ -5,5 +5,3 @@ mkdir $name
 cp target/$TARGET/release/sccache $name/
 cp README.md LICENSE $name/
 tar czvf $name.tar.gz $name
-chksum=($(shasum -ba 256 $name.tar.gz))
-echo "$chksum" > $name.tar.gz.sha256

--- a/scripts/prep_deploy.sh
+++ b/scripts/prep_deploy.sh
@@ -5,3 +5,5 @@ mkdir $name
 cp target/$TARGET/release/sccache $name/
 cp README.md LICENSE $name/
 tar czvf $name.tar.gz $name
+chksum=($(shasum -ba 256 $name.tar.gz))
+echo "$chksum" > $name.tar.gz.sha256

--- a/scripts/prep_deploy.sh
+++ b/scripts/prep_deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+name="sccache-$TRAVIS_TAG-$TARGET"
+mkdir $name
+cp target/$TARGET/release/sccache $name/
+cp README.md LICENSE $name/
+tar czvf $name.tar.gz $name
+chksum=($(shasum -ba 256 $name.tar.gz))
+echo "$chksum" > $name.tar.gz.sha256


### PR DESCRIPTION
This PR attempts to add an additional "${artifact_name}.sha256" for each platform's release tarball that just contains the sha256 hash of that tarball. This would allow external packagers/installers (eg. scoop) to validate the tarballs without actually downloading the full tarball.

Resolves: #369 