### PR TITLE
Upgrade dependencies that don't require changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "0.1.5"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46080006c1505f12f64dd2a09264b343381ed3190fa02c8005d5d662ac571c63"
+checksum = "423897d97e11b810c9da22458400b28ec866991c711409073662eb34dc44bfff"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -222,6 +222,12 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
+
+[[package]]
+name = "boxfnonce"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5988cb1d626264ac94100be357308f29ff7cbdd3b36bda27f450a4ee3f713426"
 
 [[package]]
 name = "buf_redux"
@@ -500,10 +506,11 @@ dependencies = [
 
 [[package]]
 name = "daemonize"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4093d27eb267d617f03c2ee25d4c3ca525b89a76154001954a11984508ffbde5"
+checksum = "70c24513e34f53b640819f0ac9f705b673fcf4006d7aab8778bee72ebfc89815"
 dependencies = [
+ "boxfnonce",
  "libc",
 ]
 
@@ -535,12 +542,12 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "1.0.2"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d337a64190607d4fcca2cb78982c5dd57f4916e19696b48a575fa746b6cb0f"
+checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
 dependencies = [
- "libc",
- "winapi 0.3.8",
+ "cfg-if",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -548,6 +555,17 @@ name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
  "libc",
  "redox_users",
@@ -592,15 +610,6 @@ dependencies = [
  "log 0.4.8",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
-dependencies = [
- "backtrace",
 ]
 
 [[package]]
@@ -1053,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.7.11"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -1193,7 +1202,7 @@ dependencies = [
  "linked-hash-map",
  "log 0.4.8",
  "tempfile",
- "walkdir",
+ "walkdir 1.0.7",
 ]
 
 [[package]]
@@ -1227,15 +1236,15 @@ checksum = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
 
 [[package]]
 name = "memcached-rs"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f45690519137679de66b2bdb60e37a0d4f17adde980930a05eef66929394f73"
+checksum = "e3804643a8b556cd39d6b3ec5a181fdf36b642952d57f4c52bebd457d0ee0b1d"
 dependencies = [
  "bufstream",
  "byteorder",
  "conhash",
  "log 0.4.8",
- "rand 0.5.6",
+ "rand 0.7.3",
  "semver",
  "unix_socket",
 ]
@@ -1422,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.11.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "becb657d662f1cd2ef38c7ad480ec6b8cf9e96b27adb543e594f9cf0f2e6065c"
+checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 dependencies = [
  "bitflags",
  "cc",
@@ -1435,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.14.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 dependencies = [
  "bitflags",
  "cc",
@@ -1733,7 +1742,7 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
 dependencies = [
- "error-chain 0.12.2",
+ "error-chain",
  "idna 0.2.0",
  "lazy_static",
  "regex",
@@ -2162,6 +2171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "sccache"
 version = "0.2.14-alpha.0"
 dependencies = [
@@ -2173,7 +2191,6 @@ dependencies = [
  "bincode 1.2.1",
  "blake3",
  "byteorder",
- "bytes 0.4.12",
  "cc",
  "chrono",
  "clap",
@@ -2202,7 +2219,7 @@ dependencies = [
  "lru-disk-cache",
  "md-5",
  "memcached-rs",
- "nix 0.11.1",
+ "nix 0.17.0",
  "num_cpus",
  "number_prefix",
  "openssl",
@@ -2242,7 +2259,7 @@ dependencies = [
  "uuid",
  "version-compare",
  "void",
- "walkdir",
+ "walkdir 2.3.1",
  "which",
  "winapi 0.3.8",
  "zip",
@@ -2527,11 +2544,11 @@ dependencies = [
 
 [[package]]
 name = "syslog"
-version = "4.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0641142b4081d3d44beffa4eefd7346a228cdf91ed70186db2ca2cef762d327"
+checksum = "9a5d8ef1b679c07976f3ee336a436453760c470f54b5e7237556728b8589515d"
 dependencies = [
- "error-chain 0.11.0",
+ "error-chain",
  "libc",
  "log 0.4.8",
  "time",
@@ -2600,6 +2617,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -2962,9 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.4.10"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
  "serde",
 ]
@@ -3023,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "tower-limit"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2807e2531b621e23e18693d49d0663bc617240ac0da8ed9b0c64cacd5c67fb"
+checksum = "c21ba835a08fd54b63cd91ae0548a7b6e2a91075147dfa3dc8e1a940c1b6f18f"
 dependencies = [
  "futures 0.1.29",
  "tokio-sync",
@@ -3336,8 +3373,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"
 dependencies = [
  "kernel32-sys",
- "same-file",
+ "same-file 0.1.3",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file 1.0.6",
+ "winapi 0.3.8",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3359,11 +3407,12 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "bd3edc3cf5458851a4d6a2329232bd5f42c7f9bbe4c4782c4ef9ce37e5d101b2"
 dependencies = [
  "libc",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,12 @@ ar = { version = "0.8", optional = true }
 atty = "0.2.6"
 base64 = "0.11.0"
 bincode = "1"
-blake3 = "0.1.5"
+blake3 = "0.3"
 byteorder = "1.0"
-bytes = "0.4"
 chrono = { version = "0.4", optional = true }
 clap = "2.23.0"
 counted-array = "0.1"
-directories = "1"
+directories = "2"
 env_logger = "0.5"
 filetime = "0.2"
 flate2 = { version = "1.0", optional = true, default-features = false, features = ["rust_backend"] }
@@ -52,7 +51,7 @@ local-encoding = "0.2.0"
 log = "0.4"
 lru-disk-cache = { path = "lru-disk-cache", version = "0.4.0" }
 md-5 = { version = "0.8", optional = true }
-memcached-rs = { version = "0.3" , optional = true }
+memcached-rs = { version = "0.4" , optional = true }
 num_cpus = "1.0"
 number_prefix = "0.2.5"
 openssl = { version = "0.10", optional = true }
@@ -78,21 +77,21 @@ tokio-serde-bincode = "0.1"
 tower = "0.1"
 tokio-tcp = "0.1"
 tokio-timer = "0.2"
-toml = "0.4"
+toml = "0.5"
 untrusted = { version = "0.6.0", optional = true }
 url = { version = "1.0", optional = true }
 uuid = { version = "0.7", features = ["v4"] }
-walkdir = "1.0.7"
+walkdir = "2"
 # by default which pulls in an outdated failure version
-which = { version = "3", default-features = false }
+which = { version = "4", default-features = false }
 zip = { version = "0.5", default-features = false, features = ["deflate"] }
 
 # dist-server only
 crossbeam-utils = { version = "0.5", optional = true }
 libmount = { version = "0.1.10", optional = true }
-nix = { version = "0.11.0", optional = true }
+nix = { version = "0.17.0", optional = true }
 rouille = { version = "2.2", optional = true, default-features = false, features = ["ssl"] }
-syslog = { version = "4.0.1", optional = true }
+syslog = { version = "5", optional = true }
 void = { version = "1", optional = true }
 version-compare = { version = "0.0.10", optional = true }
 quote = "1.0.2"
@@ -105,13 +104,13 @@ tiny_http = { git = "https://github.com/tiny-http/tiny-http.git", rev = "619680d
 assert_cmd = "1"
 cc = "1.0"
 chrono = "0.4"
-itertools = "0.7"
+itertools = "0.9"
 predicates = "1"
 # Waiting for #15 to make it into a release
 selenium-rs = { git = "https://github.com/saresend/selenium-rs.git", rev = "0314a2420da78cce7454a980d862995750771722" }
 
 [target.'cfg(unix)'.dependencies]
-daemonize = "0.3"
+daemonize = "0.4"
 tokio-uds = "0.2"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
Except redis, which pulls in async-std, which needs some further
consideration.