### PR TITLE
CI: remove beta build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
     - rust: 1.36.0 # oldest supported version, keep in sync with README.md
     - rust: 1.36.0
       env: DIST_SCCACHE=1
-    - rust: beta
     - rust: nightly
 
     # deployments


### PR DESCRIPTION
The beta build is broken since Rust 1.42.0 was released because blake
0.1.1 is broken in 1.43.0-beta.1. Since sccache is an executable, not a
library, it's not very useful to test the build under many different
versions of Rust.

Fixes #699 