### PR TITLE
[env] CARGO env can't be ignored.

### DIFF
--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1366,7 +1366,7 @@ where
                 env_vars.sort();
                 for &(ref var, ref val) in env_vars.iter() {
                     // CARGO_MAKEFLAGS will have jobserver info which is extremely non-cacheable.
-                    if var.starts_with("CARGO_") && var != "CARGO_MAKEFLAGS" {
+                    if var.eq("CARGO") || (var.starts_with("CARGO_") && var != "CARGO_MAKEFLAGS") {
                         var.hash(&mut HashToDigest { digest: &mut m });
                         m.update(b"=");
                         val.hash(&mut HashToDigest { digest: &mut m });


### PR DESCRIPTION
Until it's last release trybuild embedded the CARGO env.   When we were switching our ci platform the location of CARGO changed.   This resulted in failed tests that could not find the the cargo executable.