### PR TITLE
fix some workarounds now that we have non-lexical lifetimes

### DIFF
--- a/src/bin/sccache-dist/main.rs
+++ b/src/bin/sccache-dist/main.rs
@@ -812,8 +812,7 @@ impl SchedulerIncoming for Scheduler {
         let mut servers = self.servers.lock().unwrap();
 
         if let btree_map::Entry::Occupied(mut entry) = jobs.entry(job_id) {
-            // TODO: nll should mean not needing to copy this out
-            let job_detail = *entry.get();
+            let job_detail = entry.get();
             if job_detail.server_id != server_id {
                 bail!(
                     "Job id {} is not registed on server {:?}",

--- a/src/server.rs
+++ b/src/server.rs
@@ -324,8 +324,8 @@ impl DistClientContainer {
             }};
         }
         // TODO: NLL would avoid this clone
-        match config.scheduler_url.clone() {
-            Some(addr) => {
+        match config.scheduler_url {
+            Some(ref addr) => {
                 let url = addr.to_url();
                 info!("Enabling distributed sccache to {}", url);
                 let auth_token = match &config.auth {
@@ -338,7 +338,6 @@ impl DistClientContainer {
                 let auth_token = try_or_fail_with_message!(auth_token.chain_err(|| {
                     "could not load client auth token, run |sccache --dist-auth|"
                 }));
-                // TODO: NLL would let us move this inside the previous match
                 let dist_client = dist::http::Client::new(
                     &config.pool,
                     url,


### PR DESCRIPTION
The TODO in server.rs that we didn't fix was somewhat cryptic and I
don't think it would have made the code any clearer even if it could
have been fixed.