### PR TITLE
fix(windows): remove `DETACHED_PROCESS` flag when starting the server process

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -157,7 +157,7 @@ fn run_server_process() -> Result<ServerStartup> {
     use winapi::um::handleapi::CloseHandle;
     use winapi::um::processthreadsapi::{CreateProcessW, PROCESS_INFORMATION, STARTUPINFOW};
     use winapi::um::winbase::{
-        CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, CREATE_UNICODE_ENVIRONMENT, DETACHED_PROCESS,
+        CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, CREATE_UNICODE_ENVIRONMENT,
     };
 
     trace!("run_server_process");
@@ -227,10 +227,7 @@ fn run_server_process() -> Result<ServerStartup> {
             ptr::null_mut(),
             ptr::null_mut(),
             FALSE,
-            CREATE_UNICODE_ENVIRONMENT
-                | DETACHED_PROCESS
-                | CREATE_NEW_PROCESS_GROUP
-                | CREATE_NO_WINDOW,
+            CREATE_UNICODE_ENVIRONMENT | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW,
             envp.as_mut_ptr() as LPVOID,
             ptr::null(),
             &mut si,


### PR DESCRIPTION
The `DETACHED_PROCESS` flag causes the `CREATE_NO_WINDOW` to be ignored. See MS docs: https://docs.microsoft.com/en-us/windows/win32/procthread/process-creation-flags.

I believe `DETACHED_PROCESS` should avoid creating a window (unless one calls `AllocConsole`), but we're definitely seeing these calls create console windows. I've observed that sccache 0.2.11 works fine and does not create console windows in command prompt, but creates many console windows in powershell. The result is that this PR is a bit of a hack fix (unless we can justify not actually needing `DETACHED_PROCESS`...?).

Note: I'm planning on leaving the discussion at https://github.com/mozilla/sccache/issues/514 (and off this PR, at least until some decision is made).