### PR TITLE
Add github actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  build:
+    name: ${{ matrix.kind }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        os: [macOS-latest, windows-2019, ubuntu-16.04]
+        kind: ['test_debug']
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v1
+        with:
+          # Use depth > 1, because sometimes we need to rebuild master and if
+          # other commits have landed it will become impossible to rebuild if
+          # the checkout is too shallow.
+          fetch-depth: 5
+          submodules: true
+
+      - name: Install rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: "1.41.0"
+
+      - name: Install clippy and rustfmt
+        run: |
+          rustup component add clippy
+          rustup component add rustfmt
+
+      - name: check formatting
+        run: cargo fmt -- --check
+
+      - name: build and test
+        run: cargo test --locked --all-targets
+
+     # TODO
+     # - name: clippy
+     #   run: cargo clippy --locked --all-target


### PR DESCRIPTION
All three operating systems build and test in about 10 minutes:
https://github.com/ry/sccache/runs/495956105

This does not include deployment. I figure we should try out GHA for a while before switching over completely to it. I can add this in a follow up PR - it would be modified from here: https://github.com/denoland/deno/blob/7f591c37835be55b8a426cca61e677fd62c23c93/.github/workflows/ci.yml#L175-L204