### PR TITLE
Bump lru-disk-cache version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "lru-disk-cache"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1818,7 +1818,7 @@ dependencies = [
  "libmount 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lru-disk-cache 0.3.0",
+ "lru-disk-cache 0.4.0",
  "md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memcached-rs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ lazy_static = "1.0.0"
 libc = "0.2.10"
 local-encoding = "0.2.0"
 log = "0.4"
-lru-disk-cache = { path = "lru-disk-cache", version = "0.3.0" }
+lru-disk-cache = { path = "lru-disk-cache", version = "0.4.0" }
 md-5 = { version = "0.8", optional = true }
 memcached-rs = { version = "0.3" , optional = true }
 num_cpus = "1.0"

--- a/lru-disk-cache/Cargo.toml
+++ b/lru-disk-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lru-disk-cache"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 license = "Apache-2.0"
 description = "A LRU cache for files on disk."


### PR DESCRIPTION
Once we publish this the in-tree code will be compatible with a release, meaning we'll be able to publish a new sccache.