### PR TITLE
Add extra note about optional features during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ set OPENSSL_LIBS=libcrypto64MT:libssl64MT
 
 `$ cargo install sccache`
 
+<sub>_use `--features=all` for non-local caching, see [build requirements](#build-requirements)_</sub>
+
 ### Windows
 
 sccache can also be installed via [scoop](https://scoop.sh/)


### PR DESCRIPTION
It took me an hour or two to debug what was going on here.

I was installing sccache on Travis, and could see the following in the logs:

```
DEBUG Trying GCS bucket(my-bucket, Some("/tmp/sccache-auth.json"), ReadWrite)
 INFO No configured caches successful, falling back to default
```

I couldn't figure out why it didn't work, and I spent some time re-creating access tokens, changing the access rights, etc. This of course took quite some time, as I had to wait for a CI run every time (I should've tested it locally, but I didn't).

It was extra confusing because I could see it was trying to use GCS, but it never printed any warnings about failing, even though the code does emit a warning if it fails.

Eventually, I found out that the `Trying GCS bucket` line is _before_ the feature check attribute, and so even it said it was trying, it never actually did:

https://github.com/mozilla/sccache/blob/6e3295a22283d6143859c8838f583cb37c176e03/src/cache/cache.rs#L185-L189

The README only mentions the feature flags in the build section, not in the install section. I kind of skipped over the build section, as I wasn't interested in building it, I just wanted to install the binary. In hindsight, it's also a bit of RTFM, but I hope this extra line saves others some time in the future 😄.

I guess another solution (or added solution) is to move that log line to after the cfg attribute.