### PR TITLE
Change error handling from `error-chain` to `anyhow`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
+
+[[package]]
 name = "ar"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2119,6 +2125,7 @@ dependencies = [
 name = "sccache"
 version = "0.2.14-alpha.0"
 dependencies = [
+ "anyhow",
  "ar",
  "assert_cmd",
  "atty",
@@ -2135,7 +2142,6 @@ dependencies = [
  "daemonize",
  "directories",
  "env_logger",
- "error-chain 0.12.2",
  "filetime 0.2.9",
  "flate2",
  "futures 0.1.29",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ name = "sccache-dist"
 required-features = ["dist-server"]
 
 [dependencies]
+anyhow = "1.0"
 ar = { version = "0.6", optional = true }
 atty = "0.2.6"
 base64 = "0.11.0"
@@ -34,7 +35,6 @@ clap = "2.23.0"
 counted-array = "0.1"
 directories = "1"
 env_logger = "0.5"
-error-chain = { version = "0.12.1", default-features = false }
 filetime = "0.2"
 flate2 = { version = "1.0", optional = true, default-features = false, features = ["rust_backend"] }
 futures = "0.1.11"

--- a/src/azure/credentials.rs
+++ b/src/azure/credentials.rs
@@ -78,10 +78,10 @@ impl AzureCredentialsProvider for EnvironmentProvider {
 
 fn credentials_from_environment() -> Result<AzureCredentials> {
     let env_conn_str = var("SCCACHE_AZURE_CONNECTION_STRING")
-        .chain_err(|| "No SCCACHE_AZURE_CONNECTION_STRING in environment")?;
+        .context("No SCCACHE_AZURE_CONNECTION_STRING in environment")?;
 
     let container_name = var("SCCACHE_AZURE_BLOB_CONTAINER")
-        .chain_err(|| "No SCCACHE_AZURE_BLOB_CONTAINER in environment")?;
+        .context("No SCCACHE_AZURE_BLOB_CONTAINER in environment")?;
 
     parse_connection_string(&env_conn_str, container_name)
 }

--- a/src/cache/azure.rs
+++ b/src/cache/azure.rs
@@ -78,7 +78,7 @@ impl Storage for AzureBlobCache {
         let response = self
             .container
             .put(key, data, &self.credentials)
-            .chain_err(|| "Failed to put cache entry in Azure");
+            .fcontext("Failed to put cache entry in Azure");
 
         Box::new(response.map(move |_| start.elapsed()))
     }

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -36,7 +36,7 @@ pub struct S3Cache {
 impl S3Cache {
     /// Create a new `S3Cache` storing data in `bucket`.
     pub fn new(bucket: &str, endpoint: &str, use_ssl: bool) -> Result<S3Cache> {
-        let user_dirs = UserDirs::new().ok_or("Couldn't get user directories")?;
+        let user_dirs = UserDirs::new().context("Couldn't get user directories")?;
         let home = user_dirs.home_dir();
 
         let profile_providers = vec![
@@ -98,13 +98,13 @@ impl Storage for S3Cache {
         let credentials = self
             .provider
             .credentials()
-            .chain_err(|| "failed to get AWS credentials");
+            .fcontext("failed to get AWS credentials");
 
         let bucket = self.bucket.clone();
         let response = credentials.and_then(move |credentials| {
             bucket
                 .put(&key, data, &credentials)
-                .chain_err(|| "failed to put cache entry in s3")
+                .fcontext("failed to put cache entry in s3")
         });
 
         Box::new(response.map(move |_| start.elapsed()))

--- a/src/client.rs
+++ b/src/client.rs
@@ -52,7 +52,7 @@ impl ServerConnection {
         let mut bytes = [0; 4];
         self.reader
             .read_exact(&mut bytes)
-            .chain_err(|| "Failed to read response header")?;
+            .context("Failed to read response header")?;
         let len = BigEndian::read_u32(&bytes);
         trace!("Should read {} more bytes", len);
         let mut data = vec![0; len as usize];

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -96,7 +96,7 @@ pub fn get_app<'a, 'b>() -> App<'a, 'b> {
 pub fn parse() -> Result<Command> {
     trace!("parse");
     let cwd =
-        env::current_dir().chain_err(|| "sccache: Couldn't determine current working directory")?;
+        env::current_dir().context("sccache: Couldn't determine current working directory")?;
     // The internal start server command is passed in the environment.
     let internal_start_server = match env::var("SCCACHE_START_SERVER") {
         Ok(val) => val == "1",

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -319,7 +319,7 @@ pub fn generate_compile_commands(
 
     let out_file = match parsed_args.outputs.get("obj") {
         Some(obj) => obj,
-        None => return Err("Missing object file output".into()),
+        None => return Err(anyhow!("Missing object file output")),
     };
 
     let mut arguments: Vec<OsString> = vec![

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -542,7 +542,7 @@ pub fn generate_compile_commands(
 
     let out_file = match parsed_args.outputs.get("obj") {
         Some(obj) => obj,
-        None => return Err("Missing object file output".into()),
+        None => return Err(anyhow!("Missing object file output")),
     };
 
     // Pass the language explicitly as we might have gotten it from the

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -643,19 +643,18 @@ pub trait ServerOutgoing {
 // Trait to handle the creation and verification of job authorization tokens
 #[cfg(feature = "dist-server")]
 pub trait JobAuthorizer: Send {
-    fn generate_token(&self, job_id: JobId) -> ExtResult<String, String>;
-    fn verify_token(&self, job_id: JobId, token: &str) -> ExtResult<(), String>;
+    fn generate_token(&self, job_id: JobId) -> Result<String>;
+    fn verify_token(&self, job_id: JobId, token: &str) -> Result<()>;
 }
 
 #[cfg(feature = "dist-server")]
 pub trait SchedulerIncoming: Send + Sync {
-    type Error: ::std::error::Error;
     // From Client
     fn handle_alloc_job(
         &self,
         requester: &dyn SchedulerOutgoing,
         tc: Toolchain,
-    ) -> ExtResult<AllocJobResult, Self::Error>;
+    ) -> ExtResult<AllocJobResult, Error>;
     // From Server
     fn handle_heartbeat_server(
         &self,
@@ -663,34 +662,29 @@ pub trait SchedulerIncoming: Send + Sync {
         server_nonce: ServerNonce,
         num_cpus: usize,
         job_authorizer: Box<dyn JobAuthorizer>,
-    ) -> ExtResult<HeartbeatServerResult, Self::Error>;
+    ) -> ExtResult<HeartbeatServerResult, Error>;
     // From Server
     fn handle_update_job_state(
         &self,
         job_id: JobId,
         server_id: ServerId,
         job_state: JobState,
-    ) -> ExtResult<UpdateJobStateResult, Self::Error>;
+    ) -> ExtResult<UpdateJobStateResult, Error>;
     // From anyone
-    fn handle_status(&self) -> ExtResult<SchedulerStatusResult, Self::Error>;
+    fn handle_status(&self) -> ExtResult<SchedulerStatusResult, Error>;
 }
 
 #[cfg(feature = "dist-server")]
 pub trait ServerIncoming: Send + Sync {
-    type Error: ::std::error::Error;
     // From Scheduler
-    fn handle_assign_job(
-        &self,
-        job_id: JobId,
-        tc: Toolchain,
-    ) -> ExtResult<AssignJobResult, Self::Error>;
+    fn handle_assign_job(&self, job_id: JobId, tc: Toolchain) -> ExtResult<AssignJobResult, Error>;
     // From Client
     fn handle_submit_toolchain(
         &self,
         requester: &dyn ServerOutgoing,
         job_id: JobId,
         tc_rdr: ToolchainReader<'_>,
-    ) -> ExtResult<SubmitToolchainResult, Self::Error>;
+    ) -> ExtResult<SubmitToolchainResult, Error>;
     // From Client
     fn handle_run_job(
         &self,
@@ -699,12 +693,11 @@ pub trait ServerIncoming: Send + Sync {
         command: CompileCommand,
         outputs: Vec<String>,
         inputs_rdr: InputsReader<'_>,
-    ) -> ExtResult<RunJobResult, Self::Error>;
+    ) -> ExtResult<RunJobResult, Error>;
 }
 
 #[cfg(feature = "dist-server")]
 pub trait BuilderIncoming: Send + Sync {
-    type Error: ::std::error::Error;
     // From Server
     fn run_build(
         &self,
@@ -713,7 +706,7 @@ pub trait BuilderIncoming: Send + Sync {
         outputs: Vec<String>,
         inputs_rdr: InputsReader<'_>,
         cache: &Mutex<TcCache>,
-    ) -> ExtResult<BuildResult, Self::Error>;
+    ) -> ExtResult<BuildResult, Error>;
 }
 
 /////////

--- a/src/jobserver.rs
+++ b/src/jobserver.rs
@@ -73,8 +73,8 @@ impl Client {
         helper.request_token();
         tx.unbounded_send(mytx).unwrap();
         Box::new(
-            myrx.chain_err(|| "jobserver helper panicked")
-                .and_then(|t| t.chain_err(|| "failed to acquire jobserver token"))
+            myrx.fcontext("jobserver helper panicked")
+                .and_then(|t| t.context("failed to acquire jobserver token"))
                 .map(|t| Acquired { _token: Some(t) }),
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,6 @@ extern crate clap;
 #[macro_use]
 extern crate counted_array;
 #[macro_use]
-extern crate error_chain;
-#[macro_use]
 extern crate futures;
 #[cfg(feature = "jsonwebtoken")]
 use jsonwebtoken as jwt;
@@ -62,7 +60,6 @@ mod simples3;
 pub mod util;
 
 use std::env;
-use std::io::Write;
 
 pub fn main() {
     init_logging();
@@ -70,18 +67,16 @@ pub fn main() {
         Ok(cmd) => match commands::run_command(cmd) {
             Ok(s) => s,
             Err(e) => {
-                let stderr = &mut std::io::stderr();
-                writeln!(stderr, "sccache: error: {}", e).unwrap();
-
-                for e in e.iter().skip(1) {
-                    writeln!(stderr, "sccache: caused by: {}", e).unwrap();
+                eprintln!("sccache: error: {}", e);
+                for e in e.chain().skip(1) {
+                    eprintln!("sccache: caused by: {}", e);
                 }
                 2
             }
         },
         Err(e) => {
             println!("sccache: {}", e);
-            for e in e.iter().skip(1) {
+            for e in e.chain().skip(1) {
                 println!("sccache: caused by: {}", e);
             }
             cmdline::get_app().print_help().unwrap();

--- a/src/mock_command.rs
+++ b/src/mock_command.rs
@@ -268,7 +268,7 @@ impl RunCommand for AsyncCommand {
         Box::new(self.jobserver.acquire().and_then(move |token| {
             let child = inner
                 .spawn_async()
-                .chain_err(|| format!("failed to spawn {:?}", inner))?;
+                .with_context(|| format!("failed to spawn {:?}", inner))?;
             Ok(Child {
                 inner: child,
                 token,
@@ -650,7 +650,7 @@ mod test {
     fn test_mock_spawn_error() {
         let client = Client::new_num(1);
         let mut creator = MockCommandCreator::new(&client);
-        creator.next_command_spawns(Err("error".into()));
+        creator.next_command_spawns(Err(anyhow!("error")));
         let e = spawn_command(&mut creator, "foo").err().unwrap();
         assert_eq!("error", e.to_string());
     }

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -2,8 +2,6 @@
 
 extern crate assert_cmd;
 #[macro_use]
-extern crate error_chain;
-#[macro_use]
 extern crate log;
 extern crate sccache;
 extern crate serde_json;
@@ -161,7 +159,6 @@ fn test_dist_nobuilder() {
 
 struct FailingServer;
 impl ServerIncoming for FailingServer {
-    type Error = Error;
     fn handle_assign_job(&self, _job_id: JobId, _tc: Toolchain) -> Result<AssignJobResult> {
         let need_toolchain = false;
         let state = JobState::Ready;
@@ -188,7 +185,7 @@ impl ServerIncoming for FailingServer {
     ) -> Result<RunJobResult> {
         requester
             .do_update_job_state(job_id, JobState::Started)
-            .chain_err(|| "Updating job state failed")?;
+            .context("Updating job state failed")?;
         bail!("internal build failure")
     }
 }


### PR DESCRIPTION
Because `anyhow` is what seems to be the most common error library for
applications these days.

- The global `Result` type is now `anyhow::Result`.

- In errors.rs, there's no need for any boilerplate to wrap all the foreign
  errors seen: `hyper::Error`, `io:Error`, etc.

- The internal errors that we care about are now separate types, rather
  than within an enum, because that works better when we need to check for them
  by downcasting an `anyhow::Error`. And it's nice to write
  `Err(ProcessError(output))` rather than
  `Err(ErrorKind::ProcessError(output))`.

- The `Which` error was unused and is removed.

- The most common change is that `.chain_err()` is changed to
  `.context`/`.with_context()`.

- `anyhow!` is used where necessary, mostly to promote a string to an
  `anyhow::Error`.

- Errors within futures: `FutureChainErr`/`.chain_err()` is changed to
  `FutureContext`/`fcontext`/`fwith_context`. The `f` prefix is because I found
  it helpful to distinguish these cases from the simple error cases.

- `BuilderIncoming`, `SchedulerIncoming`, `ServerIncoming` no longer have an
  `Error` associated type, we just use `anyhow::Error` uniformly.

- `e.display_chain()` changes to `format!("{:?}")`, because they both print the
  full cause chain, and the backtrace (if present).

- A few places where the old code was doing something weird or more
  complicated than seemed necessary, I generally tried to replace it with
  something simpler and more typical. Two places used `with_boxed_chain()`,
  which doesn't have an equivalent in `anyhow`, so I did my best to do
  something reasonable.

- In `src/server.rs` we now import `std::task::Context` as `TaskContext` to
  avoid overshadowing the `anyhow::Context` trait :(