### PR TITLE
Add C compiler versions to the hash calculation when available

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -205,11 +205,25 @@ impl<I> CCompiler<I>
 where
     I: CCompilerImpl,
 {
-    pub fn new(compiler: I, executable: PathBuf, pool: &ThreadPool) -> SFuture<CCompiler<I>> {
+    pub fn new(
+        compiler: I,
+        executable: PathBuf,
+        version: Option<String>,
+        pool: &ThreadPool,
+    ) -> SFuture<CCompiler<I>> {
         Box::new(
             Digest::file(executable.clone(), &pool).map(move |digest| CCompiler {
                 executable,
-                executable_digest: digest,
+                executable_digest: {
+                    if let Some(version) = version {
+                        let mut m = Digest::new();
+                        m.update(digest.as_bytes());
+                        m.update(version.as_bytes());
+                        m.finish()
+                    } else {
+                        digest
+                    }
+                },
                 compiler,
             }),
         )

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1012,7 +1012,10 @@ g++
 gcc
 #elif defined(__DCC__)
 diab
+#else
+unknown
 #endif
+__VERSION__
 "
     .to_vec();
     let write = write_temp_file(&pool, "testfile.c".as_ref(), test);
@@ -1041,17 +1044,30 @@ diab
             Ok(s) => s,
             Err(_) => return f_err(anyhow!("Failed to parse output")),
         };
-        for line in stdout.lines() {
-            //TODO: do something smarter here.
-            match line {
+        let mut lines = stdout.lines().filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                None
+            } else {
+                Some(line)
+            }
+        });
+        if let Some(kind) = lines.next() {
+            let version = lines
+                .next()
+                // In case the compiler didn't expand the macro.
+                .filter(|&line| line != "__VERSION__")
+                .map(str::to_owned);
+            match kind {
                 "clang" | "clang++" => {
-                    debug!("Found {}", line);
+                    debug!("Found {}", kind);
                     return Box::new(
                         CCompiler::new(
                             Clang {
-                                clangplusplus: line == "clang++",
+                                clangplusplus: kind == "clang++",
                             },
                             executable,
+                            version,
                             &pool,
                         )
                         .map(|c| Box::new(c) as Box<dyn Compiler<T>>),
@@ -1060,25 +1076,26 @@ diab
                 "diab" => {
                     debug!("Found diab");
                     return Box::new(
-                        CCompiler::new(Diab, executable, &pool)
+                        CCompiler::new(Diab, executable, version, &pool)
                             .map(|c| Box::new(c) as Box<dyn Compiler<T>>),
                     );
                 }
                 "gcc" | "g++" => {
-                    debug!("Found {}", line);
+                    debug!("Found {}", kind);
                     return Box::new(
                         CCompiler::new(
                             GCC {
-                                gplusplus: line == "g++",
+                                gplusplus: kind == "g++",
                             },
                             executable,
+                            version,
                             &pool,
                         )
                         .map(|c| Box::new(c) as Box<dyn Compiler<T>>),
                     );
                 }
                 "msvc" | "msvc-clang" => {
-                    let is_clang = line == "msvc-clang";
+                    let is_clang = kind == "msvc-clang";
                     debug!("Found MSVC (is clang: {})", is_clang);
                     let prefix = msvc::detect_showincludes_prefix(
                         &creator,
@@ -1095,6 +1112,7 @@ diab
                                 is_clang,
                             },
                             executable,
+                            version,
                             &pool,
                         )
                         .map(|c| Box::new(c) as Box<dyn Compiler<T>>)
@@ -1103,7 +1121,7 @@ diab
                 "nvcc" => {
                     debug!("Found NVCC");
                     return Box::new(
-                        CCompiler::new(NVCC, executable, &pool)
+                        CCompiler::new(NVCC, executable, version, &pool)
                             .map(|c| Box::new(c) as Box<dyn Compiler<T>>),
                     );
                 }
@@ -1158,10 +1176,7 @@ mod test {
         let f = TestFixture::new();
         let creator = new_creator();
         let pool = ThreadPool::sized(1);
-        next_command(
-            &creator,
-            Ok(MockChild::new(exit_status(0), "foo\nbar\ngcc", "")),
-        );
+        next_command(&creator, Ok(MockChild::new(exit_status(0), "\n\ngcc", "")));
         let c = detect_compiler(creator, &f.bins[0], f.tempdir.path(), &[], &pool, None)
             .wait()
             .unwrap()
@@ -1174,10 +1189,7 @@ mod test {
         let f = TestFixture::new();
         let creator = new_creator();
         let pool = ThreadPool::sized(1);
-        next_command(
-            &creator,
-            Ok(MockChild::new(exit_status(0), "clang\nfoo", "")),
-        );
+        next_command(&creator, Ok(MockChild::new(exit_status(0), "clang\n", "")));
         let c = detect_compiler(creator, &f.bins[0], f.tempdir.path(), &[], &pool, None)
             .wait()
             .unwrap()
@@ -1199,10 +1211,7 @@ mod test {
         let prefix = String::from("blah: ");
         let stdout = format!("{}{}\r\n", prefix, s);
         // Compiler detection output
-        next_command(
-            &creator,
-            Ok(MockChild::new(exit_status(0), "foo\nmsvc\nbar", "")),
-        );
+        next_command(&creator, Ok(MockChild::new(exit_status(0), "\nmsvc\n", "")));
         // showincludes prefix detection output
         next_command(
             &creator,
@@ -1220,10 +1229,7 @@ mod test {
         let f = TestFixture::new();
         let creator = new_creator();
         let pool = ThreadPool::sized(1);
-        next_command(
-            &creator,
-            Ok(MockChild::new(exit_status(0), "nvcc\nfoo", "")),
-        );
+        next_command(&creator, Ok(MockChild::new(exit_status(0), "nvcc\n", "")));
         let c = detect_compiler(creator, &f.bins[0], f.tempdir.path(), &[], &pool, None)
             .wait()
             .unwrap()
@@ -1273,10 +1279,7 @@ LLVM version: 6.0",
         let f = TestFixture::new();
         let creator = new_creator();
         let pool = ThreadPool::sized(1);
-        next_command(
-            &creator,
-            Ok(MockChild::new(exit_status(0), "foo\ndiab\nbar", "")),
-        );
+        next_command(&creator, Ok(MockChild::new(exit_status(0), "\ndiab\n", "")));
         let c = detect_compiler(creator, &f.bins[0], f.tempdir.path(), &[], &pool, None)
             .wait()
             .unwrap()
@@ -1321,6 +1324,48 @@ LLVM version: 6.0",
         )
         .wait()
         .is_err());
+    }
+
+    #[test]
+    fn test_compiler_version_affects_hash() {
+        let f = TestFixture::new();
+        let creator = new_creator();
+        let pool = ThreadPool::sized(1);
+        let arguments = ovec!["-c", "foo.c", "-o", "foo.o"];
+        let cwd = f.tempdir.path();
+
+        let results: Vec<_> = [11, 12]
+            .iter()
+            .map(|version| {
+                let output = format!("clang\n\"{}.0.0\"", version);
+                next_command(&creator, Ok(MockChild::new(exit_status(0), &output, "")));
+                let c = detect_compiler(
+                    creator.clone(),
+                    &f.bins[0],
+                    f.tempdir.path(),
+                    &[],
+                    &pool,
+                    None,
+                )
+                .wait()
+                .unwrap()
+                .0;
+                next_command(
+                    &creator,
+                    Ok(MockChild::new(exit_status(0), "preprocessor output", "")),
+                );
+                let hasher = match c.parse_arguments(&arguments, ".".as_ref()) {
+                    CompilerArguments::Ok(h) => h,
+                    o => panic!("Bad result from parse_arguments: {:?}", o),
+                };
+                hasher
+                    .generate_hash_key(&creator, cwd.to_path_buf(), vec![], false, &pool, false)
+                    .wait()
+                    .unwrap()
+            })
+            .collect();
+        assert_eq!(results.len(), 2);
+        assert_ne!(results[0].key, results[1].key);
     }
 
     #[test]


### PR DESCRIPTION
The clang compiler is a relatively thin wrapper around libclang-cpp and
libllvm, and in some cases, it's possible that two identical clang
executables are actually for different builds of clang. While ideally
we could find all the libraries it could be using, a work-around,
good enough for now, is to check the compiler version, which we get from
the __VERSION__ macro in the preprocessor we're already making.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1685034