### PR TITLE
Fix `-o` flag separator type

### DIFF
--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -159,7 +159,7 @@ counted_array!(pub static ARGS: [ArgInfo<ArgData>; _] = [
     take_arg!("-iwithprefixbefore", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
     flag!("-nostdinc", PreprocessorArgumentFlag),
     flag!("-nostdinc++", PreprocessorArgumentFlag),
-    take_arg!("-o", PathBuf, Separated, Output),
+    take_arg!("-o", PathBuf, CanBeSeparated, Output),
     flag!("-remap", PreprocessorArgumentFlag),
     flag!("-save-temps", TooHardFlag),
     take_arg!("-stdlib", OsString, Concatenated('='), PreprocessorArgument),


### PR DESCRIPTION
When I tried to enable sccache for native compilation in addition to rust I ran into errors (the same kind as #189), I found that `ring` was causing sccache to fail because it's a bit more involved in the use of `cc` and when specifying the output object file is just directly concatenating the flag and the arg, so the command ends up being

```
$ "scccache" "gcc" blah blah blah "-c" "-o/somepathto.o" "somepathto.c"
```

Just changing the type of separator to support both `-ofile` or `-o file` allowed sccache to compile `ring` successfully.

Resolves: #189 