### PR TITLE
Fix checksum files

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,8 +61,7 @@ for:
           Copy-Item README.md "${NAME}/"
           7z a -ttar "${NAME}.tar" "${NAME}"
           7z a "${NAME}.tar.gz" "${NAME}.tar"
-          $hash = Get-FileHash "${NAME}.tar.gz" -Algorithm SHA256
-          $hash.Hash > "${NAME}.tar.gz.sha256"
+          (Get-FileHash "${NAME}.tar.gz").Hash | Out-File "${NAME}.tar.gz.sha256" -NoNewline
           Push-AppveyorArtifact "${NAME}.tar.gz" -DeploymentName windep
           Push-AppveyorArtifact "${NAME}.tar.gz.sha256" -DeploymentName windep
 

--- a/scripts/prep_deploy.sh
+++ b/scripts/prep_deploy.sh
@@ -5,5 +5,6 @@ mkdir $name
 cp target/$TARGET/release/sccache $name/
 cp README.md LICENSE $name/
 tar czvf $name.tar.gz $name
-chksum=($(shasum -ba 256 $name.tar.gz))
-echo "$chksum" > $name.tar.gz.sha256
+
+# Get the sha-256 checksum w/o filename and newline
+echo -n $(shasum -ba 256 "$name.tar.gz" | cut -d " " -f 1) > $name.tar.gz.sha256


### PR DESCRIPTION
All of the .sha256 files had trailing newlines, which are now removed. Note that the chksum files generated with shasum are just the raw bytes of the checksum, not the ASCII hex like for Windows, but getting the same behavior seems to require using sha256sum instead of shasum, which isn't available by default on OSX, so I figured it was ok to just use the raw bytes on Linux and OSX.