### PR TITLE
Avoid de-allocating active servers under high load. Fixes #573

### DIFF
--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -303,7 +303,7 @@ mod server {
 
     const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
     const HEARTBEAT_ERROR_INTERVAL: Duration = Duration::from_secs(10);
-    pub const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(60);
+    pub const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(90);
 
     fn create_https_cert_and_privkey(addr: SocketAddr) -> Result<(Vec<u8>, Vec<u8>, Vec<u8>)> {
         let rsa_key = openssl::rsa::Rsa::<openssl::pkey::Private>::generate(2048)


### PR DESCRIPTION
This adjusts our notion of active server to include servers we've seen
job update from recently, and bumps time hearbeat timeout to account
for cases a server and scheduler are servicing many concurrent requests
and may not service a hearbeat in a timely fashion.