### PR TITLE
Wrap comment to 80 chars in sample scheduler.conf

### DIFF
--- a/docs/DistributedQuickstart.md
+++ b/docs/DistributedQuickstart.md
@@ -25,8 +25,8 @@ The scheduler is a daemon that manages compile request from clients and parcels 
 
 Create a scheduler.conf file to configure client/server authentication. A minimal example looks like:
 ```toml
-# The socket address the scheduler will listen on. It's strongly recommended to listen
-# on localhost and put a HTTPS server in front of it.
+# The socket address the scheduler will listen on. It's strongly recommended
+# to listen on localhost and put a HTTPS server in front of it.
 public_addr = "127.0.0.1:10600"
 
 [client_auth]


### PR DESCRIPTION
First line of the sample scheduler.conf is currently
```
# The socket address the scheduler will listen on. It's strongly recommended to listen
```
which is 86 characters wide, which is too wide to fit in many default-sized terminal windows (e.g. as you edit/view this file locally, starting with the sample contents).

This commit just wraps the comment at 80 cols.