### PR TITLE
server: support a configurable timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ sccache defaults to using local disk storage. You can set the `SCCACHE_DIR` envi
 
 The default cache size is 10 gigabytes. To change this, set `SCCACHE_CACHE_SIZE`, for example `SCCACHE_CACHE_SIZE="1G"`.
 
+With large caches, server startup time may take a long time. The `SCCACHE_STARTUP_TIMEOUT_MS` evironment variable may be set to extend this (defaults to `10000` or 10 seconds).
+
 ### S3
 If you want to use S3 storage for the sccache cache, you need to set the `SCCACHE_BUCKET` environment variable to the name of the S3 bucket to use.
 


### PR DESCRIPTION
With large caches, the server may take a long time to respond.

---
Cc: @bradking