### PR TITLE
Support caching Clang invocations with -fprofile-use and -fprofile-instr-use.

### DIFF
--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -122,6 +122,7 @@ ArgData! { pub
     Language(OsString),
     SplitDwarf,
     ProfileGenerate,
+    ClangProfileUse(PathBuf),
     TestCoverage,
     Coverage,
     ExtraHashFile(PathBuf),
@@ -168,6 +169,8 @@ counted_array!(pub static ARGS: [ArgInfo<ArgData>; _] = [
     flag!("-c", DoCompilation),
     take_arg!("-fdiagnostics-color", OsString, Concatenated('='), DiagnosticsColor),
     flag!("-fno-diagnostics-color", NoDiagnosticsColorFlag),
+    flag!("-fno-profile-generate", TooHardFlag),
+    flag!("-fno-profile-use", TooHardFlag),
     flag!("-fno-working-directory", PreprocessorArgumentFlag),
     flag!("-fplugin=libcc1plugin", TooHardFlag),
     flag!("-fprofile-arcs", ProfileGenerate),
@@ -278,6 +281,9 @@ where
                     OsString::from(arg.flag_str().expect("Compilation flag expected"));
             }
             Some(ProfileGenerate) => profile_generate = true,
+            Some(ClangProfileUse(path)) => {
+                extra_hash_files.push(clang::resolve_profile_use_path(path, cwd));
+            }
             Some(TestCoverage) => outputs_gcno = true,
             Some(Coverage) => {
                 outputs_gcno = true;
@@ -337,6 +343,7 @@ where
         let args = match arg.get_data() {
             Some(SplitDwarf)
             | Some(ProfileGenerate)
+            | Some(ClangProfileUse(_))
             | Some(TestCoverage)
             | Some(Coverage)
             | Some(DiagnosticsColor(_))
@@ -380,6 +387,7 @@ where
         let args = match arg.get_data() {
             Some(SplitDwarf)
             | Some(ProfileGenerate)
+            | Some(ClangProfileUse(_))
             | Some(TestCoverage)
             | Some(Coverage)
             | Some(DoCompilation)


### PR DESCRIPTION
This PR adds support for caching Clang invocations with `-fprofile-use` and `-fprofile-instr-use`, something that will be required for supporting [PGOed Rust compiler builds](https://github.com/rust-lang/rust/issues/79562).

The PR *only* implements support for Clang. I have not had time to look into how GCC works (although from a superficial glance it looks like it might be harder to find out which files to hash exactly). Adding support for Rust should be straightforward though.

I added some unit tests and verified that things work locally, but found it hard to write end-to-end tests because of Clang's PGO setup which requires the external `llvm-profdata` tool to generate the `.profdata` file. Let me know if this is something that is required.

In https://github.com/mozilla/sccache/issues/941 I expressed the concern that hashing these rather big `.profdata` files would take a long time. In practice this does not seem to be true. In my local tests compiling LLVM with a full cache took about 50 seconds. Caching the file hashes (so that most of the hashing work could be skipped) only reduced the total build time by a couple of seconds or so.

r? @luser 