### PR TITLE
Modify logging to use SCCACHE_LOG.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,13 +223,13 @@ the container for you - you'll need to do that yourself.
 Debugging
 ---------
 
-You can run the server manually in foreground mode by running `SCCACHE_START_SERVER=1 SCCACHE_NO_DAEMON=1 sccache`, and send logging to stderr by setting the [`RUST_LOG` environment variable](https://docs.rs/env_logger/0.7.1/env_logger/#enabling-logging) for example
+You can run the server manually in foreground mode by running `SCCACHE_START_SERVER=1 SCCACHE_NO_DAEMON=1 sccache`, and send logging to stderr by setting the [`SCCACHE_LOG` environment variable](https://docs.rs/env_logger/0.7.1/env_logger/#enabling-logging) for example
 
-    RUST_LOG=debug SCCACHE_START_SERVER=1 SCCACHE_NO_DAEMON=1 sccache
+    SCCACHE_LOG=debug SCCACHE_START_SERVER=1 SCCACHE_NO_DAEMON=1 sccache
 
-Alternately, you can set the `SCCACHE_ERROR_LOG` environment variable to a path and set `RUST_LOG` to get the server process to redirect its logging there (including the output of unhandled panics, since the server sets `RUST_BACKTRACE=1` internally).
+Alternately, you can set the `SCCACHE_ERROR_LOG` environment variable to a path and set `SCCACHE_LOG` to get the server process to redirect its logging there (including the output of unhandled panics, since the server sets `RUST_BACKTRACE=1` internally).
 
-    SCCACHE_ERROR_LOG=/tmp/sccache_log.txt RUST_LOG=debug sccache
+    SCCACHE_ERROR_LOG=/tmp/sccache_log.txt SCCACHE_LOG=debug sccache
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,8 @@ pub mod util;
 
 use std::env;
 
+const LOGGING_ENV: &str = "SCCACHE_LOG";
+
 pub fn main() {
     init_logging();
     std::process::exit(match cmdline::parse() {
@@ -87,8 +89,8 @@ pub fn main() {
 }
 
 fn init_logging() {
-    if env::var("RUST_LOG").is_ok() {
-        match env_logger::try_init() {
+    if env::var(LOGGING_ENV).is_ok() {
+        match env_logger::Builder::from_env(LOGGING_ENV).try_init() {
             Ok(_) => (),
             Err(e) => panic!(format!("Failed to initalize logging: {:?}", e)),
         }


### PR DESCRIPTION
As per #810, modify env_logger to use the SCCACHE_LOG environment
variable instead of the RUST_LOG one. This is to enable control of
sccache logs whilst debugging other rust binaries.