### PR TITLE
Fix deprecated warnings on `Error::source`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,8 +454,11 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "escargot"
@@ -1694,7 +1697,7 @@ dependencies = [
  "daemonize 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "escargot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2709,7 +2712,7 @@ dependencies = [
 "checksum encoding_rs 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)" = "065f4d0c826fdaef059ac45487169d918558e3cf86c9d89f6e81cf52369126e5"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
-"checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
+"checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum escargot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19db1f7e74438642a5018cdf263bb1325b2e792f02dd0a3ca6d6c0f0d7b1d5a5"
 "checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"
 "checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ clap = "2.23.0"
 counted-array = "0.1"
 directories = "1"
 env_logger = "0.5"
-error-chain = { version = "0.12", default-features = false }
+error-chain = { version = "0.12.1", default-features = false }
 filetime = "0.2"
 flate2 = { version = "1.0", optional = true, default-features = false, features = ["rust_backend"] }
 futures = "0.1.11"

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -462,7 +462,7 @@ mod server {
 
     impl<'a> ErrJson<'a> {
         fn from_err<E: ?Sized + std::error::Error>(err: &'a E) -> ErrJson<'a> {
-            let cause = err.cause().map(ErrJson::from_err).map(Box::new);
+            let cause = err.source().map(ErrJson::from_err).map(Box::new);
             ErrJson {
                 description: err.description(),
                 cause,
@@ -480,11 +480,11 @@ mod server {
                     // TODO: would ideally just use error_chain
                     use std::error::Error;
                     let mut err_msg = err.to_string();
-                    let mut maybe_cause = err.cause();
+                    let mut maybe_cause = err.source();
                     while let Some(cause) = maybe_cause {
                         err_msg.push_str(", caused by: ");
                         err_msg.push_str(cause.description());
-                        maybe_cause = cause.cause()
+                        maybe_cause = cause.source();
                     }
 
                     warn!("Res {} error: {}", $reqid, err_msg);


### PR DESCRIPTION
r? @chmanchester 