### PR TITLE
Implement `g++` and `clang++` behavior when used on a `.c` input file. Fixes #803

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -30,20 +30,31 @@ use std::process;
 
 use crate::errors::*;
 
-/// A unit struct on which to implement `CCompilerImpl`.
+/// A struct on which to implement `CCompilerImpl`.
 #[derive(Clone, Debug)]
-pub struct Clang;
+pub struct Clang {
+    /// true iff this is clang++.
+    pub clangplusplus: bool,
+}
 
 impl CCompilerImpl for Clang {
     fn kind(&self) -> CCompilerKind {
         CCompilerKind::Clang
+    }
+    fn plusplus(&self) -> bool {
+        self.clangplusplus
     }
     fn parse_arguments(
         &self,
         arguments: &[OsString],
         cwd: &Path,
     ) -> CompilerArguments<ParsedArguments> {
-        gcc::parse_arguments(arguments, cwd, (&gcc::ARGS[..], &ARGS[..]))
+        gcc::parse_arguments(
+            arguments,
+            cwd,
+            (&gcc::ARGS[..], &ARGS[..]),
+            self.clangplusplus,
+        )
     }
 
     fn preprocess<T>(
@@ -131,7 +142,10 @@ mod test {
 
     fn parse_arguments_(arguments: Vec<String>) -> CompilerArguments<ParsedArguments> {
         let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
-        Clang.parse_arguments(&arguments, ".".as_ref())
+        Clang {
+            clangplusplus: false,
+        }
+        .parse_arguments(&arguments, ".".as_ref())
     }
 
     macro_rules! parses {

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -970,8 +970,12 @@ nvcc
 msvc-clang
 #elif defined(_MSC_VER)
 msvc
+#elif defined(__clang__) && defined(__cplusplus)
+clang++
 #elif defined(__clang__)
 clang
+#elif defined(__GNUC__) && defined(__cplusplus)
+g++
 #elif defined(__GNUC__)
 gcc
 #elif defined(__DCC__)
@@ -1008,11 +1012,17 @@ diab
         for line in stdout.lines() {
             //TODO: do something smarter here.
             match line {
-                "clang" => {
-                    debug!("Found clang");
+                "clang" | "clang++" => {
+                    debug!("Found {}", line);
                     return Box::new(
-                        CCompiler::new(Clang, executable, &pool)
-                            .map(|c| Box::new(c) as Box<dyn Compiler<T>>),
+                        CCompiler::new(
+                            Clang {
+                                clangplusplus: line == "clang++",
+                            },
+                            executable,
+                            &pool,
+                        )
+                        .map(|c| Box::new(c) as Box<dyn Compiler<T>>),
                     );
                 }
                 "diab" => {
@@ -1022,11 +1032,17 @@ diab
                             .map(|c| Box::new(c) as Box<dyn Compiler<T>>),
                     );
                 }
-                "gcc" => {
-                    debug!("Found GCC");
+                "gcc" | "g++" => {
+                    debug!("Found {}", line);
                     return Box::new(
-                        CCompiler::new(GCC, executable, &pool)
-                            .map(|c| Box::new(c) as Box<dyn Compiler<T>>),
+                        CCompiler::new(
+                            GCC {
+                                gplusplus: line == "g++",
+                            },
+                            executable,
+                            &pool,
+                        )
+                        .map(|c| Box::new(c) as Box<dyn Compiler<T>>),
                     );
                 }
                 "msvc" | "msvc-clang" => {

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -38,6 +38,9 @@ impl CCompilerImpl for Diab {
     fn kind(&self) -> CCompilerKind {
         CCompilerKind::Diab
     }
+    fn plusplus(&self) -> bool {
+        false
+    }
     fn parse_arguments(
         &self,
         arguments: &[OsString],

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -47,6 +47,9 @@ impl CCompilerImpl for MSVC {
     fn kind(&self) -> CCompilerKind {
         CCompilerKind::MSVC
     }
+    fn plusplus(&self) -> bool {
+        false
+    }
     fn parse_arguments(
         &self,
         arguments: &[OsString],

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -39,12 +39,15 @@ impl CCompilerImpl for NVCC {
     fn kind(&self) -> CCompilerKind {
         CCompilerKind::NVCC
     }
+    fn plusplus(&self) -> bool {
+        false
+    }
     fn parse_arguments(
         &self,
         arguments: &[OsString],
         cwd: &Path,
     ) -> CompilerArguments<ParsedArguments> {
-        gcc::parse_arguments(arguments, cwd, (&gcc::ARGS[..], &ARGS[..]))
+        gcc::parse_arguments(arguments, cwd, (&gcc::ARGS[..], &ARGS[..]), false)
     }
 
     fn preprocess<T>(


### PR DESCRIPTION
`g++` and `clang++` both compile `.c` files in C++ mode in the absence of any other directions (like the `-x` flag); add code to distinguish between the two compilers and their `++` variations, then fix up language selection and caching accordingly.