### PR TITLE
tests: Install openssl 1.1 in the docker image.

### DIFF
--- a/tests/harness/Dockerfile.sccache-dist
+++ b/tests/harness/Dockerfile.sccache-dist
@@ -10,6 +10,6 @@ RUN cd /bubblewrap-0.3.1 && \
 
 FROM aidanhs/ubuntu-docker:18.04-17.03.2-ce
 RUN apt-get update && \
-    apt-get install libcap2 libssl1.0.0 && \
+    apt-get install libcap2 libssl1.1 && \
     apt-get clean
 COPY --from=bwrap-build /bubblewrap-0.3.1/bwrap /bwrap


### PR DESCRIPTION
We copy the sccache-dist binary from the host to the container. If the host is
using openssl 1.1 (like Fedora by default) then the sccache-dist binary can't
find the right shared libs and fails.

This allows me to run dist-tests in Fedora 31, with some hackarounds like:

 * https://github.com/mozilla/kitsune/issues/3991#issuecomment-552154956