### PR TITLE
Replace usage of jsonwebtoken for GCS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bincode"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,12 +851,12 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "5.0.1"
-source = "git+https://github.com/Jake-Shadle/jsonwebtoken.git?rev=2f469a61#2f469a61ee31b02cb6b6c3d55515592e9aaeec3b"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1691,13 +1696,15 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.13.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1777,7 +1784,7 @@ dependencies = [
  "arraydeque 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cmd 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1801,7 +1808,7 @@ dependencies = [
  "hyperx 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonwebtoken 5.0.1 (git+https://github.com/Jake-Shadle/jsonwebtoken.git?rev=2f469a61)",
+ "jsonwebtoken 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "libmount 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1820,7 +1827,7 @@ dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rouille 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "selenium-rs 0.1.1 (git+https://github.com/saresend/selenium-rs.git?rev=0314a2420da78cce7454a980d862995750771722)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1845,6 +1852,7 @@ dependencies = [
  "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "version-compare 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2910,6 +2918,7 @@ dependencies = [
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
 "checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
@@ -2994,7 +3003,7 @@ dependencies = [
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
-"checksum jsonwebtoken 5.0.1 (git+https://github.com/Jake-Shadle/jsonwebtoken.git?rev=2f469a61)" = "<none>"
+"checksum jsonwebtoken 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a81d1812d731546d2614737bee92aa071d37e9afa1409bc374da9e5e70e70b22"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -3085,7 +3094,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
 "checksum retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29460f6011a25fc70b22010e796bd98330baccaa0005cba6f90b858a510dec0d"
-"checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
+"checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
 "checksum rouille 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0845b9c39ba772da769fe2aaa4d81bfd10695a7ea051d0510702260ff4159841"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ required-features = ["dist-server"]
 [dependencies]
 ar = { version = "0.6", optional = true }
 atty = "0.2.6"
-base64 = "0.9.0"
+base64 = "0.11.0"
 bincode = "1"
 byteorder = "1.0"
 bytes = "0.4"
@@ -43,7 +43,7 @@ http = "0.1"
 hyper = { version = "0.12", optional = true }
 hyperx = { version = "0.12", optional = true }
 jobserver = "0.1"
-jsonwebtoken = { version = "5.0", optional = true }
+jsonwebtoken = { version = "6.0.1", optional = true }
 lazy_static = "1.0.0"
 libc = "0.2.10"
 local-encoding = "0.2.0"
@@ -59,7 +59,7 @@ redis = { version = "0.9.0", optional = true }
 regex = "1"
 reqwest = { version = "0.9.11", optional = true }
 retry = "0.4.0"
-ring = "0.13.2"
+ring = "0.14.6"
 sha-1 = { version = "0.8", optional = true }
 sha2 = { version = "0.8", optional = true }
 serde = "1.0"
@@ -78,8 +78,9 @@ tower = "0.1"
 tokio-tcp = "0.1"
 tokio-timer = "0.2"
 toml = "0.4"
-uuid = { version = "0.7", features = ["v4"] }
+untrusted = { version = "0.6.0", optional = true }
 url = { version = "1.0", optional = true }
+uuid = { version = "0.7", features = ["v4"] }
 walkdir = "1.0.7"
 which = "2"
 zip = { version = "0.4", default-features = false, features = ["deflate"] }
@@ -97,8 +98,6 @@ version-compare = { version = "0.0.8", optional = true }
 [patch.crates-io]
 # Waiting for #151 to make it into a release
 tiny_http = { git = "https://github.com/tiny-http/tiny-http.git", rev = "619680de" }
-# Waiting for https://github.com/Keats/jsonwebtoken/pull/74
-jsonwebtoken = { git = "https://github.com/Jake-Shadle/jsonwebtoken.git", rev = "2f469a61" }
 
 [dev-dependencies]
 assert_cmd = "0.9"
@@ -132,7 +131,7 @@ all = ["dist-client", "redis", "s3", "memcached", "gcs", "azure"]
 azure = ["chrono", "hyper", "hyperx", "url", "hmac", "md-5", "sha2"]
 s3 = ["chrono", "hyper", "hyperx", "reqwest", "simple-s3", "hmac", "sha-1"]
 simple-s3 = []
-gcs = ["chrono", "hyper", "hyperx", "jsonwebtoken", "reqwest", "url"]
+gcs = ["chrono", "hyper", "hyperx", "reqwest", "untrusted", "url"]
 memcached = ["memcached-rs"]
 # Enable features that require unstable features of Nightly Rust.
 unstable = []

--- a/src/bin/sccache-dist/main.rs
+++ b/src/bin/sccache-dist/main.rs
@@ -380,7 +380,6 @@ fn run(command: Command) -> Result<i32> {
                     let validation = jwt::Validation {
                         leeway: 0,
                         validate_exp: false,
-                        validate_iat: false,
                         validate_nbf: false,
                         aud: None,
                         iss: None,

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -407,7 +407,6 @@ mod server {
         static ref JWT_VALIDATION: jwt::Validation = jwt::Validation {
             leeway: 0,
             validate_exp: false,
-            validate_iat: false,
             validate_nbf: false,
             aud: None,
             iss: None,


### PR DESCRIPTION
This removes the use of the patched jsonwebtoken

`jsonwebtoken = { git = "https://github.com/Jake-Shadle/jsonwebtoken.git", rev = "2f469a61" }`

which is still needed due to no release from jsonwebtoken with the relevant changes (last release was May). Using patches are supposed to be temporary, because what ends up happening is that people that do `cargo install sccache --features=gcs` end up with a broken sccache because the patched version of jsonwebtoken that "works" is not used when installing from crates.io, and for some reason, the prebuilt binaries (at least the musl one) in github releases are also incorrect.

Rather than wait for a release, this change removes the need for jsonwebtoken altogether for `gcs` caching, by just doing the relevant pieces directly using base64/ring.

* Serializes  (JSON + base64) the JWT header (signing algorithm)
* Serializes (JSON + base64) the JWT claim (scope, timestamps, uri etc)
* Signs the JWT payload with the private key from the service account
* Concatenates the JWT payload and the base64 encoded signature

jsonwebtoken is still used in the dist stuff, only required 2 changes due to a field being removed from JWT.

Resolves: #489