### PR TITLE
Fix misleading error message

### DIFF
--- a/src/simples3/credential.rs
+++ b/src/simples3/credential.rs
@@ -359,7 +359,7 @@ impl ProvideAwsCredentials for IamProvider {
                 }).chain_err(|| "failed to read http body")
         });
         let body = body
-            .map_err(|_e| "Didn't get a parseable response body from instance role details".into())
+            .map_err(|e| format!("Failed to get IAM credentials: {}", e).into())
             .and_then(|body| {
                 String::from_utf8(body).chain_err(|| "failed to read iam role response")
             });


### PR DESCRIPTION
"Didn't get a parseable response body from instance role details"
suggests that something was parsed -- that's not the case.  Rather,
something failed in fetching the value, and that failure is `e`, so
should be included in the message.

---

I don't have the right version of OpenSSL installed to build this, so I'm hoping CI will tell me if this small change is correct.  If not, I'll figure out how to get OpenSSL built.