### PR TITLE
Don't do distributed compilation if we're building with plugins.

### DIFF
--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -511,6 +511,13 @@ pub fn generate_compile_commands(path_transformer: &mut dist::PathTransformer,
     let dist_command = None;
     #[cfg(feature = "dist-client")]
     let dist_command = (|| {
+        if !parsed_args.extra_hash_files.is_empty() {
+            // If we're using a plugin of sorts, we have no guarantee that it'll
+            // be in the distributed server, so compile locally.
+            warn!("Cannot perform distributed compile due to gcc or clang plugin");
+            return None;
+        }
+
         // https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Overall-Options.html
         let language = match parsed_args.language {
             Language::C => "cpp-output",


### PR DESCRIPTION
Partially addresses #562 by not building remotely.

That is not amazing, and we should probably look into how to address this use
case...

We could try to address it sending the plugins to the server, but that doesn't
seem to work when cross-compiling, and I don't have great ideas for that...