### PR TITLE
Remove `#![allow(renamed_and_removed_lints)]`.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO error_chain needs to be upgraded, it uses deprecated APIs.
-#![allow(deprecated)]
-#![allow(renamed_and_removed_lints)]
-
 use std::boxed::Box;
 use std::convert;
 use std::error;


### PR DESCRIPTION
It's not needed now that `error_chain` 0.12 is being used.