### PR TITLE
ci: Use Ubuntu 18.04 as base image for CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,17 +41,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             rustc: 1.43.0 # Oldest supported version, keep in sync with README.md
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             rustc: 1.43.0
             extra_desc: dist-server
             extra_args: --no-default-features --features=dist-tests test_dist_ -- --test-threads 1
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             rustc: stable
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             rustc: beta
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             rustc: nightly
             allow_failure: true
             extra_args: --features=unstable


### PR DESCRIPTION
Fixes the dist test CI failures; see #1002 where this came up.

Some notes copied over from https://github.com/paritytech/sccache/pull/74:
> We've started to hit the following error during our dist tests in the CI (https://github.com/paritytech/sccache/pull/71#issuecomment-832632351):
> ```
> /sccache-dist: error while loading shared libraries: libssl.so.1.0.0: cannot open shared object file: No such file or directory
> ```

> My hypothesis is that the binary is built in the GHA Ubuntu 16.04 environment with some older ssl packages/setup but when the binary is copied over to a Ubuntu 18.04-based Docker image, there is no `libssl.so.1.0.0` linking fallback and only
> ```
> /usr/lib/x86_64-linux-gnu/libssl.so.1.1
> /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1
> ```
> are available. I did not confirm this but bumping the base image seems to do the trick.