### PR TITLE
chore/error: remove deprecated useage of description() and cause()

### DIFF
--- a/src/compiler/args.rs
+++ b/src/compiler/args.rs
@@ -56,7 +56,7 @@ impl Display for ArgToStringError {
 }
 
 impl Error for ArgToStringError {
-    fn cause(&self) -> Option<&dyn Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         None
     }
 }

--- a/src/mock_command.rs
+++ b/src/mock_command.rs
@@ -652,7 +652,7 @@ mod test {
         let mut creator = MockCommandCreator::new(&client);
         creator.next_command_spawns(Err("error".into()));
         let e = spawn_command(&mut creator, "foo").err().unwrap();
-        assert_eq!("error", e.description());
+        assert_eq!("error", e.to_string());
     }
 
     #[test]
@@ -664,7 +664,7 @@ mod test {
             "error",
         ))));
         let e = spawn_wait_command(&mut creator, "foo").err().unwrap();
-        assert_eq!("error", e.description());
+        assert_eq!("error", e.to_string());
     }
 
     #[test]

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -199,7 +199,7 @@ fn test_server_unsupported_compiler() {
     );
     match res {
         Ok(_) => panic!("do_compile should have failed!"),
-        Err(e) => assert_eq!("Compiler not supported: \"error\"", e.description()),
+        Err(e) => assert_eq!("Compiler not supported: \"error\"", e.to_string()),
     }
     // Make sure we ran the mock processes.
     assert_eq!(0, server_creator.lock().unwrap().children.len());


### PR DESCRIPTION
Extracted from #666 