### PR TITLE
Typo: putting $HOME in code markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Known Caveats
 
 ### General
 
-* Absolute paths to files must match to get a cache hit. This means that even if you are using a shared cache, everyone will have to build at the same absolute path (i.e. not in $HOME) in order to benefit each other. In Rust this includes the source for third party crates which are stored in `$HOME/.cargo/registry/cache` by default.
+* Absolute paths to files must match to get a cache hit. This means that even if you are using a shared cache, everyone will have to build at the same absolute path (i.e. not in `$HOME`) in order to benefit each other. In Rust this includes the source for third party crates which are stored in `$HOME/.cargo/registry/cache` by default.
 
 ### Rust
 


### PR DESCRIPTION
Signed-off-by: ed neville <ed@s5h.net>