### PR TITLE
Make hashes path agnostic for MSVC

### DIFF
--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -487,7 +487,7 @@ where
     T: CommandCreatorSync,
 {
     let mut cmd = creator.clone().new_command_sync(executable);
-    cmd.arg("-E")
+    cmd.arg("-EP")
         .arg(&parsed_args.input)
         .arg("-nologo")
         .args(&parsed_args.preprocessor_args)


### PR DESCRIPTION
Similar to #208, but for MSVC.
Verified to work locally.

References:
1. https://docs.microsoft.com/en-us/cpp/build/reference/e-preprocess-to-stdout?view=vs-2019
2. https://docs.microsoft.com/en-us/cpp/build/reference/ep-preprocess-to-stdout-without-hash-line-directives?view=vs-2019