### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/bin/sccache-dist/token_check.rs
+++ b/src/bin/sccache-dist/token_check.rs
@@ -202,7 +202,7 @@ fn check_mozilla_profile(user: &str, required_groups: &[String], profile: &str) 
 #[test]
 fn test_auth_verify_check_mozilla_profile() {
     // A successful response
-    let profile =  r#"{
+    let profile = r#"{
         "sub": "ad|Mozilla-LDAP|asayers",
         "https://sso.mozilla.com/claim/groups": [
             "everyone",

--- a/src/compiler/args.rs
+++ b/src/compiler/args.rs
@@ -956,7 +956,7 @@ mod tests {
             "-quxbar", // -quxbar is not -qux with a value of bar
             "-qux=value",
         ];
-        let iter = ArgsIter::new(args.into_iter().map(OsString::from), &ARGS[..]);
+        let iter = ArgsIter::new(args.iter().map(OsString::from), &ARGS[..]);
         let expected = vec![
             arg!(UnknownFlag("-nomatch")),
             arg!(WithValue("-foo", ArgData::Foo("value"), Separated)),
@@ -1029,8 +1029,7 @@ mod tests {
 
     #[test]
     fn test_arginfo_process_take_concat_arg_delim_doesnt_crash() {
-        let _ = take_arg!("-foo", OsString, Concatenated('='), Foo)
-            .process("-foo", || None);
+        let _ = take_arg!("-foo", OsString, Concatenated('='), Foo).process("-foo", || None);
     }
 
     #[cfg(debug_assertions)]

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -36,7 +36,6 @@ use std::hash::Hash;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process;
-use which::which;
 
 use crate::errors::*;
 
@@ -551,7 +550,7 @@ impl pkg::ToolchainPackager for CToolchainPackager {
             if path.is_absolute() {
                 Some(path)
             } else {
-                which(path).ok()
+                which::which(path).ok()
             }
         };
 

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -19,7 +19,7 @@ use crate::compiler::{
 };
 use crate::dist;
 use crate::mock_command::{CommandCreatorSync, RunCommand};
-use crate::util::{run_input_output, OsStrExt};
+use crate::util::run_input_output;
 use futures::future::Future;
 use futures_cpupool::CpuPool;
 use local_encoding::{Encoder, Encoding};


### PR DESCRIPTION
Compiling on mac I get the following warnings:

```
> rustc --version
rustc 1.41.0 (5e1a79984 2020-01-27)
> cargo test
   Compiling sccache v0.2.14-alpha.0 (/Users/rld/src/sccache)
warning: unused import: `which::which`
  --> src/compiler/c.rs:39:5
   |
39 | use which::which;
   |     ^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `which::which`
  --> src/compiler/c.rs:39:5
   |
39 | use which::which;
   |     ^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `OsStrExt`
  --> src/compiler/msvc.rs:22:37
   |
22 | use crate::util::{run_input_output, OsStrExt};
   |                                     ^^^^^^^^

warning: unused import: `OsStrExt`
  --> src/compiler/msvc.rs:22:37
   |
22 | use crate::util::{run_input_output, OsStrExt};
   |                                     ^^^^^^^^

warning: this method call currently resolves to `<&[T; N] as IntoIterator>::into_iter` (due to autoref coercions), but that might change in the future when `IntoIterator` impls for arrays are added.
   --> src/compiler/args.rs:959:39
    |
959 |         let iter = ArgsIter::new(args.into_iter().map(OsString::from), &ARGS[..]);
    |                                       ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = note: `#[warn(array_into_iter)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>

    Finished test [unoptimized + debuginfo] target(s) in 1m 21s
     Running /Users/rld/src/sccache/target/debug/deps/sccache-a87290b5c3fd512d

```

This patch fixes them.