### PR TITLE
update test harness crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,14 +65,15 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "assert_cmd"
-version = "0.9.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b60c276f334145cf2cec09c5bb6f63523f078c0c850909f66bca8f933cf809"
+checksum = "c88b9ca26f9c16ec830350d309397e74ee9abdfd8eb1f71cb6ecc71a3fc818da"
 dependencies = [
- "escargot",
+ "doc-comment",
  "predicates",
  "predicates-core",
  "predicates-tree",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -550,6 +551,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dtoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,16 +606,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
 dependencies = [
  "version_check 0.9.1",
-]
-
-[[package]]
-name = "escargot"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19db1f7e74438642a5018cdf263bb1325b2e792f02dd0a3ca6d6c0f0d7b1d5a5"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -677,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134a8fa843d80a51a5b77d36d42bc2def9edcb0262c914861d08129fd1926600"
+checksum = "da62c4f1b81918835a8c6a484a397775fff5953fe83529afd51b05f5c6a6617d"
 dependencies = [
  "num-traits 0.2.11",
 ]
@@ -1447,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "normalize-line-endings"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0a1a39eab95caf4f5556da9289b9e68f0aafac901b2ce80daaf020d3b733a8"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-integer"
@@ -1646,9 +1643,9 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "predicates"
-version = "0.9.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31e7977fc111984fdac76b6ae3a4cb598008fc6fd02dfdca189bf180bd7be20"
+checksum = "347a1b6f0b21e636bc9872fb60b83b8e185f6f5516298b8238699f7f9a531030"
 dependencies = [
  "difference",
  "float-cmp",
@@ -1659,15 +1656,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "0.9.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f80bc390d1c02a4cdaa63f27f05c3c426679eb65433d8dd65d392147e4e5c5"
+checksum = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
 
 [[package]]
 name = "predicates-tree"
-version = "0.9.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e86df9b81bdcb0a5141aca9d2b9c5e0c558ef6626d3ae2c12912f5c9df740bd"
+checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
 dependencies = [
  "predicates-core",
  "treeline",
@@ -2146,7 +2143,6 @@ dependencies = [
  "directories",
  "env_logger",
  "error-chain 0.12.2",
- "escargot",
  "filetime 0.2.9",
  "flate2",
  "futures 0.1.29",
@@ -3264,6 +3260,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f42f536e22f7fcbb407639765c8fd78707a33109301f834a594758bedd6e8cf"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,12 +102,11 @@ quote = "1.0.2"
 tiny_http = { git = "https://github.com/tiny-http/tiny-http.git", rev = "619680de" }
 
 [dev-dependencies]
-assert_cmd = "0.9"
+assert_cmd = "1"
 cc = "1.0"
 chrono = "0.4"
-escargot = "0.3"
 itertools = "0.7"
-predicates = "0.9.0"
+predicates = "1"
 # Waiting for #15 to make it into a release
 selenium-rs = { git = "https://github.com/saresend/selenium-rs.git", rev = "0314a2420da78cce7454a980d862995750771722" }
 

--- a/tests/oauth.rs
+++ b/tests/oauth.rs
@@ -1,7 +1,6 @@
 #![deny(rust_2018_idioms)]
 #![cfg(all(feature = "dist-client"))]
 
-use escargot::CargoBuild;
 use selenium_rs::webdriver::{Browser, Selector, WebDriver};
 use std::fs;
 use std::io::{self, Read, Write};
@@ -64,17 +63,7 @@ fn config_with_dist_auth(
 }
 
 fn sccache_command() -> Command {
-    CargoBuild::new()
-        .bin("sccache")
-        // This should just inherit from the feature list we're compiling with to avoid recompilation
-        // https://github.com/assert-rs/assert_cmd/issues/44#issuecomment-418485128
-        .arg("--features")
-        .arg("dist-client dist-server")
-        .current_release()
-        .current_target()
-        .run()
-        .unwrap()
-        .command()
+    Command::new(assert_cmd::cargo::cargo_bin("sccache"))
 }
 
 fn retry<F: FnMut() -> Option<T>, T>(interval: Duration, until: Duration, mut f: F) -> Option<T> {

--- a/tests/sccache_cargo.rs
+++ b/tests/sccache_cargo.rs
@@ -22,7 +22,6 @@ fn test_rust_cargo() {
 fn test_rust_cargo_cmd(cmd: &str) {
     use assert_cmd::prelude::*;
     use chrono::Local;
-    use escargot::CargoBuild;
     use predicates::prelude::*;
     use std::env;
     use std::fs;
@@ -31,13 +30,7 @@ fn test_rust_cargo_cmd(cmd: &str) {
     use std::process::{Command, Stdio};
 
     fn sccache_command() -> Command {
-        CargoBuild::new()
-            .bin("sccache")
-            .current_release()
-            .current_target()
-            .run()
-            .unwrap()
-            .command()
+        Command::new(assert_cmd::cargo::cargo_bin("sccache"))
     }
 
     fn stop() {
@@ -67,8 +60,7 @@ fn test_rust_cargo_cmd(cmd: &str) {
     );
     let cargo = env!("CARGO");
     debug!("cargo: {}", cargo);
-    #[allow(deprecated)]
-    let sccache = assert_cmd::cargo::main_binary_path().unwrap();
+    let sccache = assert_cmd::cargo::cargo_bin("sccache");
     debug!("sccache: {:?}", sccache);
     let crate_dir = Path::new(file!()).parent().unwrap().join("test-crate");
     // Ensure there's no existing sccache server running.

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -24,7 +24,6 @@ use crate::harness::{
     write_json_cfg, write_source, zero_stats,
 };
 use assert_cmd::prelude::*;
-use escargot::CargoBuild;
 use log::Level::Trace;
 use predicates::prelude::*;
 use std::collections::HashMap;
@@ -161,8 +160,7 @@ fn test_noncacheable_stats(compiler: Compiler, tempdir: &Path) {
     copy_to_tempdir(&[INPUT], tempdir);
 
     trace!("compile");
-    Command::main_binary()
-        .unwrap()
+    Command::new(assert_cmd::cargo::cargo_bin("sccache"))
         .arg(&exe)
         .arg("-E")
         .arg(INPUT)


### PR DESCRIPTION
This patch looks like a routine crate version update, but it fixes
something very fundamentally wrong with the tests: `escargot`, to find
the `sccache` binary during tests, would actually run `cargo build` and
parse the output.  There were all manner of hacks to try and build the
binary with the correct set of features, none of which were reliable,
and the hacks were not reliably present in all places, either.

When the hacks were not present, `escargot` would rebuild the entire
sccache crate, which was responsible for the `sccache_cargo` test taking
entirely too long.  When the hacks failed utterly, perfectly fine
patches would mysteriously fail, as seen in #774.

We can get rid of `escargot` because `assert-cmd` has been updated to a)
not use `escargot` under the hood; and b) do something smarter to locate
the target binary.  The upshot is fewer mysterious test failures and
significantly faster running tests.