### PR TITLE
Build the distributed compilation client support by default. Fixes #383

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,8 +115,8 @@ tokio-named-pipes = "0.1"
 tokio-reactor = "0.1"
 
 [features]
-default = ["s3"]
-all = ["redis", "s3", "memcached", "gcs", "azure"]
+default = ["dist-client", "s3"]
+all = ["dist-client", "redis", "s3", "memcached", "gcs", "azure"]
 azure = ["chrono", "hyper", "hyperx", "rust-crypto", "url"]
 s3 = ["chrono", "hyper", "hyperx", "reqwest", "rust-crypto", "simple-s3"]
 simple-s3 = []


### PR DESCRIPTION
I'm not sure exactly why @luser phrased #383 as enabling the client support in "releases", rather than "by default". It seems more consistent to me to simply built it in all types of builds, release or otherwise, since it seems to build on Linux, macOS and Windows.