### PR TITLE
Make the stats persistant by saving them to cache

### DIFF
--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -164,7 +164,7 @@ pub trait Storage {
     fn get_stats(&self) -> SFuture<Option<ServerStats>>;
 
     /// Save the stats into storage
-    fn save_stats(&self, stats: ServerStats) -> SFuture<Duration>;
+    fn save_stats(&self, stats: ServerStats) -> SFuture<()>;
 }
 
 /// Get a suitable `Storage` implementation from configuration.

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -24,6 +24,8 @@ use crate::cache::redis::RedisCache;
 #[cfg(feature = "s3")]
 use crate::cache::s3::S3Cache;
 use crate::config::{self, CacheType, Config};
+use crate::errors::*;
+use crate::server::ServerStats;
 use futures_cpupool::CpuPool;
 use std::fmt;
 #[cfg(feature = "gcs")]
@@ -33,8 +35,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use zip::write::FileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter};
-
-use crate::errors::*;
 
 /// Result of a cache lookup.
 pub enum Cache {
@@ -159,6 +159,12 @@ pub trait Storage {
 
     /// Get the maximum storage size, if applicable.
     fn max_size(&self) -> SFuture<Option<u64>>;
+
+    /// Get the stats from storage.
+    fn get_stats(&self) -> SFuture<Option<ServerStats>>;
+
+    /// Save the stats into storage
+    fn save_stats(&self, stats: ServerStats) -> SFuture<Duration>;
 }
 
 /// Get a suitable `Storage` implementation from configuration.

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -26,3 +26,5 @@ pub mod redis;
 pub mod s3;
 
 pub use crate::cache::cache::*;
+
+const STATS_KEY: &'static str = "STATS_KEY";

--- a/src/test/mock_storage.rs
+++ b/src/test/mock_storage.rs
@@ -14,6 +14,7 @@
 
 use crate::cache::{Cache, CacheWrite, Storage};
 use crate::errors::*;
+use crate::server::ServerStats;
 use futures::future;
 use std::cell::RefCell;
 use std::time::Duration;
@@ -57,5 +58,11 @@ impl Storage for MockStorage {
     }
     fn max_size(&self) -> SFuture<Option<u64>> {
         Box::new(future::ok(None))
+    }
+    fn get_stats(&self) -> SFuture<Option<ServerStats>> {
+        Box::new(future::ok(None))
+    }
+    fn save_stats(&self, _stats: ServerStats) -> SFuture<()> {
+        f_ok(())
     }
 }


### PR DESCRIPTION
Closes #33 
I tried making it as boilerplate in the Storage trait, but too much lifetime issues (upgrading to latest futures (if possible in mozilla?) should solve a lot of those)
 https://play.rust-lang.org/?gist=917b00ea0c752d6fa50f35965d969648