### PR TITLE
Identify more messages as coming from sccache.

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -425,10 +425,10 @@ fn handle_compile_finished(
         trace!("compiler exited with status {}", ret);
         Ok(ret)
     } else if let Some(signal) = response.signal {
-        println!("Compiler killed by signal {}", signal);
+        println!("sccache: Compiler killed by signal {}", signal);
         Ok(-2)
     } else {
-        println!("Missing compiler exit status!");
+        println!("sccache: Missing compiler exit status!");
         Ok(-3)
     }
 }
@@ -466,7 +466,7 @@ where
                 Ok(_) => bail!("unexpected response from server"),
                 Err(Error(ErrorKind::Io(ref e), _)) if e.kind() == io::ErrorKind::UnexpectedEof => {
                     eprintln!(
-                        "warning: sccache server looks like it shut down \
+                        "sccache: warning: The server looks like it shut down \
                          unexpectedly, compiling locally instead"
                     );
                 }
@@ -499,7 +499,7 @@ where
 
     Ok(status.code().unwrap_or_else(|| {
         if let Some(sig) = status_signal(status) {
-            println!("Compile terminated by signal {}", sig);
+            println!("sccache: Compile terminated by signal {}", sig);
         }
         // Arbitrary.
         2
@@ -560,12 +560,12 @@ pub fn run_command(cmd: Command) -> Result<i32> {
         }
         Command::StartServer => {
             trace!("Command::StartServer");
-            println!("Starting sccache server...");
+            println!("sccache: Starting the server...");
             let startup = run_server_process().chain_err(|| "failed to start server process")?;
             match startup {
                 ServerStartup::Ok { port } => {
                     if port != DEFAULT_PORT {
-                        println!("Listening on port {}", port);
+                        println!("sccache: Listening on port {}", port);
                     }
                 }
                 ServerStartup::TimedOut => bail!("Timed out waiting for server startup"),

--- a/src/dist/client_auth.rs
+++ b/src/dist/client_auth.rs
@@ -51,7 +51,7 @@ fn serve_sfuture(serve: fn(Request<Body>) -> SFutureSend<Response<Body>>) -> imp
         Box::new(serve(req).or_else(move |e| {
             let body = e.display_chain().to_string();
             eprintln!(
-                "Error during a request to {} on the client auth web server\n{}",
+                "sccache: Error during a request to {} on the client auth web server\n{}",
                 uri, body
             );
             let len = body.len();
@@ -308,7 +308,7 @@ mod code_grant_pkce {
                 MIN_TOKEN_VALIDITY_WARNING
             );
             eprintln!(
-                "Token retrieved expires in under {}",
+                "sccache: Token retrieved expires in under {}",
                 MIN_TOKEN_VALIDITY_WARNING
             );
         }
@@ -444,7 +444,7 @@ mod implicit {
                         MIN_TOKEN_VALIDITY_WARNING
                     );
                     eprintln!(
-                        "Token retrieved expires in under {}",
+                        "sccache: Token retrieved expires in under {}",
                         MIN_TOKEN_VALIDITY_WARNING
                     );
                 }
@@ -576,7 +576,7 @@ pub fn get_token_oauth2_code_grant_pkce(
     );
 
     info!("Listening on http://localhost:{} with 1 thread.", port);
-    println!("Please visit http://localhost:{} in your browser", port);
+    println!("sccache: Please visit http://localhost:{} in your browser", port);
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let (code_tx, code_rx) = mpsc::sync_channel(1);
     let state = code_grant_pkce::State {
@@ -614,7 +614,7 @@ pub fn get_token_oauth2_implicit(client_id: &str, mut auth_url: Url) -> Result<S
     implicit::finish_url(client_id, &mut auth_url, &redirect_uri, &auth_state_value);
 
     info!("Listening on http://localhost:{} with 1 thread.", port);
-    println!("Please visit http://localhost:{} in your browser", port);
+    println!("sccache: Please visit http://localhost:{} in your browser", port);
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let (token_tx, token_rx) = mpsc::sync_channel(1);
     let state = implicit::State {


### PR DESCRIPTION
This finishes what #762 started. All `println!`/`eprintln!` calls now
start with `sccache: `, except those involved in printing of requested
data, such as stats.