### PR TITLE
remove github action format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,9 @@ jobs:
           rustup component add clippy
           rustup component add rustfmt
 
-      - name: check formatting
-        run: cargo fmt -- --check
+     # Travis doesn't enforce this yet.
+     # - name: check formatting
+     #   run: cargo fmt -- --check
 
       - name: build and test
         run: cargo test --locked --all-targets


### PR DESCRIPTION
Even though Actions aren't supported on the main repo, they can still be
supported on personal repos, and people might proactively fix their
Windows bustage if GitHub sends them emails about it.  So let's keep
Actions, but turn off things we haven't enabled on Travis yet.