### PR TITLE
compiler: support '.C' for C++ code

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -110,7 +110,7 @@ impl Language {
     pub fn from_file_name(file: &Path) -> Option<Self> {
         match file.extension().and_then(|e| e.to_str()) {
             Some("c") => Some(Language::C),
-            Some("cc") | Some("cpp") | Some("cxx") => Some(Language::Cxx),
+            Some("C") | Some("cc") | Some("cpp") | Some("cxx") => Some(Language::Cxx),
             Some("m") => Some(Language::ObjectiveC),
             Some("mm") => Some(Language::ObjectiveCxx),
             e => {


### PR DESCRIPTION
Assume a file ending in '.C' is a C++ file.