### PR TITLE
fix(build): dist-server without any other features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ unstable = []
 # Enables distributed support in the sccache client
 dist-client = ["ar", "flate2", "hyper", "hyperx", "reqwest", "url", "sha2"]
 # Enables the sccache-dist binary
-dist-server = ["crossbeam-utils", "jsonwebtoken", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "void", "version-compare"]
+dist-server = ["crossbeam-utils", "jsonwebtoken", "flate2", "hyperx", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "void", "version-compare"]
 # Enables dist tests with external requirements
 dist-tests = ["dist-client", "dist-server"]
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -110,7 +110,7 @@ macro_rules! ftry {
     };
 }
 
-#[cfg(any(feature = "dist-client", feature = "dist-server"))]
+#[cfg(feature = "dist-client")]
 macro_rules! ftry_send {
     ($e:expr) => {
         match $e {

--- a/src/server.rs
+++ b/src/server.rs
@@ -28,6 +28,7 @@ use crate::jobserver::Client;
 use crate::mock_command::{CommandCreatorSync, ProcessCommandCreator};
 use crate::protocol::{Compile, CompileFinished, CompileResponse, Request, Response};
 use crate::util;
+#[cfg(feature = "dist-client")]
 use anyhow::Context as _;
 use filetime::FileTime;
 use futures::sync::mpsc;


### PR DESCRIPTION
`sccache` build fails e.g. for `cargo build --release --no-default-features --features dist-server` and any other combination where `hyperx` isn't pulled in with 
```
error[E0432]: unresolved import `hyperx`
  --> src/dist/http.rs:26:9
```
This issue is present at least both in `master` and `0.2.13`.

As far as I know, there is no associated issue.