### PR TITLE
Cache file hashes

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -212,7 +212,7 @@ where
         pool: &ThreadPool,
     ) -> SFuture<CCompiler<I>> {
         Box::new(
-            Digest::file(executable.clone(), &pool).map(move |digest| CCompiler {
+            Digest::file(executable.clone(), &pool).map(move |(digest, _)| CCompiler {
                 executable,
                 executable_digest: {
                     if let Some(version) = version {


### PR DESCRIPTION
This PR adds a cache for file hashes in the server, as suggested in https://github.com/mozilla/sccache/issues/758. 

The implementation is kind of simplistic (maybe even too much so):

- It does not try to avoid races between multiple threads hashing the same file. If one thread is already hashing file `x` and another thread wants to do the same, it will just go ahead an calculate the hash by itself. Both threads will write the hash to the cache (in the order they finish). This should be a benign race since hashes are always associated with their timestamps. In the worst case, a long-running hash computation overwrites a new entry with an outdated hash. In that case the next request for the file hash would re-do the hashing again.

- The cache is simply kept in a local static variable. Keeping it somewhere else requires lots of additional parameter passing in many places. I'm undecided on whether I think this ugly or an example of good encapsulation `:)`

In my local testing this kind of caching did not make a lot of difference for C/C++ builds. Those seem to be completely dominated by the C preprocessor. It did not get a chance to benchmark this with Rust code yet.

Feedback welcome!

Closes https://github.com/mozilla/sccache/issues/758.

cc @froydnj @luser 