### PR TITLE
Make the rust input packager aware of rmeta files.

### DIFF
--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -62,6 +62,9 @@ const RLIB_PREFIX: &str = "lib";
 #[cfg(feature = "dist-client")]
 const RLIB_EXTENSION: &str = "rlib";
 
+#[cfg(feature = "dist-client")]
+const RMETA_EXTENSION: &str = "rmeta";
+
 /// Directory in the sysroot containing binary to which rustc is linked.
 #[cfg(feature = "dist-client")]
 const BINS_DIR: &str = "bin";
@@ -1001,7 +1004,6 @@ where
             host,
             sysroot,
             compiler_shlibs_digests,
-            #[cfg(feature = "dist-client")]
             rlib_dep_reader,
             parsed_args:
                 ParsedArguments {
@@ -1488,7 +1490,7 @@ impl pkg::InputsPackager for RustInputsPackager {
                         "Cannot distribute dylib input {} on this platform",
                         input_path.display()
                     )
-                } else if ext == RLIB_EXTENSION {
+                } else if ext == RLIB_EXTENSION || ext == RMETA_EXTENSION {
                     if let Some((ref rlib_dep_reader, ref mut dep_crate_names)) =
                         rlib_dep_reader_and_names
                     {
@@ -1559,6 +1561,9 @@ impl pkg::InputsPackager for RustInputsPackager {
                             (&libname[DLL_PREFIX.len()..], ext)
                         }
                         Some(ext) if libname.starts_with(RLIB_PREFIX) && ext == RLIB_EXTENSION => {
+                            (&libname[RLIB_PREFIX.len()..], ext)
+                        }
+                        Some(ext) if libname.starts_with(RLIB_PREFIX) && ext == RMETA_EXTENSION => {
                             (&libname[RLIB_PREFIX.len()..], ext)
                         }
                         _ => continue,

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -999,11 +999,13 @@ where
         pool: &CpuPool,
     ) -> SFuture<HashResult> {
         let me = *self;
+        #[rustfmt::skip] // https://github.com/rust-lang/rustfmt/issues/3759
         let RustHasher {
             executable,
             host,
             sysroot,
             compiler_shlibs_digests,
+            #[cfg(feature = "dist-client")]
             rlib_dep_reader,
             parsed_args:
                 ParsedArguments {


### PR DESCRIPTION
Distributing rust compilations was failing routinely due to the
dependent crate discovery mechanism coming up empty looking for
rlibs passed with --extern. As or a recent rustc version rmeta files
are passed instead, so we need to take those into account.