### PR TITLE
Reject caching when multiple -arch arguments are present

### DIFF
--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -1223,6 +1223,25 @@ mod test {
     }
 
     #[test]
+    fn test_parse_arguments_multiple_arch() {
+        match parse_arguments_(
+            stringvec!["-arch", "arm64", "-o", "foo.o", "-c", "foo.cpp"],
+            false,
+        ) {
+            CompilerArguments::Ok(_) => {}
+            o => panic!("Got unexpected parse result: {:?}", o),
+        }
+
+        match parse_arguments_(
+            stringvec!["-arch", "arm64", "-arch", "i386", "-o", "foo.o", "-c", "foo.cpp"],
+            false,
+        ) {
+            CompilerArguments::Ok(_) => {}
+            o => panic!("Got unexpected parse result: {:?}", o),
+        }
+    }
+
+    #[test]
     fn at_signs() {
         let td = tempfile::Builder::new()
             .prefix("sccache")

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -561,6 +561,7 @@ pub fn parse_arguments(
                 Some(DiagnosticsColor(_))
                 | Some(DiagnosticsColorFlag)
                 | Some(NoDiagnosticsColorFlag)
+                | Some(Arch(_))
                 | Some(PassThrough(_))
                 | Some(PassThroughPath(_)) => &mut common_args,
 


### PR DESCRIPTION
Please read the commit messages and #847 for more context for this change.

The argument parsing code performs multiple loops of the args and I'm unsure what the nuanced distinctions are between them. Because I don't fully grok what's going on here, I may have put the validation in the wrong loop. That's what code review is for!