### PR TITLE
Fix window release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,6 +53,9 @@ for:
     RELEASE: --release
 
   before_deploy:
+    # We need to rerun the build, due to `cargo test` overwriting the original sccache.exe
+    # with a version that only has the default features (this should be fast, just annoying)
+    - cmd: cargo build --release --verbose --features="all %EXTRA_FEATURES%"
     - ps: |
           $NAME = "sccache-${env:APPVEYOR_REPO_TAG_NAME}-${env:TARGET}"
           New-Item -Path $NAME -ItemType directory


### PR DESCRIPTION
So I'm making my own releases on my fork for now, and I noticed only Windows was failing (when trying to use GCS), which turned out to be because only the default features (s3) were enabled. I thought this was weird because looking at appveyor, it should be using `--features="all"` at a minimum, but the actual executable in the tarball wasn't. It seems that the `target/release/sccache.exe` that was being tarballed was actually one that got overwritten by `cargo test`, not the one that was built initially with just `cargo build`. This was still super confusing, because...cargo test is supposedly using the same flags. I don't really know the root cause of this issue and am frankly tired of iterating on CI stuff, so I just did a quick fix to rerun the normal release build before doing the rest of the release deployment, which correctly enables all the features, and doesn't really add to much to build time because the intermediate rlibs are already all built and ready to go so it just needs to relink the executable.

`¯\_(ツ)_/¯`