### PR TITLE
Simplify Clippy lint setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
             cargo_cmd: fmt -- --check
             os: ubuntu-latest
           - component: clippy
-            cargo_cmd: clippy --locked --all-targets -- -D warnings -A clippy::unknown-clippy-lints -A clippy::type_complexity -A clippy::new-without-default
+            cargo_cmd: clippy --locked --all-targets -- -D warnings
     steps:
       - name: Clone repository
         uses: actions/checkout@v1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #![deny(rust_2018_idioms)]
+#![allow(unknown_lints)]
+#![allow(clippy::type_complexity, clippy::new_without_default)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #![deny(rust_2018_idioms)]
-#![allow(unknown_lints)]
 #![allow(clippy::type_complexity, clippy::new_without_default)]
 #![recursion_limit = "256"]
 


### PR DESCRIPTION
The `unknown_clippy_lints` is deprecated and has been integrated into
the rustc `unknown_lints` lint, see
https://rust-lang.github.io/rust-clippy/master/#unknown_clippy_lints.

For the other two lints that are currently allowed, this moves it to the
source code so it's easier to see what's expected to work and be warned
against and what's not, without having to look at how exactly the
current CI is set up. It's common to simply run `cargo clippy` when
working on the project (similarly to `cargo fmt`) so this optimizes for
that scenario.

Some other repos that use this:
- https://github.com/rust-lang/cargo/blob/master/src/cargo/lib.rs
- https://github.com/rust-lang/rls/blob/master/rls/src/lib.rs
- https://github.com/serde-rs/json/blob/master/src/lib.rs