### PR TITLE
Add support for key prefixes when using S3 as the storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ You can use `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to set the S3 creden
 
 If you need to override the default endpoint you can set `SCCACHE_ENDPOINT`. To connect to a minio storage for example you can set `SCCACHE_ENDPOINT=<ip>:<port>`. If your endpoint requires TLS, set `SCCACHE_S3_USE_SSL=true`.
 
+You can also define a prefix that will be prepended to the keys of all cache objects created and read within the S3 bucket, effectively creating a scope. To do that use the `SCCACHE_S3_KEY_PREFIX` environment variable. This can be useful when sharing a bucket with another application.
+
 
 ### Redis
 Set `SCCACHE_REDIS` to a [Redis](https://redis.io/) url in format `redis://[:<passwd>@]<hostname>[:port][/<db>]` to store the cache in a Redis instance. Redis can be configured as a LRU (least recently used) cache with a fixed maximum cache size. Set `maxmemory` and `maxmemory-policy` according to the [Redis documentation](https://redis.io/topics/lru-cache). The `allkeys-lru` policy which discards the *least recently accessed or modified* key fits well for the sccache use case.

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -377,7 +377,7 @@ pub fn storage_from_config(config: &Config, pool: &ThreadPool) -> Arc<dyn Storag
             CacheType::S3(ref c) => {
                 debug!("Trying S3Cache({}, {})", c.bucket, c.endpoint);
                 #[cfg(feature = "s3")]
-                match S3Cache::new(&c.bucket, &c.endpoint, c.use_ssl) {
+                match S3Cache::new(&c.bucket, &c.endpoint, c.use_ssl, &c.key_prefix) {
                     Ok(s) => {
                         trace!("Using S3Cache");
                         return Arc::new(s);

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -52,11 +52,22 @@ impl S3Cache {
             AutoRefreshingProvider::new(ChainProvider::with_profile_providers(profile_providers));
         let ssl_mode = if use_ssl { Ssl::Yes } else { Ssl::No };
         let bucket = Rc::new(Bucket::new(bucket, endpoint, ssl_mode)?);
-        Ok(S3Cache { bucket, provider, key_prefix: key_prefix.to_owned() })
+        Ok(S3Cache {
+            bucket,
+            provider,
+            key_prefix: key_prefix.to_owned(),
+        })
     }
 
     fn normalize_key(&self, key: &str) -> String {
-        format!("{}{}/{}/{}/{}", &self.key_prefix, &key[0..1], &key[1..2], &key[2..3], &key)
+        format!(
+            "{}{}/{}/{}/{}",
+            &self.key_prefix,
+            &key[0..1],
+            &key[1..2],
+            &key[2..3],
+            &key
+        )
     }
 }
 


### PR DESCRIPTION
The corresponding environment variable is `SCCACHE_S3_KEY_PREFIX`.

Closes #1.