### PR TITLE
cmdline: Allow running sccache under rr without crashing the remote compiler.

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -201,11 +201,22 @@ pub fn parse() -> Result<Command> {
     } else if let Some(mut args) = cmd {
         if let Some(exe) = args.next() {
             let cmdline = args.map(|s| s.to_owned()).collect::<Vec<_>>();
+            let mut env_vars = env::vars_os().collect::<Vec<_>>();
+
+            // If we're running under rr, avoid the `LD_PRELOAD` bits, as it will
+            // almost surely do the wrong thing, as the compiler gets executed
+            // in a different process tree.
+            //
+            // FIXME: Maybe we should strip out `LD_PRELOAD` always?
+            if env::var_os("RUNNING_UNDER_RR").is_some() {
+                env_vars.retain(|(k, _v)| k != "LD_PRELOAD" && k != "RUNNING_UNDER_RR");
+            }
+
             Ok(Command::Compile {
                 exe: exe.to_owned(),
-                cmdline: cmdline,
-                cwd: cwd,
-                env_vars: env::vars_os().collect(),
+                cmdline,
+                cwd,
+                env_vars,
             })
         } else {
             bail!("No compile command");


### PR DESCRIPTION
Otherwise we remote LD_PRELOAD to the builder, and crash...

This is a huge hack and probably should only be done in the dist path. But it
worked for me so I wanted to post it somewhere. Happy to do the work to make
something like this landable or what not. It's clearly not perfect.