### PR TITLE
Ignore SCCACHE_ERROR_LOG when empty

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -135,7 +135,7 @@ fn redirect_stderr(f: File) -> Result<()> {
 /// If `SCCACHE_ERROR_LOG` is set, redirect stderr to it.
 fn redirect_error_log() -> Result<()> {
     let name = match env::var("SCCACHE_ERROR_LOG") {
-        Ok(filename) => filename,
+        Ok(filename) if !filename.is_empty() => filename,
         _ => return Ok(()),
     };
     let f = OpenOptions::new().create(true).append(true).open(name)?;


### PR DESCRIPTION
STR:

- Install sccache "stock" with no configuration (local).
- Ensure the sccache local server is not running with `killall sccache`.
- Run `RUSTC_WRAPPER=sccache SCCACHE_ERROR_LOG= cargo build` on a *clean* rust project.

You will get:
> Connection to server timed out

This is because the server [will fail to start](https://github.com/mozilla/sccache/blob/1351a07a0f8a50e6671ff6742db23d6dff6845dd/src/commands.rs#L558) if `redirect_error_log` errors-out (and it will since the log path is empty in my example).
I could be wrong, but there's no way for the end-user to figure out what went wrong if they provide an invalid path. Maybe we should considering writing an error message to a "predictable" file in the file-system then error-out instead? (`eprintln! + cargo build -vv` doesn't do anything either :/)

In any case, the following patch doesn't solve all cases, but at least takes care of the "empty path" one.