### PR TITLE
Make integration tests more environment-agnostic

### DIFF
--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -2,7 +2,6 @@
 use sccache::config::HTTPUrl;
 use sccache::dist::{self, SchedulerStatusResult, ServerId};
 use sccache::server::ServerInfo;
-#[cfg(feature = "dist-server")]
 use std::env;
 use std::fs;
 use std::io::Write;
@@ -109,11 +108,16 @@ pub fn write_source(path: &Path, filename: &str, contents: &str) {
     f.write_all(contents.as_bytes()).unwrap();
 }
 
-// Override any environment variables that could adversely affect test execution.
+// Prune any environment variables that could adversely affect test execution.
 pub fn sccache_command() -> Command {
+    use sccache::util::OsStrExt;
+
     let mut cmd = Command::new(assert_cmd::cargo::cargo_bin("sccache"));
-    cmd.env("SCCACHE_CONF", "nonexistent_conf_path")
-        .env("SCCACHE_CACHED_CONF", "nonexistent_cached_conf_path");
+    for (var, _) in env::vars_os() {
+        if var.starts_with("SCCACHE_") {
+            cmd.env_remove(var);
+        }
+    }
     cmd
 }
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -150,7 +150,7 @@ fn test_noncacheable_stats(compiler: Compiler, tempdir: &Path) {
     copy_to_tempdir(&[INPUT], tempdir);
 
     trace!("compile");
-    Command::new(assert_cmd::cargo::cargo_bin("sccache"))
+    sccache_command()
         .arg(&exe)
         .arg("-E")
         .arg(INPUT)


### PR DESCRIPTION
Discovered when we were running unit tests in our CI environment with `CARGO_INCREMENTAL` set to `0` (https://github.com/paritytech/sccache/issues/23).

It seems this relies on the incremental compilation being enabled by default, so this change explicitly disables it to make the test more robust/independent of the environment. The test crate compiled is effectively empty so incremental comp. should be negligible in cost (or even cheaper - less overhead to setup).