### PR TITLE
[DRAFT] add an OS X + Rust 1.43.1 job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
     # OS compat
     - os: linux
     - os: osx
+    - os: osx
+      rust: 1.43.1
 
     # rustc version compat
     - rust: 1.41.1 # oldest supported version, keep in sync with README.md


### PR DESCRIPTION
Trying to see if the OS + Rust stable crash looks like a Rust regression or not.  The TravisCI configuration is a little weird, so this might require some iterations to get it right.