### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ By default, `sccache` builds with support for all storage backends, but individu
 
 ### Building portable binaries
 
-When building with the `gcs` feature, `sccache` will depend on OpenSSL, which can be an annoyance if you want to distribute portable binaries. It is possible to statically link against OpenSSL using the `openssl/vendored` feature.
+When building with the `dist-server` feature, `sccache` will depend on OpenSSL, which can be an annoyance if you want to distribute portable binaries. It is possible to statically link against OpenSSL using the `openssl/vendored` feature.
 
 #### Linux
 


### PR DESCRIPTION
It seems that the `gcs` feature doesn't depend on OpenSSL whereas `dist-server` still does, so update the README accordingly.