### PR TITLE
docker to podman migration

### DIFF
--- a/docs/Distributed.md
+++ b/docs/Distributed.md
@@ -2,29 +2,29 @@
 
 Background:
 
- - You should read about JSON Web Tokens - https://jwt.io/.
+- You should read about JSON Web Tokens - https://jwt.io/.
    - HS256 in short: you can sign a piece of (typically unencrypted)
-     data with a key. Verification involves signing the data again
-     with the same key and comparing the result. As a result, if you
-     want two parties to verify each others messages, the key must be
-     shared beforehand.
- - 'secure token's referenced below should be generated with a CSPRNG
-   (your OS random number generator should suffice).
-   For example, on Linux this is accessible with: `openssl rand -hex 64`.
- - When relying on random number generators (for generating keys or
-   tokens), be aware that a lack of entropy is possible in cloud or
-   virtualized environments in some scenarios.
+    data with a key. Verification involves signing the data again
+    with the same key and comparing the result. As a result, if you
+    want two parties to verify each others messages, the key must be
+    shared beforehand.
+- 'secure token's referenced below should be generated with a CSPRNG
+  (your OS random number generator should suffice).
+  For example, on Linux this is accessible with: `openssl rand -hex 64`.
+- When relying on random number generators (for generating keys or
+  tokens), be aware that a lack of entropy is possible in cloud or
+  virtualized environments in some scenarios.
 
 ## Overview
 
 Distributed sccache consists of three parts:
 
- - the client, an sccache binary that wishes to perform a compilation on
-   remote machines
- - the scheduler (`sccache-dist` binary), responsible for deciding where
-   a compilation job should run
- - the server (`sccache-dist` binary), responsible for actually executing
-   a build
+- the client, an sccache binary that wishes to perform a compilation on
+  remote machines
+- the scheduler (`sccache-dist` binary), responsible for deciding where
+  a compilation job should run
+- the server (`sccache-dist` binary), responsible for actually executing
+  a build
 
 All servers are required to be a 64-bit Linux install. Clients may request
 compilation from Linux, Windows or macOS. Linux compilations will attempt to
@@ -35,13 +35,13 @@ need to specify a toolchain for cross-compilation ahead of time.
 
 The HTTP implementation of sccache has the following API, where all HTTP body content is encoded using [`bincode`](http://docs.rs/bincode):
 
- - scheduler
+- scheduler
    - `POST /api/v1/scheduler/alloc_job`
       - Called by a client to submit a compilation request.
       - Returns information on where the job is allocated it should run.
    - `GET /api/v1/scheduler/server_certificate`
       - Called by a client to retrieve the (dynamically created) HTTPS
-        certificate for a server, for use in communication with that server.
+      certificate for a server, for use in communication with that server.
       - Returns a digest and PEM for the temporary server HTTPS certificate.
    - `POST /api/v1/scheduler/heartbeat_server`
       - Called (repeatedly) by servers to register as available for jobs.
@@ -49,7 +49,7 @@ The HTTP implementation of sccache has the following API, where all HTTP body co
       - Called by servers to inform the scheduler of the state of the job.
    - `GET /api/v1/scheduler/status`
       - Returns information about the scheduler.
- - `server`
+- `server`
    - `POST /api/v1/distserver/assign_job`
       - Called by the scheduler to inform of a new job being assigned to this server.
       - Returns whether the toolchain is already on the server or needs submitting.
@@ -88,14 +88,14 @@ Create a scheduler key with `sccache-dist auth generate-jwt-hs256-key` (which wi
 use your OS random number generator) and put it in your scheduler config file as
 follows:
 
-```
+```toml
 server_auth = { type = "jwt_hs256", secret_key = "YOUR_KEY_HERE" }
 ```
 
 Now generate a token for the server, giving the IP and port the scheduler and clients can
 connect to the server on (address `192.168.1.10:10501` here):
 
-```
+```sh
 sccache-dist auth generate-jwt-hs256-server-token \
     --secret-key YOUR_KEY_HERE \
     --server 192.168.1.10:10501
@@ -103,7 +103,7 @@ sccache-dist auth generate-jwt-hs256-server-token \
 
 *or:*
 
-```
+```sh
 sccache-dist auth generate-jwt-hs256-server-token \
     --config /path/to/scheduler-config.toml \
     --server 192.168.1.10:10501
@@ -112,7 +112,7 @@ sccache-dist auth generate-jwt-hs256-server-token \
 This will output a token (you can examine it with https://jwt.io if you're
 curious) that you should add to your server config file as follows:
 
-```
+```toml
 scheduler_auth = { type = "jwt_token", token = "YOUR_TOKEN_HERE" }
 ```
 
@@ -129,13 +129,13 @@ Choose a 'secure token' you can share between your scheduler and all servers.
 
 Put the following in your scheduler config file:
 
-```
+```toml
 server_auth = { type = "token", token = "YOUR_TOKEN_HERE" }
 ```
 
 Put the following in your server config file:
 
-```
+```toml
 scheduler_auth = { type = "token", token = "YOUR_TOKEN_HERE" }
 ```
 
@@ -152,13 +152,13 @@ provides no security at all.
 
 Put the following in your scheduler config file:
 
-```
+```toml
 server_auth = { type = "DANGEROUSLY_INSECURE" }
 ```
 
 Put the following in your server config file:
 
-```
+```toml
 scheduler_auth = { type = "DANGEROUSLY_INSECURE" }
 ```
 
@@ -191,7 +191,7 @@ which has a few different options for performing validation on that token.
 Put one of the following settings in your scheduler config file to determine how
 the scheduler will validate tokens from the client:
 
-```
+```toml
 # Use the known settings for Mozilla OAuth2 token validation
 client_auth = { type = "mozilla" }
 
@@ -204,7 +204,7 @@ client_auth = { type = "proxy_token", url = "...", cache_secs = 60 }
 Additionally, each client should set up an OAuth2 configuration in the with one of
 the following settings (as appropriate for your OAuth service):
 
-```
+```toml
 # Use the known settings for Mozilla OAuth2 authentication
 auth = { type = "mozilla" }
 
@@ -234,13 +234,13 @@ Choose a 'secure token' you can share between your scheduler and all clients.
 
 Put the following in your scheduler config file:
 
-```
+```toml
 client_auth = { type = "token", token = "YOUR_TOKEN_HERE" }
 ```
 
 Put the following in your client config file:
 
-```
+```toml
 auth = { type = "token", token = "YOUR_TOKEN_HERE" }
 ```
 
@@ -257,7 +257,7 @@ provides no security at all.
 
 Put the following in your scheduler config file:
 
-```
+```toml
 client_auth = { type = "DANGEROUSLY_INSECURE" }
 ```
 
@@ -285,9 +285,10 @@ the heartbeat. If a client does not have the appropriate certificate for communi
 securely with a server (after receiving a job allocation from the scheduler), the
 certificate will be requested from the scheduler.
 
-# Building the Distributed Server Binaries
+## Building the Distributed Server Binaries
 
 Until these binaries [are included in releases](https://github.com/mozilla/sccache/issues/393) I've put together a Docker container that can be used to easily build a release binary:
-```
+
+```sh
 podman run -ti --rm -v $PWD:/sccache luser/sccache-musl-build:0.1 /bin/bash -c "cd /sccache; cargo build --release --target x86_64-unknown-linux-musl --features=dist-server && strip target/x86_64-unknown-linux-musl/release/sccache-dist && cd target/x86_64-unknown-linux-musl/release/ && tar czf sccache-dist.tar.gz sccache-dist"
 ```

--- a/docs/Distributed.md
+++ b/docs/Distributed.md
@@ -289,5 +289,5 @@ certificate will be requested from the scheduler.
 
 Until these binaries [are included in releases](https://github.com/mozilla/sccache/issues/393) I've put together a Docker container that can be used to easily build a release binary:
 ```
-docker run -ti --rm -v $PWD:/sccache luser/sccache-musl-build:0.1 /bin/bash -c "cd /sccache; cargo build --release --target x86_64-unknown-linux-musl --features=dist-server && strip target/x86_64-unknown-linux-musl/release/sccache-dist && cd target/x86_64-unknown-linux-musl/release/ && tar czf sccache-dist.tar.gz sccache-dist"
+podman run -ti --rm -v $PWD:/sccache luser/sccache-musl-build:0.1 /bin/bash -c "cd /sccache; cargo build --release --target x86_64-unknown-linux-musl --features=dist-server && strip target/x86_64-unknown-linux-musl/release/sccache-dist && cd target/x86_64-unknown-linux-musl/release/ && tar czf sccache-dist.tar.gz sccache-dist"
 ```

--- a/scripts/extratest.sh
+++ b/scripts/extratest.sh
@@ -79,8 +79,8 @@ elif [ "$1" = test ]; then
     # if you have multiple test functions in one file.
 
     set +x
-    if ! which docker; then
-        echo -e "WARNING: =====\n\ndocker not present, some tests will fail\n\n=====\n\n\n\n\n"
+    if ! which podman; then
+        echo -e "WARNING: =====\n\npodman not present, some tests will fail\n\n=====\n\n\n\n\n"
         sleep 5
     fi
     if ! which icecc-create-env; then

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -550,7 +550,7 @@ impl Storage for GCSCache {
 #[test]
 fn test_gcs_credential_provider() {
     const EXPIRE_TIME: &str = "3000-01-01T00:00:00.0Z";
-    let addr = ([127, 0, 0, 1], 3000).into();
+    let addr = ([127, 0, 0, 1], 34598).into();
     let make_service = || {
         hyper::service::service_fn_ok(|_| {
             let token = serde_json::json!({

--- a/src/config.rs
+++ b/src/config.rs
@@ -751,7 +751,7 @@ pub mod server {
     #[serde(tag = "type")]
     #[serde(deny_unknown_fields)]
     pub enum BuilderType {
-        #[serde(rename = "docker")]
+        #[serde(rename = "podman")]
         Docker,
         #[serde(rename = "overlay")]
         Overlay {

--- a/tests/harness/Dockerfile.sccache-dist
+++ b/tests/harness/Dockerfile.sccache-dist
@@ -8,7 +8,7 @@ RUN cd /bubblewrap-0.3.1 && \
     ./configure --disable-man && \
     make
 
-FROM aidanhs/ubuntu-docker:18.04-17.03.2-ce
+FROM aidanhs/ubuntu-podman:18.04-17.03.2-ce
 RUN apt-get update && \
     apt-get install libcap2 libssl1.1 && \
     apt-get clean

--- a/tests/harness/Dockerfile.sccache-dist
+++ b/tests/harness/Dockerfile.sccache-dist
@@ -8,7 +8,7 @@ RUN cd /bubblewrap-0.3.1 && \
     ./configure --disable-man && \
     make
 
-FROM aidanhs/ubuntu-podman:18.04-17.03.2-ce
+FROM aidanhs/ubuntu-docker:18.04-17.03.2-ce
 RUN apt-get update && \
     apt-get install libcap2 libssl1.1 && \
     apt-get clean

--- a/tests/oauth.rs
+++ b/tests/oauth.rs
@@ -155,7 +155,7 @@ impl SeleniumContainer {
                 "SE_OPTS=-debug",
                 "selenium/standalone-chrome-debug:3.14.0",
             ];
-            let output = Command::new("docker").args(args).output().unwrap();
+            let output = Command::new("podman").args(args).output().unwrap();
             check_output(&output);
             let stdout = String::from_utf8(output.stdout).unwrap();
             stdout.trim().to_owned()
@@ -166,11 +166,11 @@ impl SeleniumContainer {
 
 impl Drop for SeleniumContainer {
     fn drop(&mut self) {
-        let Output { stdout, stderr, .. } = Command::new("docker")
+        let Output { stdout, stderr, .. } = Command::new("podman")
             .args(&["logs", &self.cid])
             .output()
             .unwrap();
-        let output = Command::new("docker")
+        let output = Command::new("podman")
             .args(&["kill", &self.cid])
             .output()
             .unwrap();


### PR DESCRIPTION
Simplify harness and allow ci usage by moving to `podman` which should allow rootless containers just fine.

TODO

* [ ] check if bubblewrap can be launched from userspace