### PR TITLE
use zstd to compress cache entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,9 @@ name = "cc"
 version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -883,6 +886,12 @@ name = "gimli"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
@@ -2263,6 +2272,7 @@ dependencies = [
  "which",
  "winapi 0.3.8",
  "zip",
+ "zstd",
 ]
 
 [[package]]
@@ -3495,4 +3505,35 @@ dependencies = [
  "crc32fast",
  "flate2",
  "podio",
+]
+
+[[package]]
+name = "zstd"
+version = "0.5.2+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644352b10ce7f333d6e0af85bd4f5322dc449416dc1211c6308e95bca8923db4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "2.0.4+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7113c0c9aed2c55181f2d9f5b0a36e7d2c0183b11c058ab40b35987479efe4d7"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.4.16+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c442965efc45353be5a9b9969c9b0872fff6828c7e06d118dda2cb2d0bb11d5a"
+dependencies = [
+ "cc",
+ "glob",
+ "itertools",
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ walkdir = "2"
 # by default which pulls in an outdated failure version
 which = { version = "4", default-features = false }
 zip = { version = "0.5", default-features = false, features = ["deflate"] }
+zstd = { version = "0.5" }
 
 # dist-server only
 crossbeam-utils = { version = "0.5", optional = true }

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -621,7 +621,7 @@ impl pkg::ToolchainPackager for CToolchainPackager {
 }
 
 /// The cache is versioned by the inputs to `hash_key`.
-pub const CACHE_VERSION: &[u8] = b"8";
+pub const CACHE_VERSION: &[u8] = b"9";
 
 lazy_static! {
     /// Environment variables that are factored into the cache key.

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -194,7 +194,7 @@ lazy_static! {
 }
 
 /// Version number for cache key.
-const CACHE_VERSION: &[u8] = b"5";
+const CACHE_VERSION: &[u8] = b"6";
 
 /// Get absolute paths for all source files listed in rustc's dep-info output.
 fn get_source_files<T>(


### PR DESCRIPTION
zstd is faster and gives slightly smaller (~5%) compressed blobs than
deflate does, as measured on a Firefox build.  Rather than inventing our
own compressed archive format, we piggyback on top of zip's "stored"
files to stuff zstd-compressed blobs in the zip archive.