### PR TITLE
Improve preprocessor handling such that macros are not expanded.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ before_script:
   - if [[ "${DIST_SCCACHE}" = "1" ]]; then export EXTRA_FEATURES="$EXTRA_FEATURES dist-client dist-server"; fi
 
 script:
-  - cargo build --verbose --features="all ${EXTRA_FEATURES}"
-  - RUST_BACKTRACE=1 cargo test --all --verbose --no-default-features --features="${EXTRA_FEATURES}"
+  - cargo build --verbose --features="all ${EXTRA_FEATURES}" || exit 1
+  - RUST_BACKTRACE=1 cargo test --all --verbose --no-default-features --features="${EXTRA_FEATURES}" 
   - RUST_BACKTRACE=1 cargo test --all --verbose --features="all ${EXTRA_FEATURES}"
   # Requires PR #321
   #- if [[ "${DIST_SCCACHE}" = "1" ]]; then RUST_BACKTRACE=1 cargo test --all --verbose --features="all dist-tests ${EXTRA_FEATURES}" test_dist_ -- --test-threads 1; fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ dist-client = ["ar", "flate2", "hyper", "hyperx", "reqwest", "url", "sha2"]
 # Enables the sccache-dist binary
 dist-server = ["crossbeam-utils", "jsonwebtoken", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "void", "version-compare"]
 # Enables dist tests with external requirements
-dist-tests = []
+dist-tests = ["dist-client", "dist-server"]
 
 [workspace]
 exclude = ["tests/test-crate"]

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -82,7 +82,7 @@ pub struct ParsedArguments {
     pub depfile: Option<PathBuf>,
     /// Output files, keyed by a simple name, like "obj".
     pub outputs: HashMap<&'static str, PathBuf>,
-    /// Commandline arguments for the preprocessor.
+    /// Commandline arguments for the preprocessor (not including common_args).
     pub preprocessor_args: Vec<OsString>,
     /// Commandline arguments for the preprocessor or the compiler.
     pub common_args: Vec<OsString>,

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -55,6 +55,7 @@ impl CCompilerImpl for Clang {
         cwd: &Path,
         env_vars: &[(OsString, OsString)],
         may_dist: bool,
+        rewrite_includes_only: bool,
     ) -> SFuture<process::Output>
     where
         T: CommandCreatorSync,
@@ -67,6 +68,7 @@ impl CCompilerImpl for Clang {
             env_vars,
             may_dist,
             self.kind(),
+            rewrite_includes_only,
         )
     }
 
@@ -77,8 +79,16 @@ impl CCompilerImpl for Clang {
         parsed_args: &ParsedArguments,
         cwd: &Path,
         env_vars: &[(OsString, OsString)],
+        rewrite_includes_only: bool,
     ) -> Result<(CompileCommand, Option<dist::CompileCommand>, Cacheable)> {
-        gcc::generate_compile_commands(path_transformer, executable, parsed_args, cwd, env_vars)
+        gcc::generate_compile_commands(
+            path_transformer,
+            executable,
+            parsed_args,
+            cwd,
+            env_vars,
+            rewrite_includes_only,
+        )
     }
 }
 

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(unused_imports,dead_code,unused_variables)]
+#![allow(unused_imports, dead_code, unused_variables)]
 
 use crate::compiler::args::*;
 use crate::compiler::c::{CCompilerImpl, CCompilerKind, Language, ParsedArguments};
@@ -59,7 +59,15 @@ impl CCompilerImpl for Clang {
     where
         T: CommandCreatorSync,
     {
-        gcc::preprocess(creator, executable, parsed_args, cwd, env_vars, may_dist)
+        gcc::preprocess(
+            creator,
+            executable,
+            parsed_args,
+            cwd,
+            env_vars,
+            may_dist,
+            self.kind(),
+        )
     }
 
     fn generate_compile_commands(

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -54,6 +54,7 @@ impl CCompilerImpl for Diab {
         cwd: &Path,
         env_vars: &[(OsString, OsString)],
         may_dist: bool,
+        _rewrite_includes_only: bool,
     ) -> SFuture<process::Output>
     where
         T: CommandCreatorSync,
@@ -68,6 +69,7 @@ impl CCompilerImpl for Diab {
         parsed_args: &ParsedArguments,
         cwd: &Path,
         env_vars: &[(OsString, OsString)],
+        _rewrite_includes_only: bool,
     ) -> Result<(CompileCommand, Option<dist::CompileCommand>, Cacheable)> {
         generate_compile_commands(path_transformer, executable, parsed_args, cwd, env_vars)
     }

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -63,6 +63,7 @@ impl CCompilerImpl for MSVC {
         cwd: &Path,
         env_vars: &[(OsString, OsString)],
         may_dist: bool,
+        _rewrite_includes_only: bool,
     ) -> SFuture<process::Output>
     where
         T: CommandCreatorSync,
@@ -85,6 +86,7 @@ impl CCompilerImpl for MSVC {
         parsed_args: &ParsedArguments,
         cwd: &Path,
         env_vars: &[(OsString, OsString)],
+        _rewrite_includes_only: bool,
     ) -> Result<(CompileCommand, Option<dist::CompileCommand>, Cacheable)> {
         generate_compile_commands(path_transformer, executable, parsed_args, cwd, env_vars)
     }

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -997,6 +997,7 @@ where
         env_vars: Vec<(OsString, OsString)>,
         _may_dist: bool,
         pool: &CpuPool,
+        _rewrite_includes_only: bool,
     ) -> SFuture<HashResult> {
         let me = *self;
         #[rustfmt::skip] // https://github.com/rust-lang/rustfmt/issues/3759
@@ -1260,6 +1261,7 @@ impl Compilation for RustCompilation {
     fn generate_compile_commands(
         &self,
         path_transformer: &mut dist::PathTransformer,
+        _rewrite_includes_only: bool,
     ) -> Result<(CompileCommand, Option<dist::CompileCommand>, Cacheable)> {
         let RustCompilation {
             ref executable,
@@ -2692,6 +2694,7 @@ c:/foo/bar.rs:
                 .to_vec(),
                 false,
                 &pool,
+                false,
             )
             .wait()
             .unwrap();
@@ -2777,6 +2780,7 @@ c:/foo/bar.rs:
                 env_vars.to_owned(),
                 false,
                 &pool,
+                false,
             )
             .wait()
             .unwrap()

--- a/src/config.rs
+++ b/src/config.rs
@@ -383,6 +383,7 @@ pub struct DistConfig {
     pub cache_dir: PathBuf,
     pub toolchains: Vec<DistToolchainConfig>,
     pub toolchain_cache_size: u64,
+    pub rewrite_includes_only: bool,
 }
 
 impl Default for DistConfig {
@@ -393,6 +394,7 @@ impl Default for DistConfig {
             cache_dir: default_dist_cache_dir(),
             toolchains: Default::default(),
             toolchain_cache_size: default_toolchain_cache_size(),
+            rewrite_includes_only: true,
         }
     }
 }

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -1087,6 +1087,7 @@ mod client {
         client_async: Arc<Mutex<reqwest::r#async::Client>>,
         pool: CpuPool,
         tc_cache: Arc<cache::ClientToolchains>,
+        rewrite_includes_only: bool,
     }
 
     impl Client {
@@ -1097,6 +1098,7 @@ mod client {
             cache_size: u64,
             toolchain_configs: &[config::DistToolchainConfig],
             auth_token: String,
+            rewrite_includes_only: bool,
         ) -> Result<Self> {
             let timeout = Duration::new(REQUEST_TIMEOUT_SECS, 0);
             let connect_timeout = Duration::new(CONNECT_TIMEOUT_SECS, 0);
@@ -1121,6 +1123,7 @@ mod client {
                 client_async: Arc::new(Mutex::new(client_async)),
                 pool: pool.clone(),
                 tc_cache: Arc::new(client_toolchains),
+                rewrite_includes_only: rewrite_includes_only,
             })
         }
 
@@ -1299,6 +1302,10 @@ mod client {
             Box::new(self.pool.spawn_fn(move || {
                 tc_cache.put_toolchain(&compiler_path, &weak_key, toolchain_packager)
             }))
+        }
+
+        fn rewrite_includes_only(&self) -> bool {
+            self.rewrite_includes_only
         }
     }
 }

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -747,4 +747,5 @@ pub trait Client {
         weak_key: &str,
         toolchain_packager: Box<dyn pkg::ToolchainPackager>,
     ) -> SFuture<(Toolchain, Option<String>)>;
+    fn rewrite_includes_only(&self) -> bool;
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -147,6 +147,7 @@ struct DistClientConfig {
     cache_dir: PathBuf,
     toolchain_cache_size: u64,
     toolchains: Vec<config::DistToolchainConfig>,
+    rewrite_includes_only: bool,
 }
 
 #[cfg(feature = "dist-client")]
@@ -196,6 +197,7 @@ impl DistClientContainer {
             cache_dir: config.dist.cache_dir.clone(),
             toolchain_cache_size: config.dist.toolchain_cache_size,
             toolchains: config.dist.toolchains.clone(),
+            rewrite_includes_only: config.dist.rewrite_includes_only,
         };
         let state = Self::create_state(config);
         Self {
@@ -348,6 +350,7 @@ impl DistClientContainer {
                     config.toolchain_cache_size,
                     &config.toolchains,
                     auth_token,
+                    config.rewrite_includes_only,
                 );
                 let dist_client = try_or_retry_later!(
                     dist_client.chain_err(|| "failure during dist client creation")

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -35,11 +35,12 @@ fn basic_compile(tmpdir: &Path, sccache_cfg_path: &Path, sccache_cached_cfg_path
     ];
     let source_file = "x.c";
     let obj_file = "x.o";
-    write_source(tmpdir, source_file, "int x() { return 5; }");
+    write_source(tmpdir, source_file, "#if !defined(SCCACHE_TEST_DEFINE)\n#error SCCACHE_TEST_DEFINE is not defined\n#endif\nint x() { return 5; }");
     sccache_command()
         .args(&[
             std::env::var("CC").unwrap_or("gcc".to_string()).as_str(),
             "-c",
+            "-DSCCACHE_TEST_DEFINE",
         ])
         .arg(tmpdir.join(source_file))
         .arg("-o")

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -261,6 +261,8 @@ impl DistSystem {
         let mut child = Command::new("docker")
             .args(&["build", "-q", "-t", DIST_IMAGE, "-"])
             .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
             .spawn()
             .unwrap();
         child
@@ -667,8 +669,8 @@ fn make_container_name(tag: &str) -> String {
 
 fn check_output(output: &Output) {
     if !output.status.success() {
-        println!("[BEGIN OUTPUT]\n===========\n{}\n==========\n\n\n\n=========\n{}\n===============\n[FIN OUTPUT]\n\n",
-            String::from_utf8_lossy(&output.stdout), String::from_utf8_lossy(&output.stderr));
+        println!("{}\n\n[BEGIN STDOUT]\n===========\n{}\n===========\n[FIN STDOUT]\n\n[BEGIN STDERR]\n===========\n{}\n===========\n[FIN STDERR]\n\n",
+            output.status, String::from_utf8_lossy(&output.stdout), String::from_utf8_lossy(&output.stderr));
         panic!()
     }
 }

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -194,6 +194,7 @@ pub fn sccache_client_cfg(tmpdir: &Path) -> sccache::config::FileConfig {
             cache_dir: tmpdir.join(dist_cache_relpath),
             toolchains: vec![],
             toolchain_cache_size: TC_CACHE_SIZE,
+            rewrite_includes_only: false, // TODO
         },
     }
 }

--- a/tests/oauth.rs
+++ b/tests/oauth.rs
@@ -59,6 +59,7 @@ fn config_with_dist_auth(
             cache_dir: tmpdir.join("unused-cache"),
             toolchains: vec![],
             toolchain_cache_size: 0,
+            rewrite_includes_only: true,
         },
     }
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -64,6 +64,8 @@ macro_rules! vec_from {
     };
 }
 
+// TODO: This will fail if gcc/clang is actually a ccache wrapper, as it is the
+// default case on Fedora, e.g.
 fn compile_cmdline<T: AsRef<OsStr>>(
     compiler: &str,
     exe: T,

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -390,6 +390,10 @@ fn find_compilers() -> Vec<Compiler> {
     }]
 }
 
+// TODO: This runs multiple test cases, for multiple compilers. It should be
+// split up to run them individually. In the current form, it is hard to see
+// which sub test cases are executed, and if one fails, the remaining tests
+// are not run.
 #[test]
 #[cfg(any(unix, target_env = "msvc"))]
 fn test_sccache_command() {

--- a/tests/test_macro_expansion.c
+++ b/tests/test_macro_expansion.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+
+#define foo(x)                                                                 \
+  {                                                                            \
+    if (x) {                                                                   \
+      abort();                                                                 \
+    }                                                                          \
+  }
+
+void bar() { foo(0); }

--- a/tests/test_with_define.c
+++ b/tests/test_with_define.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+#if !defined(SCCACHE_TEST_DEFINE)
+#error SCCACHE_TEST_DEFINE is not defined
+#endif
+
+void foo() { printf("hello world\n"); }


### PR DESCRIPTION
Fixes #521

This surely deserves a test that checks that there will be no warnings emitted from macro expansions that should be suppressed by the additional flags. If someone provides me some guidance on how to add a test for that, I will be happy to do that.

- [x] Make enabling this behaviour explicit via a sccache configuration option.