### PR TITLE
Revert "use tokio_reactor::Handle::default"

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -166,7 +166,7 @@ fn run_server_process() -> Result<ServerStartup> {
     let mut runtime = Runtime::new()?;
     let pipe_name = format!(r"\\.\pipe\{}", Uuid::new_v4().to_simple_ref());
     let server = runtime.block_on(future::lazy(|| {
-        NamedPipe::new(&pipe_name, &Handle::default())
+        NamedPipe::new(&pipe_name, &Handle::current())
     }))?;
 
     // Connect a client to our server, and we'll wait below if it's still in


### PR DESCRIPTION
The reverted commit introduced the following problem on Windows:

  Starting sccache server...
  error: Timed out waiting for server startup

This reverts commit b43d51fa2e536019c113cc79cd98dcc2861afad4.