### PR TITLE
Add support for NVCC ccbin argument

### DIFF
--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -184,6 +184,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("-Xnvlink", OsString, CanBeSeparated('='), PassThrough),
     take_arg!("-Xptxas", OsString, CanBeSeparated('='), PassThrough),
     take_arg!("-arch", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-ccbin", OsString, CanBeSeparated('='), PassThrough),
     take_arg!("-code", OsString, CanBeSeparated('='), PassThrough),
     flag!("-dc", DoCompilation),
     flag!("-expt-extended-lambda", PreprocessorArgumentFlag),

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -118,6 +118,7 @@ impl CCompilerImpl for NVCC {
         //NVCC only supports `-E` when it comes after preprocessor
         //and common flags.
         cmd.arg("-E")
+            .arg("-D__FILE__=\"empty\"")
             .arg("-Xcompiler=-P")
             .env_clear()
             .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))


### PR DESCRIPTION
The "[ccbin](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#file-and-path-specifications-compiler-bindir)" argument is used to control the "host" compiler that is used by NVCC, which is useful because NVCC only supports certain versions of the host compiler (collected [here](https://gist.github.com/ax3l/9489132#nvcc)). This argument is used by CMake when the `CMAKE_CUDA_HOST_COMPILER` [parameter](https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_HOST_COMPILER.html) is set (or alternatively the `CUDAHOSTCXX` environment variable)