### PR TITLE
Switch from SHA-512 to BLAKE3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "blake3"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -292,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1778,6 +1790,7 @@ dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake3 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2925,6 +2938,7 @@ dependencies = [
 "checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0"
+"checksum blake3 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ba0511b7f4f7d9cb1ef7b8dfda5293af6c1071578d65c8a05aa7d11c1985f08c"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum buf_redux 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b9279646319ff816b05fb5897883ece50d7d854d12b59992683d4f8a71b0f949"
@@ -2942,7 +2956,7 @@ dependencies = [
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
 "checksum conhash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99d6364d028778d0d98b6014fa5882da377cd10d3492b7734d266a428e9b1fca"
-"checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
+"checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ ar = { version = "0.6", optional = true }
 atty = "0.2.6"
 base64 = "0.11.0"
 bincode = "1"
+blake3 = "0.1.1"
 byteorder = "1.0"
 bytes = "0.4"
 chrono = { version = "0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ redis = { version = "0.9.0", optional = true }
 regex = "1"
 reqwest = { version = "0.9.11", optional = true }
 retry = "0.4.0"
-ring = "0.14.6"
+ring = { version = "0.14.6", optional = true }
 sha-1 = { version = "0.8", optional = true }
 sha2 = { version = "0.8", optional = true }
 serde = "1.0"
@@ -131,7 +131,7 @@ all = ["dist-client", "redis", "s3", "memcached", "gcs", "azure"]
 azure = ["chrono", "hyper", "hyperx", "url", "hmac", "md-5", "sha2"]
 s3 = ["chrono", "hyper", "hyperx", "reqwest", "simple-s3", "hmac", "sha-1"]
 simple-s3 = []
-gcs = ["chrono", "hyper", "hyperx", "reqwest", "untrusted", "url"]
+gcs = ["chrono", "hyper", "hyperx", "reqwest", "ring", "untrusted", "url"]
 memcached = ["memcached-rs"]
 # Enable features that require unstable features of Nightly Rust.
 unstable = []

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -608,7 +608,7 @@ impl pkg::ToolchainPackager for CToolchainPackager {
 }
 
 /// The cache is versioned by the inputs to `hash_key`.
-pub const CACHE_VERSION: &[u8] = b"7";
+pub const CACHE_VERSION: &[u8] = b"8";
 
 lazy_static! {
     /// Environment variables that are factored into the cache key.

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1179,7 +1179,7 @@ LLVM version: 6.0",
         let c = get_compiler_info(&creator, &f.bins[0], &[], &pool)
             .wait()
             .unwrap();
-        // sha-1 digest of an empty file.
+        // digest of an empty file.
         assert_eq!(CompilerKind::C(CCompilerKind::GCC), c.kind());
     }
 

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -187,7 +187,7 @@ lazy_static! {
 }
 
 /// Version number for cache key.
-const CACHE_VERSION: &[u8] = b"4";
+const CACHE_VERSION: &[u8] = b"5";
 
 /// Get absolute paths for all source files listed in rustc's dep-info output.
 fn get_source_files<T>(

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -86,7 +86,7 @@ pub struct Rust {
     host: String,
     /// The path to the rustc sysroot.
     sysroot: PathBuf,
-    /// The SHA-1 digests of all the shared libraries in rustc's $sysroot/lib (or /bin on Windows).
+    /// The digests of all the shared libraries in rustc's $sysroot/lib (or /bin on Windows).
     compiler_shlibs_digests: Vec<String>,
     /// A shared, caching reader for rlib dependencies
     #[cfg(feature = "dist-client")]
@@ -102,7 +102,7 @@ pub struct RustHasher {
     host: String,
     /// The path to the rustc sysroot.
     sysroot: PathBuf,
-    /// The SHA-1 digests of all the shared libraries in rustc's $sysroot/lib (or /bin on Windows).
+    /// The digests of all the shared libraries in rustc's $sysroot/lib (or /bin on Windows).
     compiler_shlibs_digests: Vec<String>,
     /// A shared, caching reader for rlib dependencies
     #[cfg(feature = "dist-client")]


### PR DESCRIPTION
BLAKE3 is designed to be a very high performance cryptographic hash. The BLAKE3 team has shown significantly higher single-thread performance than SHA-512 on modern server hardware [1].

This change resulted in a minor improvement to observed local build times.

### Comparison

`cargo check` on sccache repo (at commit 32e40bba338020ae978cea5698aba35b4a710a88) with a warm cache for each hash. Ten samples were collected for each hash.

SHA512 mean: 60.06 seconds
BLAKE3 mean: 57.77 seconds

This data shows a mean improvement of 2.29 seconds (about 4%). My statistics skills are rough, but this appears to be a very statistically significant improvement.

This test was performed on an Intel i5-7600K and a fairly ancient SATA3 SSD. It would be interesting to see a test result from a higher performance machine. The BLAKE3 team's performance analysis shows 8.5x faster single threaded performance vs SHA-512 on an AWS `c5d.metal` instance.

<details>
<summary>Raw data</summary>
sha512 initial cold build: 1m 47s<br>
blake3 initial cold build: 1m 52s<br>
sha512 build times: 57.02s, 1m 03s, 1m 02s, 58.72s, 1m 00s, 59.48s, 1m 02s, 1m 01s, 58.54s, 58.85s<br>
blake3 build times: 54.87s, 59.82s, 56.72s, 56.91s, 1m 00s, 56.46s, 57.85s, 57.13s, 59.35s, 58.57s<br>
</details>

### Related issues & PRs:

- [#504: Reevaluate hash function used](https://github.com/mozilla/sccache/issues/504)
- [#310: Use RustCrypto crates](https://github.com/mozilla/sccache/pull/310)
- [#108: Faster hash algorithm?](https://github.com/mozilla/sccache/issues/108)
- [#109: Switch from SHA-1 to SHA-512](https://github.com/mozilla/sccache/pull/109)

### References:

1. [Blake3 repo](https://github.com/BLAKE3-team/BLAKE3)
2. [Blake3 paper](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf)