### PR TITLE
New entry in ServerStartup enum to indicate AddrInUse Error

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -282,6 +282,9 @@ fn connect_or_start_server(port: u16) -> Result<ServerConnection> {
                         );
                     }
                 }
+                ServerStartup::AddrInUse => {
+                    debug!("AddrInUse: possible parallel server bootstraps, retrying..")
+                }
                 ServerStartup::TimedOut => bail!("Timed out waiting for server startup"),
                 ServerStartup::Err { reason } => bail!("Server startup failed: {}", reason),
             }
@@ -587,6 +590,7 @@ pub fn run_command(cmd: Command) -> Result<i32> {
                     }
                 }
                 ServerStartup::TimedOut => bail!("Timed out waiting for server startup"),
+                ServerStartup::AddrInUse => bail!("Server startup failed: Address in use"),
                 ServerStartup::Err { reason } => bail!("Server startup failed: {}", reason),
             }
         }


### PR DESCRIPTION
when cargo fires of parallel build jobs, we encounter a race to start
the server if the server is not already running to start the server

This is an AddrInUse error causing atleast one of the parallel build
jobs fail.

This patch adds a new entry to ServerStartup enum to clearly communicate
the AddrInUse error from the server to the client that requested the
server start. Using this information the client can retry connecting
instead of failing.