### PR TITLE
Make cargo and sccache more aware of toolchain archives

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -663,7 +663,7 @@ pub fn run_command(cmd: Command) -> Result<i32> {
             let pool = CpuPool::new(1);
             let out_file = File::create(out)?;
 
-            let compiler = compiler::get_compiler_info(&creator, &executable, &env, &pool);
+            let compiler = compiler::get_compiler_info(&creator, &executable, &env, &pool, None);
             let packager = compiler.map(|c| c.get_toolchain_packager());
             let res = packager.and_then(|p| p.write_pkg(out_file));
             runtime.block_on(res)?

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -342,6 +342,7 @@ impl Rust {
         executable: PathBuf,
         env_vars: &[(OsString, OsString)],
         rustc_verbose_version: &str,
+        dist_archive: Option<PathBuf>,
         pool: CpuPool,
     ) -> SFuture<Rust>
     where
@@ -384,6 +385,10 @@ impl Rust {
                     })
                 })
                 .collect::<Vec<_>>();
+            if let Some(path) = dist_archive {
+                trace!("Hashing {:?} along with rustc libs.", path);
+                libs.push(path.to_path_buf());
+            };
             libs.sort();
             Ok((sysroot, libs))
         });

--- a/src/dist/cache.rs
+++ b/src/dist/cache.rs
@@ -213,7 +213,7 @@ mod client {
             Ok((tc, None))
         }
 
-        fn get_custom_toolchain(
+        pub fn get_custom_toolchain(
             &self,
             compiler_path: &Path,
         ) -> Option<Result<(Toolchain, String, PathBuf)>> {

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -1295,7 +1295,7 @@ mod client {
             compiler_path: &Path,
             weak_key: &str,
             toolchain_packager: Box<dyn ToolchainPackager>,
-        ) -> SFuture<(Toolchain, Option<String>)> {
+        ) -> SFuture<(Toolchain, Option<(String, std::path::PathBuf)>)> {
             let compiler_path = compiler_path.to_owned();
             let weak_key = weak_key.to_owned();
             let tc_cache = self.tc_cache.clone();

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -1062,7 +1062,7 @@ mod client {
     use futures_cpupool::CpuPool;
     use std::collections::HashMap;
     use std::io::Write;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -1295,7 +1295,7 @@ mod client {
             compiler_path: &Path,
             weak_key: &str,
             toolchain_packager: Box<dyn ToolchainPackager>,
-        ) -> SFuture<(Toolchain, Option<(String, std::path::PathBuf)>)> {
+        ) -> SFuture<(Toolchain, Option<(String, PathBuf)>)> {
             let compiler_path = compiler_path.to_owned();
             let weak_key = weak_key.to_owned();
             let tc_cache = self.tc_cache.clone();
@@ -1306,6 +1306,12 @@ mod client {
 
         fn rewrite_includes_only(&self) -> bool {
             self.rewrite_includes_only
+        }
+        fn get_custom_toolchain(&self, exe: &PathBuf) -> Option<PathBuf> {
+            match self.tc_cache.get_custom_toolchain(exe) {
+                Some(Ok((_, _, path))) => Some(path),
+                _ => None,
+            }
         }
     }
 }

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -746,6 +746,6 @@ pub trait Client {
         compiler_path: &Path,
         weak_key: &str,
         toolchain_packager: Box<dyn pkg::ToolchainPackager>,
-    ) -> SFuture<(Toolchain, Option<String>)>;
+    ) -> SFuture<(Toolchain, Option<(String, std::path::PathBuf)>)>;
     fn rewrite_includes_only(&self) -> bool;
 }

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -18,7 +18,7 @@ use std::ffi::OsString;
 use std::fmt;
 use std::io::{self, Read};
 use std::net::SocketAddr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::str::FromStr;
 #[cfg(feature = "dist-server")]
@@ -746,6 +746,7 @@ pub trait Client {
         compiler_path: &Path,
         weak_key: &str,
         toolchain_packager: Box<dyn pkg::ToolchainPackager>,
-    ) -> SFuture<(Toolchain, Option<(String, std::path::PathBuf)>)>;
+    ) -> SFuture<(Toolchain, Option<(String, PathBuf)>)>;
     fn rewrite_includes_only(&self) -> bool;
+    fn get_custom_toolchain(&self, exe: &PathBuf) -> Option<PathBuf>;
 }


### PR DESCRIPTION
These two commits together should fix the issue of broken builds requiring both a clobber and cache-clear when updating rust toolchain archives.