### PR TITLE
Add SCCACHE_C_CUSTOM_CACHE_BUSTER to CACHED_ENV_VARS

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,19 @@ the container for you - you'll need to do that yourself.
 
 ---
 
+Separating caches between invocations
+-------------------------------------
+
+In situations where several different compilation invocations
+should not reuse the cached results from each other,
+one can set `SCCACHE_C_CUSTOM_CACHE_BUSTER` to a unique value
+that'll be mixed into the hash.
+`MACOSX_DEPLOYMENT_TARGET` and `IPHONEOS_DEPLOYMENT_TARGET` variables
+already exhibit such reuse-suppression behaviour.
+There are currently no such variables for compiling Rust.
+
+---
+
 Overwriting the cache
 ---------------------
 

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -638,6 +638,11 @@ pub const CACHE_VERSION: &[u8] = b"10";
 lazy_static! {
     /// Environment variables that are factored into the cache key.
     static ref CACHED_ENV_VARS: HashSet<&'static OsStr> = [
+        // SCCACHE_C_CUSTOM_CACHE_BUSTER has no particular meaning behind it,
+        // serving as a way for the user to factor custom data into the hash.
+        // One can set it to different values for different invocations
+        // to prevent cache reuse between them.
+        "SCCACHE_C_CUSTOM_CACHE_BUSTER",
         "MACOSX_DEPLOYMENT_TARGET",
         "IPHONEOS_DEPLOYMENT_TARGET",
     ].iter().map(OsStr::new).collect();


### PR DESCRIPTION
I needed a way to make hashes CWD-dependent, and it feels ugly to use other variables names for that purpose.