### PR TITLE
Fix OAuth token format

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,12 @@ Set `SCCACHE_MEMCACHED` to a [Memcached](https://memcached.org/) url in format `
 
 ### Google Cloud Storage
 To use [Google Cloud Storage](https://cloud.google.com/storage/), you need to set the `SCCACHE_GCS_BUCKET` environment variable to the name of the GCS bucket.
-If you're using authentication, either set `SCCACHE_GCS_KEY_PATH` to the location of your JSON service account credentials or `SCCACHE_GCS_CREDENTIALS_URL` with
-a URL that returns the oauth token.
+
+If you're using authentication, either:
+- Set `SCCACHE_GCS_KEY_PATH` to the location of your JSON service account credentials
+- (Deprecated) Set `SCCACHE_GCS_CREDENTIALS_URL` to a URL returning an OAuth token in non-standard `{"accessToken": "...", "expireTime": "..."}` format.
+- Set `SCCACHE_GCS_OAUTH_URL` to a URL returning an OAuth token. If you are running on a Google Cloud instance, this is of the form `http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/${YOUR_SERVICE_ACCOUNT}/token`
+
 By default, SCCACHE on GCS will be read-only. To change this, set `SCCACHE_GCS_RW_MODE` to either `READ_ONLY` or `READ_WRITE`.
 
 ### Azure

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -304,12 +304,13 @@ pub fn storage_from_config(config: &Config, pool: &ThreadPool) -> Arc<dyn Storag
             CacheType::GCS(config::GCSCacheConfig {
                 ref bucket,
                 ref cred_path,
-                ref url,
+                ref deprecated_url,
+                ref oauth_url,
                 rw_mode,
             }) => {
                 debug!(
-                    "Trying GCS bucket({}, {:?}, {:?}, {:?})",
-                    bucket, cred_path, url, rw_mode
+                    "Trying GCS bucket({}, {:?}, {:?}, {:?}, {:?})",
+                    bucket, cred_path, deprecated_url, oauth_url, rw_mode
                 );
                 #[cfg(feature = "gcs")]
                 {
@@ -336,8 +337,10 @@ pub fn storage_from_config(config: &Config, pool: &ThreadPool) -> Arc<dyn Storag
                             service_account_key_res
                                 .ok()
                                 .map(ServiceAccountInfo::AccountKey)
-                        } else if let Some(ref url) = *url {
-                            Some(ServiceAccountInfo::URL(url.clone()))
+                        } else if let Some(ref url) = *deprecated_url {
+                            Some(ServiceAccountInfo::DeprecatedURL(url.clone()))
+                        } else if let Some(ref url) = *oauth_url {
+                            Some(ServiceAccountInfo::OAuthURL(url.clone()))
                         } else {
                             warn!(
                             "No SCCACHE_GCS_KEY_PATH specified-- no authentication will be used."

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -510,7 +510,7 @@ impl GCSCredentialProvider {
                     self.request_new_token_from_tcauth(url, client)
                 }
                 ServiceAccountInfo::OAuthURL(ref url) => {
-                    self.request_new_token_from_tcauth(url, client)
+                    self.request_new_token_from_oauth(url, client)
                 }
             };
             *future_opt = Some(credentials.shared());

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -464,6 +464,7 @@ impl GCSCredentialProvider {
         Box::new(
             client
                 .get(url)
+                .header("Metadata-Flavor", "Google")
                 .send()
                 .map_err(Into::into)
                 .and_then(move |res| {

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -176,7 +176,8 @@ pub struct GCSCredentialProvider {
 /// ServiceAccountInfo either contains a URL to fetch the oauth token
 /// or the service account key
 pub enum ServiceAccountInfo {
-    URL(String),
+    DeprecatedURL(String),
+    OAuthURL(String),
     AccountKey(ServiceAccountKey),
 }
 
@@ -258,11 +259,18 @@ struct TokenMsg {
 
 /// AuthResponse represents the json response body from taskcluster-auth.gcsCredentials endpoint
 #[derive(Deserialize)]
-struct AuthResponse {
+struct DeprecatedAuthResponse {
     #[serde(rename = "accessToken")]
     access_token: String,
     #[serde(rename = "expireTime")]
     expire_time: String,
+}
+
+/// AuthResponse represents the json response body from taskcluster-auth.gcsCredentials endpoint
+#[derive(Deserialize)]
+struct OAuthResponse {
+    access_token: String,
+    expires_in: i64,
 }
 
 /// RWMode describes whether or not to attempt cache writes.
@@ -443,10 +451,42 @@ impl GCSCredentialProvider {
                 })
                 .and_then(move |body| {
                     let body_str = String::from_utf8(body)?;
-                    let resp: AuthResponse = serde_json::from_str(&body_str)?;
+                    let resp: DeprecatedAuthResponse = serde_json::from_str(&body_str)?;
                     Ok(GCSCredential {
                         token: resp.access_token,
                         expiration_time: resp.expire_time.parse()?,
+                    })
+                }),
+        )
+    }
+
+    fn request_new_token_from_oauth(&self, url: &str, client: &Client) -> SFuture<GCSCredential> {
+        Box::new(
+            client
+                .get(url)
+                .send()
+                .map_err(Into::into)
+                .and_then(move |res| {
+                    if res.status().is_success() {
+                        Ok(res.into_body())
+                    } else {
+                        Err(BadHttpStatusError(res.status()).into())
+                    }
+                })
+                .and_then(move |body| {
+                    body.fold(Vec::new(), |mut body, chunk| {
+                        body.extend_from_slice(&chunk);
+                        Ok::<_, reqwest::Error>(body)
+                    })
+                    .fcontext("failed to read HTTP body")
+                })
+                .and_then(move |body| {
+                    let body_str = String::from_utf8(body)?;
+                    let resp: OAuthResponse = serde_json::from_str(&body_str)?;
+                    Ok(GCSCredential {
+                        token: resp.access_token,
+                        expiration_time: chrono::offset::Utc::now()
+                            + chrono::Duration::seconds(resp.expires_in),
                     })
                 }),
         )
@@ -466,7 +506,12 @@ impl GCSCredentialProvider {
                 ServiceAccountInfo::AccountKey(ref sa_key) => {
                     self.request_new_token(sa_key, client)
                 }
-                ServiceAccountInfo::URL(ref url) => self.request_new_token_from_tcauth(url, client),
+                ServiceAccountInfo::DeprecatedURL(ref url) => {
+                    self.request_new_token_from_tcauth(url, client)
+                }
+                ServiceAccountInfo::OAuthURL(ref url) => {
+                    self.request_new_token_from_tcauth(url, client)
+                }
             };
             *future_opt = Some(credentials.shared());
         };
@@ -574,7 +619,7 @@ fn test_gcs_credential_provider() {
 
     let credential_provider = GCSCredentialProvider::new(
         RWMode::ReadWrite,
-        ServiceAccountInfo::URL("http://127.0.0.1:3000/".to_string()),
+        ServiceAccountInfo::DeprecatedURL("http://127.0.0.1:3000/".to_string()),
     );
 
     let client = Client::new();
@@ -589,6 +634,38 @@ fn test_gcs_credential_provider() {
                     .unwrap()
                     .timestamp(),
             );
+        })
+        .map_err(move |err| panic!(err.to_string()));
+
+    server.with_graceful_shutdown(cred_fut);
+}
+
+#[test]
+fn test_gcs_oauth_provider() {
+    const EXPIRE_TIME: i64 = 600;
+    let addr = ([127, 0, 0, 1], 3001).into();
+    let make_service = || {
+        hyper::service::service_fn_ok(|_| {
+            let token = serde_json::json!({
+                "access_token": "1234567890",
+                "expires_in": EXPIRE_TIME,
+            });
+            hyper::Response::new(hyper::Body::from(token.to_string()))
+        })
+    };
+
+    let server = hyper::Server::bind(&addr).serve(make_service);
+
+    let credential_provider = GCSCredentialProvider::new(
+        RWMode::ReadWrite,
+        ServiceAccountInfo::OAuthURL("http://127.0.0.1:3001/".to_string()),
+    );
+
+    let client = Client::new();
+    let cred_fut = credential_provider
+        .credentials(&client)
+        .map(move |credential| {
+            assert_eq!(credential.token, "1234567890");
         })
         .map_err(move |err| panic!(err.to_string()));
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -491,7 +491,7 @@ fn config_from_env() -> EnvConfig {
         let cred_path = env::var_os("SCCACHE_GCS_KEY_PATH").map(PathBuf::from);
 
         if oauth_url.is_some() && cred_path.is_some() {
-            warn!("Both SCCACHE_GCS_CREDENTIALS_URL and SCCACHE_GCS_KEY_PATH are set");
+            warn!("Both SCCACHE_GCS_OAUTH_URL and SCCACHE_GCS_KEY_PATH are set");
             warn!("You should set only one of them!");
             warn!("SCCACHE_GCS_KEY_PATH will take precedence");
         }


### PR DESCRIPTION
The current code expects SCCACHE_GCS_CREDENTIALS_URL to return an OAuth token in a non-standard format

```json
{"accessToken": "...", "expireTime": "2000-01-01T00:00:00Z"}
```

The standard format, which is returned by the Google Cloud auth endpoint, looks like:

```json
{"access_token": "...", "expires_in": 123}
```

This PR deprecates the non-standard format and adds a new environment variable option SCCACHE_GCS_OAUTH_URL. By conforming to the standard, it is possible to use the built-in OAuth endpoint that is available on every Google Cloud instance

    http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/${YOUR_SERVICE_ACCOUNT}/token

Fixes #870