### PR TITLE
Use a larger toolchain cache size in the example config provided by docs

### DIFF
--- a/docs/DistributedQuickstart.md
+++ b/docs/DistributedQuickstart.md
@@ -116,8 +116,8 @@ scheduler_url = "https://192.168.1.1"
 # Used for mapping local toolchains to remote cross-compile toolchains. Empty in
 # this example where the client and build server are both Linux.
 toolchains = []
-# Size of the local toolchain cache, in bytes.
-toolchain_cache_size = 1073741824
+# Size of the local toolchain cache, in bytes (5GB here, 10GB if unspecified).
+toolchain_cache_size = 5368709120
 
 [dist.auth]
 type = "token"


### PR DESCRIPTION
As seen in #629, things go badly when an individual toolchain archive ends
up larger than the entire cache. The scenario described there is relatively
likely in the case of rust, suggesting the 1GB suggestion here in not enough.