### PR TITLE
move OS X off stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ matrix:
   include:
     # OS compat
     - os: linux
+    # As of this writing, stable Rust (1.44.0) and the OS X version on TravisCI
+    # do not work well together.
     - os: osx
+      rust: 1.43.1
 
     # rustc version compat
     - rust: 1.41.1 # oldest supported version, keep in sync with README.md


### PR DESCRIPTION
Stable Rust and the OS X versions on TravisCI do not seem to get along
right now.  I filed a Rust bug (rust-lang/rust#73030) about this, but if
the bug is very OS X-configuration specific, I'm not sure there's much
that can be done about it on the Rust side.

We can at least change the CI configuration so we don't get a bunch of
spurious failures.