### PR TITLE
fix parsing for -dependency-file

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -99,6 +99,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("-Xclang", OsString, Separated, XClang),
     take_arg!("-add-plugin", OsString, Separated, PassThrough),
     take_arg!("-debug-info-kind", OsString, Concatenated('='), PassThrough),
+    take_arg!("-dependency-file", PathBuf, Separated, DepArgumentPath),
     flag!("-fcolor-diagnostics", DiagnosticsColorFlag),
     flag!("-fcxx-modules", TooHardFlag),
     take_arg!("-fdebug-compilation-dir", OsString, Separated, PassThrough),

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -157,7 +157,6 @@ counted_array!(pub static ARGS: [ArgInfo<ArgData>; _] = [
     take_arg!("-aux-info", OsString, Separated, PassThrough),
     take_arg!("-b", OsString, Separated, PassThrough),
     flag!("-c", DoCompilation),
-    take_arg!("-dependency-file", PathBuf, Separated, PreprocessorArgumentPath),
     take_arg!("-fdiagnostics-color", OsString, Concatenated('='), DiagnosticsColor),
     flag!("-fno-diagnostics-color", NoDiagnosticsColorFlag),
     flag!("-fno-working-directory", PreprocessorArgumentFlag),

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -958,6 +958,49 @@ mod test {
     }
 
     #[test]
+    fn test_parse_arguments_dependency_file() {
+        let args = ovec![
+            "-Fohost_dictionary.obj",
+            "-c",
+            "-Xclang",
+            "-MP",
+            "-Xclang",
+            "-dependency-file",
+            "-Xclang",
+            ".deps/host_dictionary.obj.pp",
+            "-Xclang",
+            "-MT",
+            "-Xclang",
+            "host_dictionary.obj",
+            "dictionary.c"
+        ];
+        let ParsedArguments {
+            dependency_args,
+            preprocessor_args,
+            ..
+        } = match parse_arguments(args) {
+            CompilerArguments::Ok(args) => args,
+            o => panic!("Got unexpected parse result: {:?}", o),
+        };
+        assert!(preprocessor_args.is_empty());
+        assert_eq!(
+            dependency_args,
+            ovec!(
+                "-Xclang",
+                "-MP",
+                "-Xclang",
+                "-dependency-file",
+                "-Xclang",
+                ".deps/host_dictionary.obj.pp",
+                "-Xclang",
+                "-MT",
+                "-Xclang",
+                "host_dictionary.obj"
+            )
+        );
+    }
+
+    #[test]
     fn test_parse_arguments_extra() {
         let args = ovec!["-c", "foo.c", "-foo", "-Fofoo.obj", "-bar"];
         let ParsedArguments {


### PR DESCRIPTION
This option was getting passed as a preprocessor argument and the
additional arguments that it requires (e.g. `-MT`) were getting passed
as dependency arguments.  So when we went to call the preprocessor, the
compiler complained about the missing arguments.  Instead, we should be
classifying it as specifying a dependency target, which will direct it
to the correct set of arguments.

We also take this opportunity to move it to be a clang-exclusive option;
the same option exists in GCC, but it's Darwin-specific and unlikely to
be actually used there.