### PR TITLE
Workaround tiny_http issue #151 by disabling HTTP pipelining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,7 +2903,8 @@ dependencies = [
 [[package]]
 name = "tiny_http"
 version = "0.6.2"
-source = "git+https://github.com/tiny-http/tiny-http.git?rev=619680de#619680dea2c4f1dfb31b552d5e7b472a9f25b8b8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1661fa0a44c95d01604bd05c66732a446c657efb62b5164a7a083a3b552b4951"
 dependencies = [
  "ascii",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,10 +95,6 @@ syslog = { version = "5", optional = true }
 void = { version = "1", optional = true }
 version-compare = { version = "0.0.11", optional = true }
 
-[patch.crates-io]
-# Waiting for #151 to make it into a release
-tiny_http = { git = "https://github.com/tiny-http/tiny-http.git", rev = "619680de" }
-
 [dev-dependencies]
 assert_cmd = "1"
 cc = "1.0"

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -73,7 +73,9 @@ mod common {
     pub fn bincode_req<T: serde::de::DeserializeOwned + 'static>(
         req: reqwest::RequestBuilder,
     ) -> Result<T> {
-        let mut res = req.send()?;
+        // Work around tiny_http issue #151 by disabling HTTP pipeline with
+        // `Connection: close`.
+        let mut res = req.set_header(header::Connection::close()).send()?;
         let status = res.status();
         let mut body = vec![];
         res.copy_to(&mut body)
@@ -94,7 +96,10 @@ mod common {
         req: reqwest::r#async::RequestBuilder,
     ) -> SFuture<T> {
         Box::new(
-            req.send()
+            // Work around tiny_http issue #151 by disabling HTTP pipeline with
+            // `Connection: close`.
+            req.set_header(header::Connection::close())
+                .send()
                 .map_err(Into::into)
                 .and_then(|res| {
                     let status = res.status();


### PR DESCRIPTION
Instead of relying on a crate patch.

Fixes: #912 