### PR TITLE
[compilers] support for CUDA compilation via nvcc

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -77,6 +77,8 @@ pub struct ParsedArguments {
     pub input: PathBuf,
     /// The type of language used in the input source file.
     pub language: Language,
+    /// The flag required to compile for the given language
+    pub compilation_flag: OsString,
     /// The file in which to generate dependencies.
     pub depfile: Option<PathBuf>,
     /// Output files, keyed by a simple name, like "obj".

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -84,6 +84,8 @@ pub struct ParsedArguments {
     pub depfile: Option<PathBuf>,
     /// Output files, keyed by a simple name, like "obj".
     pub outputs: HashMap<&'static str, PathBuf>,
+    /// Commandline arguments for dependency generation.
+    pub dependency_args: Vec<OsString>,
     /// Commandline arguments for the preprocessor (not including common_args).
     pub preprocessor_args: Vec<OsString>,
     /// Commandline arguments for the preprocessor or the compiler.

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -90,6 +90,7 @@ pub enum CompilerKind {
 impl CompilerKind {
     pub fn lang_kind(&self) -> String {
         match self {
+            CompilerKind::C(CCompilerKind::NVCC) => "CUDA",
             CompilerKind::C(_) => "C/C++",
             CompilerKind::Rust => "Rust",
         }

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -151,6 +151,7 @@ where
 {
     let mut common_args = vec![];
     let mut compilation = false;
+    let mut compilation_flag = OsString::new();
     let mut input_arg = None;
     let mut multiple_input = false;
     let mut output_arg = None;
@@ -186,7 +187,10 @@ where
             Some(TooHardFlag) | Some(TooHard(_)) => {
                 cannot_cache!(arg.flag_str().expect("Can't be Argument::Raw/UnknownFlag",))
             }
-            Some(DoCompilation) => compilation = true,
+            Some(DoCompilation) => {
+                compilation = true;
+                compilation_flag = OsString::from(arg.flag_str().expect("Compilation flag expected"));
+            }
             Some(Output(p)) => output_arg = Some(p.clone()),
             Some(PreprocessorArgument(_))
             | Some(PreprocessorArgumentFlag)
@@ -254,6 +258,7 @@ where
     CompilerArguments::Ok(ParsedArguments {
         input: input.into(),
         language,
+        compilation_flag,
         depfile: None,
         outputs,
         preprocessor_args,
@@ -307,7 +312,7 @@ pub fn generate_compile_commands(
     };
 
     let mut arguments: Vec<OsString> = vec![
-        "-c".into(),
+        parsed_args.compilation_flag.clone(),
         parsed_args.input.clone().into(),
         "-o".into(),
         out_file.into(),
@@ -657,6 +662,7 @@ mod test {
         let parsed_args = ParsedArguments {
             input: "foo.c".into(),
             language: Language::C,
+            compilation_flag: "-c".into(),
             depfile: None,
             outputs: vec![("obj", "foo.o".into())].into_iter().collect(),
             preprocessor_args: vec![],

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -110,6 +110,7 @@ ArgData! { pub
     // it's not treated as a path by the compiler - it's just written wholesale
     // (including any funny make syntax) into the dep file.
     DepTarget(OsString),
+    DepArgumentPath(PathBuf),
     Language(OsString),
     SplitDwarf,
     ProfileGenerate,
@@ -140,11 +141,11 @@ counted_array!(pub static ARGS: [ArgInfo<ArgData>; _] = [
     take_arg!("-L", OsString, Separated, PassThrough),
     flag!("-M", TooHardFlag),
     flag!("-MD", NeedDepTarget),
-    take_arg!("-MF", PathBuf, Separated, PreprocessorArgumentPath),
+    take_arg!("-MF", PathBuf, Separated, DepArgumentPath),
     flag!("-MM", TooHardFlag),
     flag!("-MMD", NeedDepTarget),
     flag!("-MP", NeedDepTarget),
-    take_arg!("-MQ", OsString, Separated, PreprocessorArgument),
+    take_arg!("-MQ", OsString, Separated, DepTarget),
     take_arg!("-MT", OsString, Separated, DepTarget),
     flag!("-P", TooHardFlag),
     take_arg!("-U", OsString, CanBeSeparated, PassThrough),
@@ -214,8 +215,10 @@ where
     let mut output_arg = None;
     let mut input_arg = None;
     let mut dep_target = None;
+    let mut dep_flag = OsString::from("-MT");
     let mut common_args = vec![];
     let mut preprocessor_args = vec![];
+    let mut dependency_args = vec![];
     let mut extra_hash_files = vec![];
     let mut compilation = false;
     let mut multiple_input = false;
@@ -280,8 +283,12 @@ where
             }
             Some(Output(p)) => output_arg = Some(p.clone()),
             Some(NeedDepTarget) => need_explicit_dep_target = true,
-            Some(DepTarget(s)) => dep_target = Some(s.clone()),
-            Some(ExtraHashFile(_))
+            Some(DepTarget(s)) => {
+                dep_flag = OsString::from(arg.flag_str().expect("Dep target flag expected"));
+                dep_target = Some(s.clone());
+            }
+            Some(DepArgumentPath(_))
+            | Some(ExtraHashFile(_))
             | Some(PreprocessorArgumentFlag)
             | Some(PreprocessorArgument(_))
             | Some(PreprocessorArgumentPath(_))
@@ -325,8 +332,9 @@ where
             }
             Some(PreprocessorArgumentFlag)
             | Some(PreprocessorArgument(_))
-            | Some(PreprocessorArgumentPath(_))
-            | Some(NeedDepTarget) => &mut preprocessor_args,
+            | Some(PreprocessorArgumentPath(_)) => &mut preprocessor_args,
+            Some(DepArgumentPath(_))
+            | Some(NeedDepTarget) => &mut dependency_args,
             Some(DoCompilation) | Some(Language(_)) | Some(Output(_)) | Some(XClang(_))
             | Some(DepTarget(_)) => continue,
             Some(TooHardFlag) | Some(TooHard(_)) => unreachable!(),
@@ -381,9 +389,10 @@ where
             }
             Some(PreprocessorArgumentFlag)
             | Some(PreprocessorArgument(_))
-            | Some(PreprocessorArgumentPath(_))
-            | Some(DepTarget(_))
-            | Some(NeedDepTarget) => &mut preprocessor_args,
+            | Some(PreprocessorArgumentPath(_)) => &mut preprocessor_args,
+            Some(DepTarget(_))
+            | Some(DepArgumentPath(_))
+            | Some(NeedDepTarget) => &mut dependency_args,
         };
 
         // Normalize attributes such as "-I foo", "-D FOO=bar", as
@@ -435,8 +444,8 @@ where
         profile_generate = true;
     }
     if need_explicit_dep_target {
-        preprocessor_args.push("-MT".into());
-        preprocessor_args.push(dep_target.unwrap_or_else(|| output.clone().into_os_string()));
+        dependency_args.push(dep_flag);
+        dependency_args.push(dep_target.unwrap_or_else(|| output.clone().into_os_string()));
     }
     outputs.insert("obj", output);
 
@@ -446,6 +455,7 @@ where
         compilation_flag,
         depfile: None,
         outputs,
+        dependency_args,
         preprocessor_args,
         common_args,
         extra_hash_files,
@@ -499,6 +509,7 @@ where
     }
     cmd.arg(&parsed_args.input)
         .args(&parsed_args.preprocessor_args)
+        .args(&parsed_args.dependency_args)
         .args(&parsed_args.common_args)
         .env_clear()
         .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
@@ -507,7 +518,7 @@ where
     if log_enabled!(Trace) {
         trace!("preprocess: {:?}", cmd);
     }
-    run_input_output(cmd, None)
+    Box::new(run_input_output(cmd, None))
 }
 
 pub fn generate_compile_commands(
@@ -974,11 +985,12 @@ mod test {
 
     #[test]
     fn test_parse_arguments_preprocessor_args() {
-        let args = stringvec!["-c", "foo.c", "-fabc", "-MF", "file", "-o", "foo.o", "-MQ", "abc"];
+        let args = stringvec!["-c", "foo.c", "-fabc", "-MF", "file", "-o", "foo.o", "-MQ", "abc", "-nostdinc"];
         let ParsedArguments {
             input,
             language,
             outputs,
+            dependency_args,
             preprocessor_args,
             msvc_show_includes,
             common_args,
@@ -992,7 +1004,8 @@ mod test {
         assert_map_contains!(outputs, ("obj", PathBuf::from("foo.o")));
         //TODO: fix assert_map_contains to assert no extra keys!
         assert_eq!(1, outputs.len());
-        assert_eq!(ovec!["-MF", "file", "-MQ", "abc"], preprocessor_args);
+        assert_eq!(ovec!["-MF", "file"], dependency_args);
+        assert_eq!(ovec!["-nostdinc"], preprocessor_args);
         assert_eq!(ovec!["-fabc"], common_args);
         assert!(!msvc_show_includes);
     }
@@ -1005,7 +1018,7 @@ mod test {
             input,
             language,
             outputs,
-            preprocessor_args,
+            dependency_args,
             msvc_show_includes,
             common_args,
             ..
@@ -1018,7 +1031,7 @@ mod test {
         assert_map_contains!(outputs, ("obj", PathBuf::from("foo.o")));
         //TODO: fix assert_map_contains to assert no extra keys!
         assert_eq!(1, outputs.len());
-        assert_eq!(ovec!["-MF", "file"], preprocessor_args);
+        assert_eq!(ovec!["-MF", "file"], dependency_args);
         assert_eq!(ovec!["-fabc"], common_args);
         assert!(!msvc_show_includes);
     }
@@ -1032,6 +1045,7 @@ mod test {
             input,
             language,
             outputs,
+            dependency_args,
             preprocessor_args,
             msvc_show_includes,
             common_args,
@@ -1047,8 +1061,41 @@ mod test {
         assert_eq!(1, outputs.len());
         assert_eq!(
             ovec!["-MF", "file", "-MD", "-MT", "depfile"],
-            preprocessor_args
+            dependency_args
         );
+        assert!(preprocessor_args.is_empty());
+        assert_eq!(ovec!["-fabc"], common_args);
+        assert!(!msvc_show_includes);
+    }
+
+    #[test]
+    fn test_parse_arguments_explicit_mq_dep_target_needed() {
+        let args = stringvec![
+            "-c", "foo.c", "-MQ", "depfile", "-fabc", "-MF", "file", "-o", "foo.o", "-MD"
+        ];
+        let ParsedArguments {
+            input,
+            language,
+            outputs,
+            dependency_args,
+            preprocessor_args,
+            msvc_show_includes,
+            common_args,
+            ..
+        } = match parse_arguments_(args) {
+            CompilerArguments::Ok(args) => args,
+            o => panic!("Got unexpected parse result: {:?}", o),
+        };
+        assert_eq!(Some("foo.c"), input.to_str());
+        assert_eq!(Language::C, language);
+        assert_map_contains!(outputs, ("obj", PathBuf::from("foo.o")));
+        //TODO: fix assert_map_contains to assert no extra keys!
+        assert_eq!(1, outputs.len());
+        assert_eq!(
+            ovec!["-MF", "file", "-MD", "-MQ", "depfile"],
+            dependency_args
+        );
+        assert!(preprocessor_args.is_empty());
         assert_eq!(ovec!["-fabc"], common_args);
         assert!(!msvc_show_includes);
     }
@@ -1088,7 +1135,7 @@ mod test {
             input,
             language,
             outputs,
-            preprocessor_args,
+            dependency_args,
             msvc_show_includes,
             common_args,
             ..
@@ -1103,7 +1150,7 @@ mod test {
         assert_eq!(1, outputs.len());
         assert_eq!(
             ovec!["-MF", "file", "-MD", "-MT", "foo.o"],
-            preprocessor_args
+            dependency_args
         );
         assert_eq!(ovec!["-fabc"], common_args);
         assert!(!msvc_show_includes);
@@ -1215,6 +1262,7 @@ mod test {
             compilation_flag: "-c".into(),
             depfile: None,
             outputs: vec![("obj", "foo.o".into())].into_iter().collect(),
+            dependency_args: vec![],
             preprocessor_args: vec![],
             common_args: vec![],
             extra_hash_files: vec![],

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -293,6 +293,7 @@ where
                     "c++" => Some(Language::Cxx),
                     "objective-c" => Some(Language::ObjectiveC),
                     "objective-c++" => Some(Language::ObjectiveCxx),
+                    "cu" => Some(Language::Cuda),
                     _ => cannot_cache!("-x"),
                 };
             }
@@ -474,6 +475,7 @@ where
         Language::Cxx => "c++",
         Language::ObjectiveC => "objective-c",
         Language::ObjectiveCxx => "objective-c++",
+        Language::Cuda => "cu",
     };
     let mut cmd = creator.clone().new_command_sync(executable);
     cmd.arg("-x").arg(language).arg("-E");
@@ -539,6 +541,7 @@ pub fn generate_compile_commands(
         Language::Cxx => "c++",
         Language::ObjectiveC => "objective-c",
         Language::ObjectiveCxx => "objective-c++",
+        Language::Cuda => "cu",
     };
     let mut arguments: Vec<OsString> = vec![
         "-x".into(),
@@ -567,6 +570,7 @@ pub fn generate_compile_commands(
             Language::Cxx => "c++",
             Language::ObjectiveC => "objective-c",
             Language::ObjectiveCxx => "objective-c++",
+            Language::Cuda => "cu",
         }
         .into();
         if !rewrite_includes_only {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -22,6 +22,7 @@ mod compiler;
 mod diab;
 mod gcc;
 mod msvc;
+mod nvcc;
 mod rust;
 
 pub use crate::compiler::compiler::*;

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -276,6 +276,7 @@ pub fn parse_arguments(
     let mut input_arg = None;
     let mut common_args = vec![];
     let mut preprocessor_args = vec![];
+    let mut dependency_args = vec![];
     let mut extra_hash_files = vec![];
     let mut compilation = false;
     let mut compilation_flag = OsString::new();
@@ -371,9 +372,10 @@ pub fn parse_arguments(
             }
             Some(PreprocessorArgumentFlag)
             | Some(PreprocessorArgument(_))
-            | Some(PreprocessorArgumentPath(_))
+            | Some(PreprocessorArgumentPath(_)) => &mut preprocessor_args,
+            Some(DepArgumentPath(_))
             | Some(DepTarget(_))
-            | Some(NeedDepTarget) => &mut preprocessor_args,
+            | Some(NeedDepTarget) => &mut dependency_args,
         };
         // Normalize attributes such as "-I foo", "-D FOO=bar", as
         // "-Ifoo", "-DFOO=bar", etc. and "-includefoo", "idirafterbar" as
@@ -430,6 +432,7 @@ pub fn parse_arguments(
         compilation_flag,
         depfile,
         outputs,
+        dependency_args,
         preprocessor_args,
         common_args,
         extra_hash_files,
@@ -496,6 +499,7 @@ where
         .arg(&parsed_args.input)
         .arg("-nologo")
         .args(&parsed_args.preprocessor_args)
+        .args(&parsed_args.dependency_args)
         .args(&parsed_args.common_args)
         .env_clear()
         .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
@@ -937,6 +941,7 @@ mod test {
             compilation_flag: "-c".into(),
             depfile: None,
             outputs: vec![("obj", "foo.obj".into())].into_iter().collect(),
+            dependency_args: vec![],
             preprocessor_args: vec![],
             common_args: vec![],
             extra_hash_files: vec![],
@@ -979,6 +984,7 @@ mod test {
             outputs: vec![("obj", "foo.obj".into()), ("pdb", pdb)]
                 .into_iter()
                 .collect(),
+            dependency_args: vec![],
             preprocessor_args: vec![],
             common_args: vec![],
             extra_hash_files: vec![],

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -1,0 +1,285 @@
+// Copyright 2016 Mozilla Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(unused_imports, dead_code, unused_variables)]
+
+use crate::compiler::args::*;
+use crate::compiler::c::{CCompilerImpl, CCompilerKind, Language, ParsedArguments};
+use crate::compiler::gcc::ArgData::*;
+use crate::compiler::{gcc, write_temp_file, Cacheable, CompileCommand, CompilerArguments};
+use crate::dist;
+use crate::mock_command::{CommandCreator, CommandCreatorSync, RunCommand};
+use crate::util::{run_input_output, OsStrExt};
+use futures::future::{self, Future};
+use futures_cpupool::CpuPool;
+use log::Level::Trace;
+use std::ffi::OsString;
+use std::fs::File;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process;
+
+use crate::errors::*;
+
+/// A unit struct on which to implement `CCompilerImpl`.
+#[derive(Clone, Debug)]
+pub struct NVCC;
+
+impl CCompilerImpl for NVCC {
+    fn kind(&self) -> CCompilerKind {
+        CCompilerKind::NVCC
+    }
+    fn parse_arguments(
+        &self,
+        arguments: &[OsString],
+        cwd: &Path,
+    ) -> CompilerArguments<ParsedArguments> {
+        gcc::parse_arguments(arguments, cwd, (&gcc::ARGS[..], &ARGS[..]))
+    }
+
+    fn preprocess<T>(
+        &self,
+        creator: &T,
+        executable: &Path,
+        parsed_args: &ParsedArguments,
+        cwd: &Path,
+        env_vars: &[(OsString, OsString)],
+        may_dist: bool,
+        rewrite_includes_only: bool,
+    ) -> SFuture<process::Output>
+    where
+        T: CommandCreatorSync,
+    {
+        trace!("preprocess");
+        let mut cmd = creator.clone().new_command_sync(executable);
+
+        //NVCC only supports `-E` when it comes after preprocessor
+        //and common flags
+        cmd.args(&parsed_args.preprocessor_args);
+        cmd.args(&parsed_args.common_args);
+
+        //We need to add "-rdc=true" if we are compiling with `-dc`
+        //So that the preprocessor has the correct implicit defines
+        if parsed_args.compilation_flag == "-dc" {
+            cmd.arg("-rdc=true");
+        }
+
+        let language = match parsed_args.language {
+            Language::C => "c",
+            Language::Cxx => "c++",
+            Language::ObjectiveC => "objective-c",
+            Language::ObjectiveCxx => "objective-c++",
+            Language::Cuda => "cu",
+        };
+
+        cmd.arg("-x").arg(language)
+           .arg(&parsed_args.input)
+           .arg("-E")
+           .env_clear()
+           .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
+           .current_dir(cwd);
+        if log_enabled!(Trace) {
+            trace!("preprocess: {:?}", cmd);
+        }
+        run_input_output(cmd, None)
+    }
+
+    fn generate_compile_commands(
+        &self,
+        path_transformer: &mut dist::PathTransformer,
+        executable: &Path,
+        parsed_args: &ParsedArguments,
+        cwd: &Path,
+        env_vars: &[(OsString, OsString)],
+        rewrite_includes_only: bool,
+    ) -> Result<(CompileCommand, Option<dist::CompileCommand>, Cacheable)> {
+        gcc::generate_compile_commands(
+            path_transformer,
+            executable,
+            parsed_args,
+            cwd,
+            env_vars,
+            self.kind(),
+            rewrite_includes_only,
+        )
+    }
+}
+
+counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
+    // take_arg!("--compiler-bindir", PathBuf, Separated, ExtraHashFile),
+    // take_arg!("-ccbin", PathBuf, Separated, ExtraHashFile),
+
+    take_arg!("--archive-options options", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("--compiler-options", OsString, CanBeSeparated('='), PreprocessorArgument),
+    take_arg!("--generate-code", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("--gpu-architecture", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("--gpu-code", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("--linker-options", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("--maxrregcount", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("--nvlink-options", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("--ptxas-options", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("--relocatable-device-code", OsString, CanBeSeparated('='), PreprocessorArgument),
+
+    take_arg!("-Xarchive", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-Xcompiler", OsString, CanBeSeparated('='), PreprocessorArgument),
+    take_arg!("-Xlinker", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-Xnvlink", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-Xptxas", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-arch", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-code", OsString, CanBeSeparated('='), PassThrough),
+    flag!("-dc", DoCompilation),
+    take_arg!("-gencode", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-maxrregcount", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-rdc", OsString, CanBeSeparated('='), PreprocessorArgument),
+    take_arg!("-x", OsString, CanBeSeparated('='), Language),
+
+]);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::compiler::gcc;
+    use crate::compiler::*;
+    use crate::mock_command::*;
+    use crate::test::utils::*;
+    use futures::Future;
+    use futures_cpupool::CpuPool;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    fn parse_arguments_(arguments: Vec<String>) -> CompilerArguments<ParsedArguments> {
+        let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
+        NVCC.parse_arguments(&arguments, ".".as_ref())
+    }
+
+    macro_rules! parses {
+        ( $( $s:expr ),* ) => {
+            match parse_arguments_(vec![ $( $s.to_string(), )* ]) {
+                CompilerArguments::Ok(a) => a,
+                o => panic!("Got unexpected parse result: {:?}", o),
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_arguments_simple_c() {
+        let a = parses!("-c", "foo.c", "-o", "foo.o");
+        assert_eq!(Some("foo.c"), a.input.to_str());
+        assert_eq!(Language::C, a.language);
+        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        //TODO: fix assert_map_contains to assert no extra keys!
+        assert_eq!(1, a.outputs.len());
+        assert!(a.preprocessor_args.is_empty());
+        assert!(a.common_args.is_empty());
+    }
+
+    #[test]
+    fn test_parse_arguments_simple_cu() {
+        let a = parses!("-c", "foo.cu", "-o", "foo.o");
+        assert_eq!(Some("foo.cu"), a.input.to_str());
+        assert_eq!(Language::Cuda, a.language);
+        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        //TODO: fix assert_map_contains to assert no extra keys!
+        assert_eq!(1, a.outputs.len());
+        assert!(a.preprocessor_args.is_empty());
+        assert!(a.common_args.is_empty());
+    }
+
+    #[test]
+    fn test_parse_arguments_simple_c_as_cu() {
+        let a = parses!("-x","cu", "-c", "foo.c", "-o", "foo.o");
+        assert_eq!(Some("foo.c"), a.input.to_str());
+        assert_eq!(Language::Cuda, a.language);
+        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        //TODO: fix assert_map_contains to assert no extra keys!
+        assert_eq!(1, a.outputs.len());
+        assert!(a.preprocessor_args.is_empty());
+        assert!(a.common_args.is_empty());
+    }
+
+    #[test]
+    fn test_parse_arguments_dc_compile_flag() {
+        let a = parses!("-x","cu", "-dc", "foo.c", "-o", "foo.o");
+        assert_eq!(Some("foo.c"), a.input.to_str());
+        assert_eq!(Language::Cuda, a.language);
+        assert_eq!(Some("-dc"), a.compilation_flag.to_str());
+        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        //TODO: fix assert_map_contains to assert no extra keys!
+        assert_eq!(1, a.outputs.len());
+        assert!(a.preprocessor_args.is_empty());
+        assert!(a.common_args.is_empty());
+    }
+
+    #[test]
+    fn test_parse_md_mt_flags_cu() {
+        let a = parses!("-x", "cu", "-c", "foo.c", "-fabc",
+                           "-MD", "-MT", "foo.o", "-MF", "foo.o.d", "-o", "foo.o");
+        assert_eq!(Some("foo.c"), a.input.to_str());
+        assert_eq!(Language::Cuda, a.language);
+        assert_eq!(Some("-c"), a.compilation_flag.to_str());
+        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        //TODO: fix assert_map_contains to assert no extra keys!
+        assert_eq!(1, a.outputs.len());
+        assert_eq!(
+            ovec!["-MD", "-MF", "foo.o.d", "-MT", "foo.o"],
+            a.preprocessor_args
+        );
+        assert_eq!(ovec!["-fabc"], a.common_args);
+    }
+
+    #[test]
+    fn test_parse_generate_code_flags() {
+        let a = parses!("-x","cu", "--generate-code=arch=compute_61,code=sm_61",
+                        "-c", "foo.c", "-o", "foo.o");
+        assert_eq!(Some("foo.c"), a.input.to_str());
+        assert_eq!(Language::Cuda, a.language);
+        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        //TODO: fix assert_map_contains to assert no extra keys!
+        assert_eq!(1, a.outputs.len());
+        assert!(a.preprocessor_args.is_empty());
+        assert_eq!(
+            ovec!["--generate-code", "arch=compute_61,code=sm_61"],
+            a.common_args
+        );
+    }
+
+    #[test]
+    fn test_parse_pass_to_host_flags() {
+        let a = parses!("-x=cu",
+                        "--generate-code=arch=compute_60,code=[sm_60,sm_61]",
+                        "-Xnvlink=--suppress-stack-size-warning",
+                        "-Xcompiler", "-fPIC,-fno-common",
+                        "-Xcompiler=-fvisibility=hidden",
+                        "-Xcompiler=-Wall,-Wno-unknown-pragmas,-Wno-unused-local-typedefs",
+                        "-Xcudafe", "--display_error_number",
+                        "-c", "foo.c", "-o", "foo.o");
+        assert_eq!(Some("foo.c"), a.input.to_str());
+        assert_eq!(Language::Cuda, a.language);
+        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        //TODO: fix assert_map_contains to assert no extra keys!
+        assert_eq!(1, a.outputs.len());
+        assert_eq!(
+            ovec!["-Xcompiler", "-fPIC,-fno-common", "-Xcompiler", "-fvisibility=hidden",
+                  "-Xcompiler", "-Wall,-Wno-unknown-pragmas,-Wno-unused-local-typedefs"],
+            a.preprocessor_args
+        );
+        assert_eq!(
+            ovec!["--generate-code", "arch=compute_60,code=[sm_60,sm_61]",
+                  "-Xnvlink", "--suppress-stack-size-warning", "-Xcudafe",
+                  "--display_error_number"],
+            a.common_args
+        );
+    }
+
+}

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -86,6 +86,7 @@ impl CCompilerImpl for NVCC {
         cmd.arg("-x").arg(language)
            .arg(&parsed_args.input)
            .arg("-E")
+           .arg("-Xcompiler=-P")
            .env_clear()
            .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
            .current_dir(cwd);

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -145,6 +145,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("-gencode", OsString, CanBeSeparated('='), PassThrough),
     take_arg!("-isystem", PathBuf, CanBeSeparated('='), PreprocessorArgumentPath),
     take_arg!("-maxrregcount", OsString, CanBeSeparated('='), PassThrough),
+    flag!("-ptx", DoCompilation),
     take_arg!("-rdc", OsString, CanBeSeparated('='), PreprocessorArgument),
     take_arg!("-x", OsString, CanBeSeparated('='), Language),
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -180,7 +180,7 @@ where
 ///
 /// If the command returns a non-successful exit status, an error of `ErrorKind::ProcessError`
 /// will be returned containing the process output.
-pub fn run_input_output<C>(mut command: C, input: Option<Vec<u8>>) -> SFuture<process::Output>
+pub fn run_input_output<C>(mut command: C, input: Option<Vec<u8>>) -> impl Future<Item = process::Output, Error = Error>
 where
     C: RunCommand,
 {
@@ -195,7 +195,7 @@ where
         .stderr(Stdio::piped())
         .spawn();
 
-    Box::new(child.and_then(|child| {
+    child.and_then(|child| {
         wait_with_input_output(child, input).and_then(|output| {
             if output.status.success() {
                 f_ok(output)
@@ -203,7 +203,7 @@ where
                 f_err(ErrorKind::ProcessError(output))
             }
         })
-    }))
+    })
 }
 
 /// Write `data` to `writer` with bincode serialization, prefixed by a `u32` length.


### PR DESCRIPTION
To get sccache to support the nvcc compiler I had to make the following changes to how compilers work. As this is my first time modifying the sccache code base, I am happy to refactor these changes to better suite what the project is looking for.

1. The compilation flag (`-c`) is not hard-coded but extracted from the compilation. This is necessary as the nvcc compiler uses different compilation flags for different types of compilation such as: `-c` ( whole compilation ), `-dc` (separable compilation ), `-ptx` ( ptx generation ). This merge request adds support for all three above compilation types, and follow work can be done (if needed) to also support `-dw`, `-cubin`, and `-fatbin`.

2. Dependency related flags ( -MT, -MF, -MD ) are stored into a separate vector and not the pre-processor flags. This was done for the following reasons:

 - The dependency information only needs to be generated once for each compilation, but since it was stored in `preprocessor_args` it would cause generation to occur both in the `preprocess` pass, and `generate_compile_commands`. This refactor now makes this generation occur during the `preprocess` pass only.

- Removal of the hard-coded `-MT` and fixed a bug related to `-MQ`. When `need_explicit_dep_target` is detected the `gcc` compiler will hard-code adding `-MT` to the preprocessor line, this can be wrong as the user initial flag set included `-MQ` and that should be used. I refactored this logic to handle picking up either `-MT` or `-MQ` from the user, and if neither is provided falling back to adding `-MT`.

- The nvcc compiler doesn't support generation of dependency information when requesting pre-processed output ( `-E` ). This was the driving need for the separation of dependency flags so I could safely invoke the compiler with `-E`. To get everything to work correctly the nvcc `preprocess` pass does 2 invocations of the compiler to generate dep info and pre-processed output.


This set of changes has been in use on the VTK-m project ( https://gitlab.kitware.com/vtk/vtk-m/- ) for over 10 days without issues. In this time sccache has handled ~400k compilation units, with CUDA counting for ~100k of those. 