### PR TITLE
Fix clippy warnings with new version of clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         uses: ./.github/actions/rust-toolchain
         with:
           components: ${{ matrix.component }}
+          toolchain: 1.50.0
 
       - name: clippy version
         run: cargo clippy --version

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -47,6 +47,7 @@ fn get_file_mode(file: &fs::File) -> Result<Option<u32>> {
 }
 
 #[cfg(windows)]
+#[allow(clippy::unnecessary_wraps)]
 fn get_file_mode(_file: &fs::File) -> Result<Option<u32>> {
     Ok(None)
 }
@@ -61,6 +62,7 @@ fn set_file_mode(path: &Path, mode: u32) -> Result<()> {
 }
 
 #[cfg(windows)]
+#[allow(clippy::unnecessary_wraps)]
 fn set_file_mode(_path: &Path, _mode: u32) -> Result<()> {
     Ok(())
 }

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -348,7 +348,7 @@ impl GCSCredentialProvider {
             RWMode::ReadWrite => "https://www.googleapis.com/auth/devstorage.read_write",
         };
 
-        Ok(encode(
+        encode(
             &Header {
                 typ: "JWT",
                 alg: "RS256",
@@ -362,7 +362,6 @@ impl GCSCredentialProvider {
             },
             &sa_key.private_key,
         )
-        .unwrap())
     }
 
     fn request_new_token(

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -112,18 +112,17 @@ fn run_server_process() -> Result<ServerStartup> {
 }
 
 #[cfg(not(windows))]
-fn redirect_stderr(f: File) -> Result<()> {
+fn redirect_stderr(f: File) {
     use libc::dup2;
     use std::os::unix::io::IntoRawFd;
     // Ignore errors here.
     unsafe {
         dup2(f.into_raw_fd(), 2);
     }
-    Ok(())
 }
 
 #[cfg(windows)]
-fn redirect_stderr(f: File) -> Result<()> {
+fn redirect_stderr(f: File) {
     use std::os::windows::io::IntoRawHandle;
     use winapi::um::processenv::SetStdHandle;
     use winapi::um::winbase::STD_ERROR_HANDLE;
@@ -131,7 +130,6 @@ fn redirect_stderr(f: File) -> Result<()> {
     unsafe {
         SetStdHandle(STD_ERROR_HANDLE, f.into_raw_handle());
     }
-    Ok(())
 }
 
 /// If `SCCACHE_ERROR_LOG` is set, redirect stderr to it.
@@ -141,7 +139,8 @@ fn redirect_error_log() -> Result<()> {
         _ => return Ok(()),
     };
     let f = OpenOptions::new().create(true).append(true).open(name)?;
-    redirect_stderr(f)
+    redirect_stderr(f);
+    Ok(())
 }
 
 /// Re-execute the current executable as a background server.

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1453,7 +1453,7 @@ LLVM version: 6.0",
                 // wait on cache write future so we don't race with it!
                 f.wait().unwrap();
             }
-            _ => assert!(false, "Unexpected compile result: {:?}", cached),
+            _ => panic!("Unexpected compile result: {:?}", cached),
         }
         assert_eq!(exit_status(0), res.status);
         assert_eq!(COMPILER_STDOUT, res.stdout.as_slice());
@@ -1554,7 +1554,7 @@ LLVM version: 6.0",
                 // wait on cache write future so we don't race with it!
                 f.wait().unwrap();
             }
-            _ => assert!(false, "Unexpected compile result: {:?}", cached),
+            _ => panic!("Unexpected compile result: {:?}", cached),
         }
         assert_eq!(exit_status(0), res.status);
         assert_eq!(COMPILER_STDOUT, res.stdout.as_slice());
@@ -1662,7 +1662,7 @@ LLVM version: 6.0",
                 // wait on cache write future so we don't race with it!
                 f.wait().unwrap();
             }
-            _ => assert!(false, "Unexpected compile result: {:?}", cached),
+            _ => panic!("Unexpected compile result: {:?}", cached),
         }
 
         assert_eq!(exit_status(0), res.status);
@@ -1744,7 +1744,7 @@ LLVM version: 6.0",
                 // wait on cache write future so we don't race with it!
                 f.wait().unwrap();
             }
-            _ => assert!(false, "Unexpected compile result: {:?}", cached),
+            _ => panic!("Unexpected compile result: {:?}", cached),
         }
         assert_eq!(exit_status(0), res.status);
         assert_eq!(COMPILER_STDOUT, res.stdout.as_slice());
@@ -1771,7 +1771,7 @@ LLVM version: 6.0",
                 // wait on cache write future so we don't race with it!
                 f.wait().unwrap();
             }
-            _ => assert!(false, "Unexpected compile result: {:?}", cached),
+            _ => panic!("Unexpected compile result: {:?}", cached),
         }
         assert_eq!(exit_status(0), res.status);
         assert_eq!(COMPILER_STDOUT, res.stdout.as_slice());
@@ -1932,7 +1932,7 @@ LLVM version: 6.0",
                     // wait on cache write future so we don't race with it!
                     f.wait().unwrap();
                 }
-                _ => assert!(false, "Unexpected compile result: {:?}", cached),
+                _ => panic!("Unexpected compile result: {:?}", cached),
             }
             assert_eq!(exit_status(0), res.status);
             assert_eq!(COMPILER_STDOUT, res.stdout.as_slice());

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -3063,6 +3063,7 @@ c:/foo/bar.rs:
             .key
     }
 
+    #[allow(clippy::unnecessary_wraps)]
     fn nothing(_path: &Path) -> Result<()> {
         Ok(())
     }


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants
https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_wraps

Partially based upon patch from Michael Woerister <michaelwoerister@posteo> in #952.