### PR TITLE
msvc: handle /MP as a passthrough argument

### DIFF
--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -308,7 +308,9 @@ msvc_args!(static ARGS: [ArgInfo<ArgData>; _] = [
     msvc_flag!("LDd", PassThrough),
     msvc_flag!("MD", PassThrough),
     msvc_flag!("MDd", PassThrough),
-    msvc_flag!("MP", TooHardFlag), // Multiple source files.
+    // MP would normally be TooHardFlag but multiple inputs are not supported.
+    // With a single input, it's fine to passthrough.
+    msvc_take_arg!("MP", OsString, Concatenated, PassThroughWithSuffix),
     msvc_flag!("MT", PassThrough),
     msvc_flag!("MTd", PassThrough),
     msvc_flag!("O1", PassThrough),


### PR DESCRIPTION
Compiler invocations with the [`/MP[processMax]`](https://docs.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes) option for MSVC are currently rejected by the cache ("multiple input files"). The `/MP` option enables multiprocessing in the compiler, so there is no impact on the cache-ability of the call if a single source file is given. This commit changes the behavior to passthrough.

I ran into this because [Conan](https://conan.io/) adds the `/MP` option by default.