### PR TITLE
test: Don't force the entire crate to be recompiled by escargot

### DIFF
--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -124,7 +124,6 @@ pub fn sccache_command() -> Command {
         CargoBuild::new()
             .bin("sccache")
             .current_release()
-            .current_target()
             .run()
             .unwrap()
             .command(),
@@ -148,7 +147,6 @@ pub fn sccache_command() -> Command {
             .arg("--features")
             .arg(features)
             .current_release()
-            .current_target()
             .run()
             .unwrap()
             .command(),
@@ -164,7 +162,6 @@ pub fn sccache_dist_path() -> PathBuf {
         .arg("--features")
         .arg("dist-client dist-server")
         .current_release()
-        .current_target()
         .run()
         .unwrap()
         .path()

--- a/tests/oauth.rs
+++ b/tests/oauth.rs
@@ -71,7 +71,6 @@ fn sccache_command() -> Command {
         .arg("--features")
         .arg("dist-client dist-server")
         .current_release()
-        .current_target()
         .run()
         .unwrap()
         .command()

--- a/tests/sccache_cargo.rs
+++ b/tests/sccache_cargo.rs
@@ -34,7 +34,6 @@ fn test_rust_cargo_cmd(cmd: &str) {
         CargoBuild::new()
             .bin("sccache")
             .current_release()
-            .current_target()
             .run()
             .unwrap()
             .command()


### PR DESCRIPTION
Every time one of these commands were run in tests they forced the entire crate to be recompiled which is quite a pain. Removing the `current_target` fixes it though, at least for me.