### PR TITLE
move some functionality into the cache object layer

### DIFF
--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -28,7 +28,7 @@ use futures_cpupool::CpuPool;
 use std::fmt;
 #[cfg(feature = "gcs")]
 use std::fs::File;
-use std::io::{self, Read, Seek, Write};
+use std::io::{self, Cursor, Read, Seek, Write};
 use std::sync::Arc;
 use std::time::Duration;
 use zip::write::FileOptions;
@@ -137,6 +137,22 @@ impl CacheWrite {
             .start_file(name, opts)
             .chain_err(|| "Failed to start cache entry object")?;
         io::copy(from, &mut self.zip)?;
+        Ok(())
+    }
+
+    pub fn put_stdout(&mut self, bytes: &[u8]) -> Result<()> {
+        self.put_bytes("stdout", bytes)
+    }
+
+    pub fn put_stderr(&mut self, bytes: &[u8]) -> Result<()> {
+        self.put_bytes("stderr", bytes)
+    }
+
+    fn put_bytes(&mut self, name: &str, bytes: &[u8]) -> Result<()> {
+        if !bytes.is_empty() {
+            let mut cursor = Cursor::new(bytes);
+            return self.put_object(name, &mut cursor, None);
+        }
         Ok(())
     }
 

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -90,6 +90,22 @@ impl CacheRead {
         io::copy(&mut file, to)?;
         Ok(file.unix_mode())
     }
+
+    /// Get the stdout from this cache entry, if it exists.
+    pub fn get_stdout(&mut self) -> Vec<u8> {
+        self.get_bytes("stdout")
+    }
+
+    /// Get the stderr from this cache entry, if it exists.
+    pub fn get_stderr(&mut self) -> Vec<u8> {
+        self.get_bytes("stderr")
+    }
+
+    fn get_bytes(&mut self, name: &str) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        drop(self.get_object(name, &mut bytes));
+        bytes
+    }
 }
 
 /// Data to be stored in the compiler cache.

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -251,10 +251,8 @@ where
                             out_pretty,
                             fmt_duration_as_secs(&duration)
                         );
-                        let mut stdout = Vec::new();
-                        let mut stderr = Vec::new();
-                        drop(entry.get_object("stdout", &mut stdout));
-                        drop(entry.get_object("stderr", &mut stderr));
+                        let stdout = entry.get_stdout();
+                        let stderr = entry.get_stderr();
                         let write = pool.spawn_fn(move || {
                             for (key, path) in &outputs {
                                 let dir = match path.parent() {

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -36,7 +36,7 @@ use std::fmt;
 #[cfg(any(feature = "dist-client", unix))]
 use std::fs;
 use std::fs::File;
-use std::io::{prelude::*, Cursor};
+use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::process::{self, Stdio};
 use std::str;
@@ -364,14 +364,8 @@ where
                         Box::new(
                             write
                                 .and_then(move |mut entry| {
-                                    if !compiler_result.stdout.is_empty() {
-                                        let mut cursor = Cursor::new(&compiler_result.stdout);
-                                        entry.put_object("stdout", &mut cursor, None)?;
-                                    }
-                                    if !compiler_result.stderr.is_empty() {
-                                        let mut cursor = Cursor::new(&compiler_result.stderr);
-                                        entry.put_object("stderr", &mut cursor, None)?;
-                                    }
+                                    entry.put_stdout(&compiler_result.stdout)?;
+                                    entry.put_stderr(&compiler_result.stderr)?;
 
                                     // Try to finish storing the newly-written cache
                                     // entry. We'll get the result back elsewhere.


### PR DESCRIPTION
None of this is strictly necessary, but I do think it makes `compiler.rs` slightly easier to follow.  I think this makes the implementation of #757 slightly easier as well (and keeps the implementation details hidden from external clients, which is good).