### PR TITLE
Remove "Known Caveats" link from README TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Table of Contents (ToC)
   * [Azure](#azure)
 * [Debugging](#debugging)
 * [Interaction with GNU `make` jobserver](#interaction-with-gnu-make-jobserver)
-* [Known Caveats](#known-caveats)
 
 ---
 


### PR DESCRIPTION
The "Known Caveats" section of the README was removed in 98c62b5404fac2149bcebaf1f05050d55133859d, but the link in the Table of Contents was not.