### PR TITLE
Remove the unused `quote` crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2233,7 +2233,6 @@ dependencies = [
  "number_prefix",
  "openssl",
  "predicates",
- "quote 1.0.7",
  "rand 0.5.6",
  "redis",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,6 @@ rouille = { version = "2.2", optional = true, default-features = false, features
 syslog = { version = "5", optional = true }
 void = { version = "1", optional = true }
 version-compare = { version = "0.0.10", optional = true }
-quote = "1.0.2"
 
 [patch.crates-io]
 # Waiting for #151 to make it into a release


### PR DESCRIPTION
I found this using `cargo-udeps`.