### PR TITLE
update deps of lru-disk-cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,17 +654,6 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "filetime"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714653f3e34871534de23771ac7b26e999651a0a228f47beb324dfdf1dd4b10f"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
-name = "filetime"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695"
@@ -1208,7 +1197,7 @@ dependencies = [
 name = "lru-disk-cache"
 version = "0.4.0"
 dependencies = [
- "filetime 0.1.15",
+ "filetime",
  "linked-hash-map",
  "log 0.4.8",
  "tempfile",
@@ -2110,7 +2099,7 @@ checksum = "0845b9c39ba772da769fe2aaa4d81bfd10695a7ea051d0510702260ff4159841"
 dependencies = [
  "base64 0.9.3",
  "chrono",
- "filetime 0.2.10",
+ "filetime",
  "multipart",
  "num_cpus",
  "rand 0.4.6",
@@ -2199,7 +2188,7 @@ dependencies = [
  "daemonize",
  "directories",
  "env_logger",
- "filetime 0.2.10",
+ "filetime",
  "flate2",
  "futures 0.1.29",
  "futures 0.3.5",
@@ -2560,7 +2549,7 @@ version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c058ad0bd6ccb84faa24cc44d4fc99bee8a5d7ba9ff33aa4d993122d1aeeac2"
 dependencies = [
- "filetime 0.2.10",
+ "filetime",
  "libc",
  "redox_syscall",
  "xattr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
  "linked-hash-map",
  "log 0.4.8",
  "tempfile",
- "walkdir 1.0.7",
+ "walkdir",
 ]
 
 [[package]]
@@ -2172,16 +2172,6 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"
-dependencies = [
- "kernel32-sys",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
@@ -2267,7 +2257,7 @@ dependencies = [
  "uuid",
  "version-compare",
  "void",
- "walkdir 2.3.1",
+ "walkdir",
  "which",
  "winapi 0.3.8",
  "zip",
@@ -3378,22 +3368,11 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"
-dependencies = [
- "kernel32-sys",
- "same-file 0.1.3",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "walkdir"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 dependencies = [
- "same-file 1.0.6",
+ "same-file",
  "winapi 0.3.8",
  "winapi-util",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.2.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda158e0dabeb97ee8a401f4d17e479d6b891a14de0bba79d5cc2d4d325b5e48"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "local-encoding"

--- a/lru-disk-cache/Cargo.toml
+++ b/lru-disk-cache/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/mozilla/sccache/"
 edition = "2018"
 
 [dependencies]
-filetime = "0.1"
+filetime = "0.2"
 linked-hash-map = "0.2"
 log = "0.4"
 # This is currently vendored to allow publishing on crates.io.

--- a/lru-disk-cache/Cargo.toml
+++ b/lru-disk-cache/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 filetime = "0.2"
-linked-hash-map = "0.2"
+linked-hash-map = "0.5"
 log = "0.4"
 # This is currently vendored to allow publishing on crates.io.
 #lru-cache = { git = "https://github.com/luser/lru-cache", branch = "non-mut-get" }

--- a/lru-disk-cache/Cargo.toml
+++ b/lru-disk-cache/Cargo.toml
@@ -13,7 +13,7 @@ linked-hash-map = "0.2"
 log = "0.4"
 # This is currently vendored to allow publishing on crates.io.
 #lru-cache = { git = "https://github.com/luser/lru-cache", branch = "non-mut-get" }
-walkdir = "1"
+walkdir = "2.3.1"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
I use lru-disc-cache as separate crate. And it is a pity that I have several versions of the same crates
in my dependency tree.