### PR TITLE
Fix warnings with latest Rust stable

### DIFF
--- a/src/bin/sccache-dist/main.rs
+++ b/src/bin/sccache-dist/main.rs
@@ -433,7 +433,7 @@ fn init_logging() {
     if env::var("RUST_LOG").is_ok() {
         match env_logger::try_init() {
             Ok(_) => (),
-            Err(e) => panic!(format!("Failed to initalize logging: {:?}", e)),
+            Err(e) => panic!("Failed to initalize logging: {:?}", e),
         }
     }
 }

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -590,7 +590,7 @@ fn test_gcs_credential_provider() {
                     .timestamp(),
             );
         })
-        .map_err(move |err| panic!(err.to_string()));
+        .map_err(|err| panic!("{}", err));
 
     server.with_graceful_shutdown(cred_fut);
 }

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1131,7 +1131,7 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
                 cannot_cache!(concat!("missing ", stringify!($x)));
             };
         };
-    };
+    }
     // We don't actually save the input value, but there needs to be one.
     req!(input);
     drop(input);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ fn init_logging() {
     if env::var(LOGGING_ENV).is_ok() {
         match env_logger::Builder::from_env(LOGGING_ENV).try_init() {
             Ok(_) => (),
-            Err(e) => panic!(format!("Failed to initalize logging: {:?}", e)),
+            Err(e) => panic!("Failed to initalize logging: {:?}", e),
         }
     }
 }


### PR DESCRIPTION
Out of the two warnings fixed, the latter is more interesting as it fixes a warning that's going to be phased out in Rust 2021 (calling `panic` with something else than a format string literal).