### PR TITLE
Handle clang plugins better.

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -46,6 +46,15 @@ use tokio_timer::Timeout;
 
 use crate::errors::*;
 
+/// Can dylibs (shared libraries or proc macros) be distributed on this platform?
+#[cfg(all(feature = "dist-client", target_os = "linux", target_arch = "x86_64"))]
+pub const CAN_DIST_DYLIBS: bool = true;
+#[cfg(all(
+    feature = "dist-client",
+    not(all(target_os = "linux", target_arch = "x86_64"))
+))]
+pub const CAN_DIST_DYLIBS: bool = false;
+
 #[derive(Clone, Debug)]
 pub struct CompileCommand {
     pub executable: PathBuf,

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -497,13 +497,6 @@ pub fn generate_compile_commands(
     let dist_command = None;
     #[cfg(feature = "dist-client")]
     let dist_command = (|| {
-        if !parsed_args.extra_hash_files.is_empty() {
-            // If we're using a plugin of sorts, we have no guarantee that it'll
-            // be in the distributed server, so compile locally.
-            warn!("Cannot perform distributed compile due to gcc or clang plugin");
-            return None;
-        }
-
         // https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Overall-Options.html
         let language = match parsed_args.language {
             Language::C => "cpp-output",

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -57,15 +57,6 @@ use tempdir::TempDir;
 
 use crate::errors::*;
 
-/// Can dylibs (like proc macros) be distributed on this platform?
-#[cfg(all(feature = "dist-client", target_os = "linux", target_arch = "x86_64"))]
-const CAN_DIST_DYLIBS: bool = true;
-#[cfg(all(
-    feature = "dist-client",
-    not(all(target_os = "linux", target_arch = "x86_64"))
-))]
-const CAN_DIST_DYLIBS: bool = false;
-
 #[cfg(feature = "dist-client")]
 const RLIB_PREFIX: &str = "lib";
 #[cfg(feature = "dist-client")]
@@ -1493,7 +1484,7 @@ impl pkg::InputsPackager for RustInputsPackager {
         for input_path in inputs.into_iter() {
             let input_path = pkg::simplify_path(&input_path)?;
             if let Some(ext) = input_path.extension() {
-                if !CAN_DIST_DYLIBS && ext == DLL_EXTENSION {
+                if !super::CAN_DIST_DYLIBS && ext == DLL_EXTENSION {
                     bail!(
                         "Cannot distribute dylib input {} on this platform",
                         input_path.display()
@@ -1581,7 +1572,7 @@ impl pkg::InputsPackager for RustInputsPackager {
                     }
                     if !path.is_file() {
                         continue;
-                    } else if !CAN_DIST_DYLIBS && ext == DLL_EXTENSION {
+                    } else if !super::CAN_DIST_DYLIBS && ext == DLL_EXTENSION {
                         bail!(
                             "Cannot distribute dylib input {} on this platform",
                             path.display()


### PR DESCRIPTION
This runs the analysis in a distributed fashion for me, but it causes errors
because the plugin fails to distinguish whether something is in a third-party
path or not, presumably.

So you get errors like:

```
0:12.92 /home/emilio/src/moz/gecko-2/security/sandbox/chromium/base/strings/safe_sprintf.h:177:3: error: bad implicit conversion constructor for 'Arg'
0:12.92   Arg(unsigned long long j) : type(UINT) {
0:12.92   ^
0:12.92 /home/emilio/src/moz/gecko-2/security/sandbox/chromium/base/strings/safe_sprintf.h:177:3: note: consider adding the explicit keyword to the constructor
0:12.92   Arg(unsigned long long j) : type(UINT) {
0:12.92   ^
0:12.92   explicit
0:12.92 /home/emilio/src/moz/gecko-2/security/sandbox/chromium/base/strings/safe_sprintf.h:183:3: error: bad implicit conversion constructor for 'Arg'
0:12.92   Arg(const char* s) : str(s), type(STRING) { }
0:12.92   ^
0:12.92 /home/emilio/src/moz/gecko-2/security/sandbox/chromium/base/strings/safe_sprintf.h:183:3: note: consider adding the explicit keyword to the constructor
0:12.92   Arg(const char* s) : str(s), type(STRING) { }
```

Even though security/sandbox/chromium is in a third-party path. This is a bug in
the clang plugin which doesn't handle line directives, and I have a patch for
it.

Fixes #562.