### PR TITLE
Fix `-o` flag separator type

### DIFF
--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -159,7 +159,7 @@ counted_array!(pub static ARGS: [ArgInfo<ArgData>; _] = [
     take_arg!("-iwithprefixbefore", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
     flag!("-nostdinc", PreprocessorArgumentFlag),
     flag!("-nostdinc++", PreprocessorArgumentFlag),
-    take_arg!("-o", PathBuf, Separated, Output),
+    take_arg!("-o", PathBuf, CanBeSeparated, Output),
     flag!("-remap", PreprocessorArgumentFlag),
     flag!("-save-temps", TooHardFlag),
     take_arg!("-stdlib", OsString, Concatenated('='), PreprocessorArgument),


### PR DESCRIPTION
The `-o` compiler flag doesn't necessarily have to be separated from its value, a good example of this invocation style can be found in [ring](https://github.com/briansmith/ring/blob/63c0364bd3d1478689b7e90550a855a2a3648e3c/build.rs#L598-L605). Without this change, the .c files compiled by ring are not cached, but with it they are, without negatively impacting the more prevalent `-o <path>` style.