### PR TITLE
improve hashing from a file

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -22,7 +22,6 @@ use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::hash::Hasher;
 use std::io::prelude::*;
-use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process::{self, Stdio};
 use std::time;
@@ -52,13 +51,12 @@ impl Digest {
     }
 
     /// Calculate the BLAKE3 digest of the contents read from `reader`.
-    pub fn reader_sync<R: Read>(reader: R) -> Result<String> {
+    pub fn reader_sync<R: Read>(mut reader: R) -> Result<String> {
         let mut m = Digest::new();
-        let mut reader = BufReader::new(reader);
+        // A buffer of 128KB should give us the best performance.
+        // See https://eklitzke.org/efficient-file-copying-on-linux.
+        let mut buffer = [0; 128 * 1024];
         loop {
-            // A buffer of 128KB should give us the best performance.
-            // See https://eklitzke.org/efficient-file-copying-on-linux.
-            let mut buffer = [0; 128 * 1024];
             let count = reader.read(&mut buffer[..])?;
             if count == 0 {
                 break;


### PR DESCRIPTION
This routine had a couple of problems:

1. The buffer was reinitialized with zeros every time through the loop,
   rather than once outside of the loop.
2. We created a buffered reader, but we are using it to do large block
   reads, which makes the internal buffer essentially useless.  `BufReader`
   is at least smart enough to bypass the internal buffer in such cases,
   but still, we were allocating an additional amount of heap memory that
   we didn't need.

This patch addresses both of those problems.  It is arguably better to use
`std::io::copy`, which currently takes advantage of `Read::initialize`, a
Nightly-only API that attempts to avoid needing to initialize buffers prior to
passing them off to `Read::read`, but the default buffer size of
`std::io::copy` is much smaller than what we use here.  Rust rlibs can get
rather large (e.g. about 80% of rlibs during a Firefox compilation are larger
than 128kb and will therefore go through even the loop we have here at least
twice; ~55% are larger than 700k; about 10% are larger than 12mb (!)) and are
the primary consumers of this method (via `util::hash_all`), so at least
fixing the obvious major issues above seems worthwhile.