### PR TITLE
make mutable borrowing more explicit during cache writing

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -36,7 +36,7 @@ use std::fmt;
 #[cfg(any(feature = "dist-client", unix))]
 use std::fs;
 use std::fs::File;
-use std::io::prelude::*;
+use std::io::{prelude::*, Cursor};
 use std::path::{Path, PathBuf};
 use std::process::{self, Stdio};
 use std::str;
@@ -367,12 +367,12 @@ where
                             write
                                 .and_then(move |mut entry| {
                                     if !compiler_result.stdout.is_empty() {
-                                        let mut stdout = &compiler_result.stdout[..];
-                                        entry.put_object("stdout", &mut stdout, None)?;
+                                        let mut cursor = Cursor::new(&compiler_result.stdout);
+                                        entry.put_object("stdout", &mut cursor, None)?;
                                     }
                                     if !compiler_result.stderr.is_empty() {
-                                        let mut stderr = &compiler_result.stderr[..];
-                                        entry.put_object("stderr", &mut stderr, None)?;
+                                        let mut cursor = Cursor::new(&compiler_result.stderr);
+                                        entry.put_object("stderr", &mut cursor, None)?;
                                     }
 
                                     // Try to finish storing the newly-written cache


### PR DESCRIPTION
It's not clear to me whether something like this is already happening
inside type derivation or not, but this at least makes things clearer
that `compiler_result` is not being borrowed mutably.

r? @nnethercote 