### PR TITLE
update to zip-rs 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,16 +1361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "msdos_time"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729"
-dependencies = [
- "time",
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "multipart"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3381,12 +3371,11 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.4.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b9e08fb518a65cf7e08a1e482573eb87a2f4f8c6619316612a3c1f162fe822"
+checksum = "6df134e83b8f0f8153a094c7b0fd79dfebe437f1d76e7715afa18ed95ebe2fd7"
 dependencies = [
+ "crc32fast",
  "flate2",
- "msdos_time",
  "podio",
- "time",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ uuid = { version = "0.7", features = ["v4"] }
 walkdir = "1.0.7"
 # by default which pulls in an outdated failure version
 which = { version = "3", default-features = false }
-zip = { version = "0.4", default-features = false, features = ["deflate"] }
+zip = { version = "0.5", default-features = false, features = ["deflate"] }
 
 # dist-server only
 crossbeam-utils = { version = "0.5", optional = true }


### PR DESCRIPTION
I was looking through old issues, and #160 mentioned that crc32
checksumming for zip files was showing up in profiles.  zip-rs 0.4 uses
a byte-at-a-time version of crc32; zip-rs 0.5 relies on the `crc32fast`
crate, which features faster implementations.