### PR TITLE
compiler: Log server id on failed distributed compile.

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -519,7 +519,7 @@ where
                             debug!("[{}]: Running job", compile_out_pretty3);
                             dist_client.do_run_job(job_alloc, dist_compile_cmd, dist_output_paths, inputs_packager)
                                 .map(move |res| ((job_id, server_id), res))
-                                .chain_err(|| "could not run distributed compilation job")
+                                .chain_err(move || format!("could not run distributed compilation job on {:?}", server_id))
                         })
                 })
                 .and_then(move |((job_id, server_id), (jres, path_transformer))| {


### PR DESCRIPTION
When something goes slow because of too many distributed compiles failing, if you start
the client with logging you may see something like this:

```
> 4203: WARN 2020-01-16T22:54:36Z: sccache::compiler::compiler: [IPCMessageTypeName.o]: Could not perform distributed compile, falling back to local: could not run distributed compilation job: Error 500 (Headers={"server": "tiny-http (Rust)", "date": "Thu, 16 Jan 2020 22:54:36 GMT", "content-type": "application/json", "content-length": "147"}): {"description":"run build failed","cause":{"description":"failed to prepare overlay dirs","cause":{"description":"entity not found","cause":null}}}
```

That says that something is going wrong on the server, but doesn't tell you
which server.

This patch logs the server id so that you get some clue about where the failure
happens.