### PR TITLE
Use a full path relative to `cwd` for extra hash files

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -145,7 +145,7 @@ mod test {
         Clang {
             clangplusplus: false,
         }
-        .parse_arguments(&arguments, ".".as_ref())
+        .parse_arguments(&arguments, &std::env::current_dir().unwrap())
     }
 
     macro_rules! parses {
@@ -246,7 +246,10 @@ mod test {
             ovec!["-Xclang", "-load", "-Xclang", "plugin.so"],
             a.common_args
         );
-        assert_eq!(ovec!["plugin.so"], a.extra_hash_files);
+        assert_eq!(
+            ovec![std::env::current_dir().unwrap().join("plugin.so")],
+            a.extra_hash_files
+        );
     }
 
     #[test]
@@ -367,7 +370,10 @@ mod test {
         let a = parses!("-c", "foo.c", "-o", "foo.o", "-fplugin", "plugin.so");
         println!("A {:#?}", a);
         assert_eq!(ovec!["-fplugin", "plugin.so"], a.common_args);
-        assert_eq!(ovec!["plugin.so"], a.extra_hash_files);
+        assert_eq!(
+            ovec![std::env::current_dir().unwrap().join("plugin.so")],
+            a.extra_hash_files
+        );
     }
 
     #[test]
@@ -380,7 +386,10 @@ mod test {
             "-fsanitize-blacklist=list.txt"
         );
         assert_eq!(ovec!["-fsanitize-blacklist=list.txt"], a.common_args);
-        assert_eq!(ovec!["list.txt"], a.extra_hash_files);
+        assert_eq!(
+            ovec![std::env::current_dir().unwrap().join("list.txt")],
+            a.extra_hash_files
+        );
     }
 
     #[test]

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -342,7 +342,7 @@ where
             | Some(PassThrough(_))
             | Some(PassThroughPath(_)) => &mut common_args,
             Some(ExtraHashFile(path)) => {
-                extra_hash_files.push(path.clone());
+                extra_hash_files.push(cwd.join(path));
                 &mut common_args
             }
             Some(PreprocessorArgumentFlag)
@@ -401,7 +401,7 @@ where
             | Some(PassThrough(_))
             | Some(PassThroughPath(_)) => &mut common_args,
             Some(ExtraHashFile(path)) => {
-                extra_hash_files.push(path.clone());
+                extra_hash_files.push(cwd.join(path));
                 &mut common_args
             }
             Some(PreprocessorArgumentFlag)

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -521,7 +521,7 @@ pub fn parse_arguments(
                     .iter_os_strings(),
             ),
             Some(ExtraHashFile(path)) => {
-                extra_hash_files.push(path.clone());
+                extra_hash_files.push(cwd.join(path));
                 common_args.extend(
                     arg.normalize(NormalizedDisposition::Concatenated)
                         .iter_os_strings(),
@@ -574,7 +574,7 @@ pub fn parse_arguments(
                     &mut common_args
                 }
                 Some(ExtraHashFile(path)) => {
-                    extra_hash_files.push(path.clone());
+                    extra_hash_files.push(cwd.join(path));
                     &mut common_args
                 }
                 Some(PreprocessorArgumentFlag)
@@ -884,14 +884,13 @@ fn generate_compile_commands(
 mod test {
     use super::*;
     use crate::compiler::*;
-    use crate::env;
     use crate::mock_command::*;
     use crate::test::utils::*;
     use futures::Future;
     use futures_03::executor::ThreadPool;
 
     fn parse_arguments(arguments: Vec<OsString>) -> CompilerArguments<ParsedArguments> {
-        super::parse_arguments(&arguments, &env::current_dir().unwrap(), false)
+        super::parse_arguments(&arguments, &std::env::current_dir().unwrap(), false)
     }
 
     #[test]
@@ -1331,6 +1330,9 @@ mod test {
             o => panic!("Got unexpected parse result: {:?}", o),
         };
         assert_eq!(ovec!["-fsanitize-blacklist=list.txt"], common_args);
-        assert_eq!(ovec!["list.txt"], extra_hash_files);
+        assert_eq!(
+            ovec![std::env::current_dir().unwrap().join("list.txt")],
+            extra_hash_files
+        );
     }
 }


### PR DESCRIPTION
When the current directory of the sccache process is not the same as
the current directory for the compiler process, extra hash files are
currently not found, leading to errors.

Fixes #843