### PR TITLE
MSVC: add /Brepro to the list of known args

### DIFF
--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -258,6 +258,7 @@ macro_rules! msvc_args {
 // https://docs.microsoft.com/en-us/cpp/build/reference/compiler-options-listed-alphabetically?view=vs-2019
 msvc_args!(static ARGS: [ArgInfo<ArgData>; _] = [
     msvc_flag!("?", SuppressCompilation),
+    msvc_flag!("Brepro", PassThrough),
     msvc_flag!("C", PassThrough), // Ignored unless a preprocess-only flag is specified.
     msvc_take_arg!("D", OsString, CanBeSeparated, PreprocessorArgument),
     msvc_flag!("E", SuppressCompilation),


### PR DESCRIPTION
`/Brepro` is a hidden flag of `cl.exe` that can be used to generate reproducible binaries. More information can be found here: https://blog.conan.io/2019/09/02/Deterministic-builds-with-C-C++.html .

sccache currently does not understand this flag, and thus fails to cache builds that use them. One noticable project that "forces" the usage of `/Brepro` is the LLVM project: https://github.com/llvm/llvm-project/blob/9d474be11d71b5ae13490d3d8bd66150765560e3/llvm/cmake/modules/HandleLLVMOptions.cmake#L489-L516

It should be used only as a linker flag, but MS cl.exe does understand this flag, and pass it to the linker if calling it. I think sccache should just be able to support this, in case some projects use it like LLVM.