### PR TITLE
Fix windows build by indicating anonymous lifetimes along with warning fixes

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -152,7 +152,6 @@ fn run_server_process() -> Result<ServerStartup> {
     use std::ptr;
     use std::time::Duration;
     use tokio::reactor::Handle;
-    use tokio::runtime::current_thread::Runtime;
     use tokio_named_pipes::NamedPipe;
     use uuid::Uuid;
     use winapi::shared::minwindef::{DWORD, FALSE, LPVOID, TRUE};

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -188,7 +188,7 @@ fn encode_path(dst: &mut dyn Write, path: &Path) -> io::Result<()> {
 }
 
 #[cfg(windows)]
-fn encode_path(dst: &mut Write, path: &Path) -> io::Result<()> {
+fn encode_path(dst: &mut dyn Write, path: &Path) -> io::Result<()> {
     use std::os::windows::prelude::*;
     use local_encoding::windows::wide_char_to_multi_byte;
     use winapi::um::winnls::CP_OEMCP;
@@ -428,7 +428,6 @@ pub fn parse_arguments(arguments: &[OsString], cwd: &Path, is_clang: bool) -> Co
 
 #[cfg(windows)]
 fn normpath(path: &str) -> String {
-    use std::ffi::OsString;
     use std::os::windows::ffi::OsStringExt;
     use std::ptr;
     use std::os::windows::io::AsRawHandle;

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -57,7 +57,7 @@ mod path_transform {
     use std::path::{Component, Components, Path, PathBuf, Prefix, PrefixComponent};
     use std::str;
 
-    fn take_prefix<'a>(components: &'a mut Components) -> Option<PrefixComponent<'a>> {
+    fn take_prefix<'a>(components: &'a mut Components<'_>) -> Option<PrefixComponent<'a>> {
         let prefix = components.next()?;
         let pc = match prefix {
             Component::Prefix(pc) => pc,
@@ -70,7 +70,7 @@ mod path_transform {
         Some(pc)
     }
 
-    fn transform_prefix_component(pc: PrefixComponent) -> Option<String> {
+    fn transform_prefix_component(pc: PrefixComponent<'_>) -> Option<String> {
         match pc.kind() {
             // Transforming these to the same place means these may flip-flop
             // in the tracking map, but they're equivalent so not really an
@@ -156,7 +156,7 @@ mod path_transform {
                     continue
                 }
                 let mut components = local_path.components();
-                let mut local_prefix = take_prefix(&mut components)
+                let local_prefix = take_prefix(&mut components)
                     .expect("could not take prefix from absolute path");
                 let local_prefix_component = Component::Prefix(local_prefix);
                 let local_prefix_path: &Path = local_prefix_component.as_ref();

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,7 +18,6 @@ use futures_cpupool::CpuPool;
 use crate::mock_command::{CommandChild, RunCommand};
 use ring::digest::{Context, SHA512};
 use serde::Serialize;
-use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::hash::Hasher;
@@ -433,6 +432,7 @@ mod http_extension {
 #[cfg(not(windows))]
 pub fn daemonize() -> Result<()> {
     use daemonize::Daemonize;
+    use std::env;
     use std::mem;
 
     match env::var("SCCACHE_NO_DAEMON") {


### PR DESCRIPTION
Along with the missing explicit lifetimes a couple or warnings regarding duplicate use directives are fixed.

For a reason I don't know the AppVeyor build failed on my branch because of a missing `%channel%` argument to `rustup`. AppVeyor might behave different in this PR - let's see. 