### PR TITLE
Add a note for how to use sccache with cmake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ Running `sccache --show-stats` will print a summary of cache statistics.
 
 Some notes about using `sccache` with [Jenkins](https://jenkins.io) are [here](docs/Jenkins.md).
 
+To use sccache with cmake, provide the following command line arguments to cmake 3.4 or newer:
+
+```
+-DCMAKE_C_COMPILER_LAUNCHER=sccache
+-DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+```
+
 ---
 
 Build Requirements


### PR DESCRIPTION
It feels like the obvious way would be to ask cmake to use "sccache
gcc" as CMAKE_C_COMPILER, but that option can't take arguments.  Leave
a note for the next person trying to figure it out.