### PR TITLE
Upgrade reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,12 +1105,32 @@ dependencies = [
  "bytes 0.4.12",
  "fnv",
  "futures 0.1.30",
- "http",
+ "http 0.1.21",
  "indexmap",
  "log 0.4.11",
  "slab",
  "string",
  "tokio-io",
+]
+
+[[package]]
+name = "h2"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.3",
+ "indexmap",
+ "slab",
+ "tokio 0.2.24",
+ "tokio-util",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -1150,6 +1170,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+dependencies = [
+ "bytes 1.0.0",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,8 +1188,18 @@ checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.30",
- "http",
+ "http 0.1.21",
  "tokio-buf",
+]
+
+[[package]]
+name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+dependencies = [
+ "bytes 0.5.6",
+ "http 0.2.3",
 ]
 
 [[package]]
@@ -1166,6 +1207,12 @@ name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+
+[[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
@@ -1182,9 +1229,9 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.30",
  "futures-cpupool",
- "h2",
- "http",
- "http-body",
+ "h2 0.1.26",
+ "http 0.1.21",
+ "http-body 0.1.0",
  "httparse",
  "iovec",
  "itoa",
@@ -1200,7 +1247,31 @@ dependencies = [
  "tokio-tcp",
  "tokio-threadpool",
  "tokio-timer",
- "want",
+ "want 0.2.0",
+]
+
+[[package]]
+name = "hyper"
+version = "0.13.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.2.7",
+ "http 0.2.3",
+ "http-body 0.3.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.4",
+ "socket2",
+ "tokio 0.2.24",
+ "tower-service 0.3.0",
+ "tracing",
+ "want 0.3.0",
 ]
 
 [[package]]
@@ -1211,9 +1282,22 @@ checksum = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.30",
- "hyper",
+ "hyper 0.12.35",
  "native-tls",
  "tokio-io",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+dependencies = [
+ "bytes 0.5.6",
+ "hyper 0.13.9",
+ "native-tls",
+ "tokio 0.2.24",
+ "tokio-tls",
 ]
 
 [[package]]
@@ -1224,7 +1308,7 @@ checksum = "78e2d2253d7a17929560fc3adf48c48fc924c94fa4507e037a60e6bc55c0eda6"
 dependencies = [
  "base64 0.9.3",
  "bytes 0.4.12",
- "http",
+ "http 0.1.21",
  "httparse",
  "language-tags",
  "log 0.4.11",
@@ -1283,6 +1367,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itertools"
@@ -1891,6 +1981,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+dependencies = [
+ "pin-project-internal 0.4.27",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
+dependencies = [
+ "pin-project-internal 1.0.4",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.8",
+ "syn 1.0.58",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.8",
+ "syn 1.0.58",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2286,16 +2416,16 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "futures 0.1.30",
- "http",
- "hyper",
- "hyper-tls",
+ "http 0.1.21",
+ "hyper 0.12.35",
+ "hyper-tls 0.3.2",
  "log 0.4.11",
  "mime 0.3.16",
  "mime_guess 2.0.3",
  "native-tls",
  "serde",
  "serde_json",
- "serde_urlencoded",
+ "serde_urlencoded 0.5.5",
  "time",
  "tokio 0.1.22",
  "tokio-executor",
@@ -2304,7 +2434,43 @@ dependencies = [
  "tokio-timer",
  "url 1.7.2",
  "uuid 0.7.4",
- "winreg",
+ "winreg 0.6.2",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.10.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 0.5.6",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http 0.2.3",
+ "http-body 0.3.1",
+ "hyper 0.13.9",
+ "hyper-tls 0.4.3",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log 0.4.11",
+ "mime 0.3.16",
+ "mime_guess 2.0.3",
+ "native-tls",
+ "percent-encoding 2.1.0",
+ "pin-project-lite 0.2.1",
+ "serde",
+ "serde_json",
+ "serde_urlencoded 0.7.0",
+ "tokio 0.2.24",
+ "tokio-tls",
+ "url 2.2.0",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.7.0",
 ]
 
 [[package]]
@@ -2427,8 +2593,9 @@ dependencies = [
  "futures 0.1.30",
  "futures 0.3.9",
  "hmac",
- "http",
- "hyper",
+ "http 0.1.21",
+ "http 0.2.3",
+ "hyper 0.12.35",
  "hyperx",
  "itertools 0.10.0",
  "jobserver",
@@ -2450,7 +2617,7 @@ dependencies = [
  "rand 0.7.3",
  "redis",
  "regex",
- "reqwest",
+ "reqwest 0.10.10",
  "retry",
  "ring",
  "rouille",
@@ -2532,7 +2699,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01173ad274e14fafa534a5e660d950ca1939ccebd3955df987b7df7e4e301108"
 dependencies = [
- "reqwest",
+ "reqwest 0.9.24",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2595,6 +2762,18 @@ dependencies = [
  "itoa",
  "serde",
  "url 1.7.2",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3196,6 +3375,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+dependencies = [
+ "native-tls",
+ "tokio 0.2.24",
+]
+
+[[package]]
 name = "tokio-udp"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3264,7 +3453,7 @@ dependencies = [
  "tower-limit",
  "tower-load-shed",
  "tower-retry",
- "tower-service",
+ "tower-service 0.2.0",
  "tower-timeout",
  "tower-util",
 ]
@@ -3279,7 +3468,7 @@ dependencies = [
  "tokio-executor",
  "tokio-sync",
  "tower-layer",
- "tower-service",
+ "tower-service 0.2.0",
  "tracing",
 ]
 
@@ -3290,7 +3479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73a7632286f78164d65d18fd0e570307acde9362489aa5c8c53e6315cc2bde47"
 dependencies = [
  "futures 0.1.30",
- "tower-service",
+ "tower-service 0.2.0",
 ]
 
 [[package]]
@@ -3300,7 +3489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ddf07e10c07dcc8f41da6de036dc66def1a85b70eb8a385159e3908bb258328"
 dependencies = [
  "futures 0.1.30",
- "tower-service",
+ "tower-service 0.2.0",
 ]
 
 [[package]]
@@ -3313,7 +3502,7 @@ dependencies = [
  "tokio-sync",
  "tokio-timer",
  "tower-layer",
- "tower-service",
+ "tower-service 0.2.0",
  "tracing",
 ]
 
@@ -3325,7 +3514,7 @@ checksum = "04fbaf5bfb63d84204db87b9b2aeec61549613f2bbb8706dcc36f5f3ea8cd769"
 dependencies = [
  "futures 0.1.30",
  "tower-layer",
- "tower-service",
+ "tower-service 0.2.0",
 ]
 
 [[package]]
@@ -3337,7 +3526,7 @@ dependencies = [
  "futures 0.1.30",
  "tokio-timer",
  "tower-layer",
- "tower-service",
+ "tower-service 0.2.0",
 ]
 
 [[package]]
@@ -3350,6 +3539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+
+[[package]]
 name = "tower-timeout"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3358,7 +3553,7 @@ dependencies = [
  "futures 0.1.30",
  "tokio-timer",
  "tower-layer",
- "tower-service",
+ "tower-service 0.2.0",
 ]
 
 [[package]]
@@ -3370,7 +3565,7 @@ dependencies = [
  "futures 0.1.30",
  "tokio-io",
  "tower-layer",
- "tower-service",
+ "tower-service 0.2.0",
 ]
 
 [[package]]
@@ -3404,6 +3599,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project 0.4.27",
+ "tracing",
 ]
 
 [[package]]
@@ -3648,6 +3853,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log 0.4.11",
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,6 +3881,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
  "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -3802,6 +4019,15 @@ name = "winreg"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ futures = "0.1.11"
 futures_03 = { package = "futures", version = "0.3", features = ["compat", "thread-pool"] }
 hmac = { version = "0.10", optional = true }
 http = "0.1"
+http_02 = { package = "http", version = "0.2" }
 hyper = { version = "0.12", optional = true }
 hyperx = { version = "0.12", optional = true }
 jobserver = "0.1"
@@ -58,7 +59,7 @@ percent-encoding = { version = "2", optional = true }
 rand = "0.7"
 redis = { version = "0.17", optional = true }
 regex = "1"
-reqwest = { version = "0.9.11", optional = true }
+reqwest = { version = "0.10", optional = true, features = ["blocking", "json"] }
 retry = "1"
 ring = { version = "0.16", optional = true, features = ["std"] }
 sha-1 = { version = "0.9", optional = true }

--- a/src/bin/sccache-dist/token_check.rs
+++ b/src/bin/sccache-dist/token_check.rs
@@ -77,7 +77,7 @@ const MOZ_USERINFO_ENDPOINT: &str = "https://auth.mozilla.auth0.com/userinfo";
 // Mozilla-specific check by forwarding the token onto the auth0 userinfo endpoint
 pub struct MozillaCheck {
     auth_cache: Mutex<HashMap<String, Instant>>, // token, token_expiry
-    client: reqwest::Client,
+    client: reqwest::blocking::Client,
     required_groups: Vec<String>,
 }
 
@@ -96,7 +96,7 @@ impl MozillaCheck {
     pub fn new(required_groups: Vec<String>) -> Self {
         Self {
             auth_cache: Mutex::new(HashMap::new()),
-            client: reqwest::Client::new(),
+            client: reqwest::blocking::Client::new(),
             required_groups,
         }
     }
@@ -145,22 +145,18 @@ impl MozillaCheck {
         let header = hyperx::header::Authorization(hyperx::header::Bearer {
             token: token.to_owned(),
         });
-        let mut res = self
+        let res = self
             .client
             .get(url.clone())
             .set_header(header)
             .send()
             .context("Failed to make request to mozilla userinfo")?;
+        let status = res.status();
         let res_text = res
             .text()
             .context("Failed to interpret response from mozilla userinfo as string")?;
-        if !res.status().is_success() {
-            bail!(
-                "JWT forwarded to {} returned {}: {}",
-                url,
-                res.status(),
-                res_text
-            )
+        if status.is_success() {
+            bail!("JWT forwarded to {} returned {}: {}", url, status, res_text)
         }
 
         // The API didn't return a HTTP error code, let's check the response
@@ -241,7 +237,7 @@ fn test_auth_verify_check_mozilla_profile() {
 // Don't check a token is valid (it may not even be a JWT) just forward it to
 // an API and check for success
 pub struct ProxyTokenCheck {
-    client: reqwest::Client,
+    client: reqwest::blocking::Client,
     maybe_auth_cache: Option<Mutex<(HashMap<String, Instant>, Duration)>>,
     url: String,
 }
@@ -265,7 +261,7 @@ impl ProxyTokenCheck {
         let maybe_auth_cache: Option<Mutex<(HashMap<String, Instant>, Duration)>> =
             cache_secs.map(|secs| Mutex::new((HashMap::new(), Duration::from_secs(secs))));
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::blocking::Client::new(),
             maybe_auth_cache,
             url,
         }
@@ -330,7 +326,7 @@ impl ClientAuthCheck for ValidJWTCheck {
 
 impl ValidJWTCheck {
     pub fn new(audience: String, issuer: String, jwks_url: &str) -> Result<Self> {
-        let mut res = reqwest::get(jwks_url).context("Failed to make request to JWKs url")?;
+        let res = reqwest::blocking::get(jwks_url).context("Failed to make request to JWKs url")?;
         if !res.status().is_success() {
             bail!("Could not retrieve JWKs, HTTP error: {}", res.status())
         }

--- a/src/dist/client_auth.rs
+++ b/src/dist/client_auth.rs
@@ -286,8 +286,8 @@ mod code_grant_pkce {
             grant_type: GRANT_TYPE_PARAM_VALUE,
             redirect_uri,
         };
-        let client = reqwest::Client::new();
-        let mut res = client.post(token_url).json(&token_request).send()?;
+        let client = reqwest::blocking::Client::new();
+        let res = client.post(token_url).json(&token_request).send()?;
         if !res.status().is_success() {
             bail!(
                 "Sending code to {} failed, HTTP error: {}",

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,7 +29,7 @@ use std::process;
 
 #[cfg(feature = "hyper")]
 #[derive(Debug)]
-pub struct BadHttpStatusError(pub hyper::StatusCode);
+pub struct BadHttpStatusError(pub ::http_02::StatusCode);
 
 #[derive(Debug)]
 pub struct HttpClientError(pub String);

--- a/src/simples3/s3.rs
+++ b/src/simples3/s3.rs
@@ -6,12 +6,13 @@ use std::ascii::AsciiExt;
 use std::fmt;
 
 use crate::simples3::credential::*;
-use futures::{Future, Stream};
+use futures::Future;
+use futures_03::future::{FutureExt, TryFutureExt};
 use hmac::{Hmac, Mac, NewMac};
-use hyper::header::HeaderValue;
-use hyper::Method;
+use http_02::header::HeaderValue;
+use http_02::Method;
 use hyperx::header;
-use reqwest::r#async::{Client, Request};
+use reqwest::{Client, Request};
 use sha1::Sha1;
 
 use crate::errors::*;
@@ -103,6 +104,8 @@ impl Bucket {
         Box::new(
             self.client
                 .execute(request)
+                .boxed()
+                .compat()
                 .fwith_context(move || format!("failed GET: {}", url))
                 .and_then(|res| {
                     if res.status().is_success() {
@@ -110,31 +113,30 @@ impl Bucket {
                             .headers()
                             .get_hyperx::<header::ContentLength>()
                             .map(|header::ContentLength(len)| len);
-                        Ok((res.into_body(), content_length))
+                        Ok((res.bytes(), content_length))
                     } else {
                         Err(BadHttpStatusError(res.status()).into())
                     }
                 })
                 .and_then(|(body, content_length)| {
-                    body.fold(Vec::new(), |mut body, chunk| {
-                        body.extend_from_slice(&chunk);
-                        Ok::<_, reqwest::Error>(body)
-                    })
-                    .fcontext("failed to read HTTP body")
-                    .and_then(move |bytes| {
-                        if let Some(len) = content_length {
-                            if len != bytes.len() as u64 {
-                                bail!(format!(
-                                    "Bad HTTP body size read: {}, expected {}",
-                                    bytes.len(),
-                                    len
-                                ));
-                            } else {
-                                info!("Read {} bytes from {}", bytes.len(), url2);
+                    body.boxed()
+                        .compat()
+                        .fcontext("failed to read HTTP body")
+                        .and_then(move |bytes| {
+                            let bytes: Vec<u8> = bytes.as_ref().to_vec();
+                            if let Some(len) = content_length {
+                                if len != bytes.len() as u64 {
+                                    bail!(format!(
+                                        "Bad HTTP body size read: {}, expected {}",
+                                        bytes.len(),
+                                        len
+                                    ));
+                                } else {
+                                    info!("Read {} bytes from {}", bytes.len(), url2);
+                                }
                             }
-                        }
-                        Ok(bytes)
-                    })
+                            Ok(bytes)
+                        })
                 }),
         )
     }
@@ -189,21 +191,27 @@ impl Bucket {
         );
         *request.body_mut() = Some(content.into());
 
-        Box::new(self.client.execute(request).then(|result| match result {
-            Ok(res) => {
-                if res.status().is_success() {
-                    trace!("PUT succeeded");
-                    Ok(())
-                } else {
-                    trace!("PUT failed with HTTP status: {}", res.status());
-                    Err(BadHttpStatusError(res.status()).into())
-                }
-            }
-            Err(e) => {
-                trace!("PUT failed with error: {:?}", e);
-                Err(e.into())
-            }
-        }))
+        Box::new(
+            self.client
+                .execute(request)
+                .boxed()
+                .compat()
+                .then(|result| match result {
+                    Ok(res) => {
+                        if res.status().is_success() {
+                            trace!("PUT succeeded");
+                            Ok(())
+                        } else {
+                            trace!("PUT failed with HTTP status: {}", res.status());
+                            Err(BadHttpStatusError(res.status()).into())
+                        }
+                    }
+                    Err(e) => {
+                        trace!("PUT failed with error: {:?}", e);
+                        Err(e.into())
+                    }
+                }),
+        )
     }
 
     // http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html

--- a/src/util.rs
+++ b/src/util.rs
@@ -364,7 +364,6 @@ pub use self::http_extension::{HeadersExt, RequestExt};
 
 #[cfg(feature = "hyperx")]
 mod http_extension {
-    use http::header::HeaderValue;
     use std::fmt;
 
     pub trait HeadersExt {
@@ -377,14 +376,14 @@ mod http_extension {
             H: hyperx::header::Header;
     }
 
-    impl HeadersExt for http::HeaderMap {
+    impl HeadersExt for ::http_02::HeaderMap {
         fn set<H>(&mut self, header: H)
         where
             H: hyperx::header::Header + fmt::Display,
         {
             self.insert(
                 H::header_name(),
-                HeaderValue::from_shared(header.to_string().into()).unwrap(),
+                ::http_02::HeaderValue::from_str(header.to_string().as_ref()).unwrap(),
             );
         }
 
@@ -392,7 +391,7 @@ mod http_extension {
         where
             H: hyperx::header::Header,
         {
-            http::HeaderMap::get(self, H::header_name())
+            ::http_02::HeaderMap::get(self, H::header_name())
                 .and_then(|header| H::parse_header(&header.as_bytes().into()).ok())
         }
     }
@@ -410,7 +409,7 @@ mod http_extension {
         {
             self.header(
                 H::header_name(),
-                HeaderValue::from_shared(header.to_string().into()).unwrap(),
+                ::http::HeaderValue::from_shared(header.to_string().into()).unwrap(),
             );
             self
         }
@@ -423,22 +422,9 @@ mod http_extension {
         {
             self.header(
                 H::header_name(),
-                HeaderValue::from_shared(header.to_string().into()).unwrap(),
+                ::http::HeaderValue::from_shared(header.to_string().into()).unwrap(),
             );
             self
-        }
-    }
-
-    #[cfg(feature = "reqwest")]
-    impl RequestExt for ::reqwest::r#async::RequestBuilder {
-        fn set_header<H>(self, header: H) -> Self
-        where
-            H: hyperx::header::Header + fmt::Display,
-        {
-            self.header(
-                H::header_name(),
-                HeaderValue::from_shared(header.to_string().into()).unwrap(),
-            )
         }
     }
 
@@ -450,7 +436,20 @@ mod http_extension {
         {
             self.header(
                 H::header_name(),
-                HeaderValue::from_shared(header.to_string().into()).unwrap(),
+                ::http_02::HeaderValue::from_str(header.to_string().as_ref()).unwrap(),
+            )
+        }
+    }
+
+    #[cfg(feature = "reqwest")]
+    impl RequestExt for ::reqwest::blocking::RequestBuilder {
+        fn set_header<H>(self, header: H) -> Self
+        where
+            H: hyperx::header::Header + fmt::Display,
+        {
+            self.header(
+                H::header_name(),
+                ::http_02::HeaderValue::from_str(header.to_string().as_ref()).unwrap(),
             )
         }
     }

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -449,7 +449,7 @@ impl DistSystem {
     }
 
     fn scheduler_status(&self) -> SchedulerStatusResult {
-        let res = reqwest::get(dist::http::urls::scheduler_status(
+        let res = reqwest::blocking::get(dist::http::urls::scheduler_status(
             &self.scheduler_url().to_url(),
         ))
         .unwrap();
@@ -635,7 +635,8 @@ fn wait_for_http(url: HTTPUrl, interval: Duration, max_wait: Duration) {
     wait_for(
         || {
             //match reqwest::get(url.to_url()) {
-            match net::TcpStream::connect(url.to_url()) {
+            let addrs = url.to_url().socket_addrs(|| None).unwrap();
+            match net::TcpStream::connect(&*addrs) {
                 Ok(_) => Ok(()),
                 Err(e) => Err(e.to_string()),
             }


### PR DESCRIPTION
It's complex to upgrade all crates related to http, but it's easy relatively to upgrade only `reqwest`.