### PR TITLE
gcc: Fix rewrite_includes_only support with gcc.

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -87,6 +87,7 @@ impl CCompilerImpl for Clang {
             parsed_args,
             cwd,
             env_vars,
+            self.kind(),
             rewrite_includes_only,
         )
     }


### PR DESCRIPTION
Fixes #636.

With this I'm able to get an sccache-dist build with gcc.