### PR TITLE
feat: Support enabling TLS in custom S3 endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ If you want to use S3 storage for the sccache cache, you need to set the `SCCACH
 
 You can use `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to set the S3 credentials.  Alternately, you can set `AWS_IAM_CREDENTIALS_URL` to a URL that returns credentials in the format supported by the [EC2 metadata service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials), and credentials will be fetched from that location as needed. In the absence of either of these options, credentials for the instance's IAM role will be fetched from the EC2 metadata service directly.
 
-If you need to override the default endpoint you can set `SCCACHE_ENDPOINT`. To connect to a minio storage for example you can set `SCCACHE_ENDPOINT=<ip>:<port>`. 
+If you need to override the default endpoint you can set `SCCACHE_ENDPOINT`. To connect to a minio storage for example you can set `SCCACHE_ENDPOINT=<ip>:<port>`. If your endpoint requires TLS, set `SCCACHE_S3_USE_SSL=true`.
 
 
 ### Redis

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -262,10 +262,11 @@ pub fn storage_from_config(config: &Config, pool: &CpuPool) -> Arc<dyn Storage> 
             CacheType::S3(config::S3CacheConfig {
                 ref bucket,
                 ref endpoint,
+                use_ssl,
             }) => {
                 debug!("Trying S3Cache({}, {})", bucket, endpoint);
                 #[cfg(feature = "s3")]
-                match S3Cache::new(&bucket, &endpoint) {
+                match S3Cache::new(&bucket, &endpoint, use_ssl) {
                     Ok(s) => {
                         trace!("Using S3Cache");
                         return Arc::new(s);

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -35,7 +35,7 @@ pub struct S3Cache {
 
 impl S3Cache {
     /// Create a new `S3Cache` storing data in `bucket`.
-    pub fn new(bucket: &str, endpoint: &str) -> Result<S3Cache> {
+    pub fn new(bucket: &str, endpoint: &str, use_ssl: bool) -> Result<S3Cache> {
         let user_dirs = UserDirs::new().ok_or("Couldn't get user directories")?;
         let home = user_dirs.home_dir();
 
@@ -48,8 +48,11 @@ impl S3Cache {
         ];
         let provider =
             AutoRefreshingProvider::new(ChainProvider::with_profile_providers(profile_providers));
-        //TODO: configurable SSL
-        let bucket = Rc::new(Bucket::new(bucket, endpoint, Ssl::No)?);
+        let ssl_mode = match use_ssl {
+            true => Ssl::Yes,
+            false => Ssl::No,
+        };
+        let bucket = Rc::new(Bucket::new(bucket, endpoint, ssl_mode)?);
         Ok(S3Cache {
             bucket: bucket,
             provider: provider,

--- a/src/config.rs
+++ b/src/config.rs
@@ -199,6 +199,7 @@ pub struct RedisCacheConfig {
 pub struct S3CacheConfig {
     pub bucket: String,
     pub endpoint: String,
+    pub use_ssl: bool,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -453,7 +454,15 @@ fn config_from_env() -> EnvConfig {
                 _ => format!("{}.s3.amazonaws.com", bucket),
             },
         };
-        S3CacheConfig { bucket, endpoint }
+        let use_ssl = match env::var("SCCACHE_S3_USE_SSL") {
+            Ok(ref value) if value != "off" => true,
+            _ => false,
+        };
+        S3CacheConfig {
+            bucket,
+            endpoint,
+            use_ssl,
+        }
     });
 
     let redis = env::var("SCCACHE_REDIS")


### PR DESCRIPTION
Since the `simples3` module already handles this (and it seems the only logic flipped here is the url prefix), plumbing through a config is a pretty quick change. There doesn't appear to be a github issue for this yet, but there was a `TODO` in the source which this resolves.

The tests appear to be passing, and testing against a local minio instance shows this working:

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/596042/68832831-30ea0100-066f-11ea-8727-61fccb9fd0b8.png">
