### PR TITLE
upgrade ar crate so we can do less copying when trimming rlibs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,12 +32,9 @@ checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
 name = "ar"
-version = "0.6.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579681b3fecd1e9d6b5ce6969e05f9feb913f296eddaf595be1166a5ca597bc4"
-dependencies = [
- "byteorder",
-]
+checksum = "450575f58f7bee32816abbff470cbc47797397c2a81e0eaced4b98436daf52e1"
 
 [[package]]
 name = "arc-swap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ required-features = ["dist-server"]
 
 [dependencies]
 anyhow = "1.0"
-ar = { version = "0.6", optional = true }
+ar = { version = "0.8", optional = true }
 atty = "0.2.6"
 base64 = "0.11.0"
 bincode = "1"

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1873,12 +1873,11 @@ impl pkg::InputsPackager for RustInputsPackager {
                     if entry.header().identifier() != b"rust.metadata.bin" {
                         continue;
                     }
-                    let mut metadata = vec![];
-                    io::copy(&mut entry, &mut metadata)?;
                     let mut metadata_ar = vec![];
                     {
                         let mut ar_builder = ar::Builder::new(&mut metadata_ar);
-                        ar_builder.append(entry.header(), metadata.as_slice())?
+                        let header = entry.header().clone();
+                        ar_builder.append(&header, &mut entry)?
                     }
                     file_header.set_size(metadata_ar.len() as u64);
                     file_header.set_cksum();


### PR DESCRIPTION
The current trimming of rlibs in the dist-sccache case looks like:

1. Find the `rust.metadata.bin` file in the rlib (archive).
2. Read its data.
3. Create a new archive that will only contain said file.
4. Copy the data into the new archive.

We can do better than this, by doing the following:

1. Find the `rust.metadata.bin` file in the rlib (archive).
2. Create a new archive that will only contain said file.
3. Copy the data from the original rlib directly into the new archive.

We thus save a copy.

All that being said, it looks like recent versions of Rust don't
actually output `rust.metadata.bin` files into rlibs...unless we ought
to be only taking the `lib.rmeta` file that lives inside the archive.
But that would be a separate fix.  (It's also great that we're seemingly
copying the rmeta file twice, once because it lives in the rlib and once
because it lives on disk as a separate file...)