### PR TITLE
Revert "use tokio_reactor::Handle::default"

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -166,7 +166,7 @@ fn run_server_process() -> Result<ServerStartup> {
     let mut runtime = Runtime::new()?;
     let pipe_name = format!(r"\\.\pipe\{}", Uuid::new_v4().to_simple_ref());
     let server = runtime.block_on(future::lazy(|| {
-        NamedPipe::new(&pipe_name, &Handle::default())
+        NamedPipe::new(&pipe_name, #[allow(deprecated)] &Handle::current())
     }))?;
 
     // Connect a client to our server, and we'll wait below if it's still in

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -296,10 +296,6 @@ fn test_server_port_in_use() {
         .unwrap();
     assert!(!output.status.success());
     let s = String::from_utf8_lossy(&output.stderr);
-    // Windows times out when the port is already in use.
-    #[cfg(target_os = "windows")]
-    const MSG: &str = "Timed out waiting for server startup";
-    #[cfg(not(target_os = "windows"))]
     const MSG: &str = "Server startup failed:";
     assert!(
         s.contains(MSG),


### PR DESCRIPTION
This reverts commit b43d51fa2e536019c113cc79cd98dcc2861afad4.

While tokio_reactor::Handle::current has a deprecation note that says
"semantics were sometimes surprising, use Handle::default()", it turns
out the the semantics of current work better for sccache, as sccache
--start-server times out with default but not with current (although
the server does start).