### PR TITLE
fix: add CREATE_NO_WINDOW flag to server startup CreateProcess invocation

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -157,7 +157,7 @@ fn run_server_process() -> Result<ServerStartup> {
     use winapi::shared::minwindef::{DWORD, FALSE, LPVOID, TRUE};
     use winapi::um::processthreadsapi::{CreateProcessW, PROCESS_INFORMATION, STARTUPINFOW};
     use winapi::um::winbase::{
-        CREATE_NEW_PROCESS_GROUP, CREATE_UNICODE_ENVIRONMENT, DETACHED_PROCESS,
+        CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, CREATE_UNICODE_ENVIRONMENT, DETACHED_PROCESS,
     };
     use winapi::um::handleapi::CloseHandle;
 
@@ -224,7 +224,7 @@ fn run_server_process() -> Result<ServerStartup> {
             ptr::null_mut(),
             ptr::null_mut(),
             FALSE,
-            CREATE_UNICODE_ENVIRONMENT | DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP,
+            CREATE_UNICODE_ENVIRONMENT | DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW,
             envp.as_mut_ptr() as LPVOID,
             ptr::null(),
             &mut si,


### PR DESCRIPTION
This changeset adds `CREATE_NO_WINDOW` to `run_server_process`'s `CreateProcessW` call for Windows targets. This fixes `sccache` creating many console windows when it's starting all the server processes. Fixes the comments made after the resolution of #16.