### PR TITLE
fix Date header

### DIFF
--- a/src/simples3/s3.rs
+++ b/src/simples3/s3.rs
@@ -15,7 +15,7 @@ use reqwest::r#async::{Client, Request};
 use sha1::Sha1;
 
 use crate::errors::*;
-use crate::util::HeadersExt;
+use crate::util::{DateTimeExt, HeadersExt};
 
 #[derive(Debug, Copy, Clone)]
 #[allow(dead_code)]
@@ -88,7 +88,7 @@ impl Bucket {
                 canonical_headers
                     .push_str(format!("{}:{}\n", "x-amz-security-token", token).as_ref());
             }
-            let date = chrono::offset::Utc::now().to_rfc2822();
+            let date = chrono::offset::Utc::now().to_rfc7231();
             let auth = self.auth("GET", &date, key, "", &canonical_headers, "", creds);
             request.headers_mut().insert(
                 "Date",
@@ -145,7 +145,7 @@ impl Bucket {
         let mut request = Request::new(Method::PUT, url.parse().unwrap());
 
         let content_type = "application/octet-stream";
-        let date = chrono::offset::Utc::now().to_rfc2822();
+        let date = chrono::offset::Utc::now().to_rfc7231();
         let mut canonical_headers = String::new();
         let token = creds.token().as_ref().map(|s| s.as_str());
         // Keep the list of header values sorted!

--- a/src/util.rs
+++ b/src/util.rs
@@ -461,8 +461,8 @@ pub trait DateTimeExt {
 }
 
 impl<Tz: chrono::TimeZone> DateTimeExt for chrono::DateTime<Tz>
-    where
-        Tz::Offset: core::fmt::Display,
+where
+    Tz::Offset: core::fmt::Display,
 {
     fn to_rfc7231(&self) -> String {
         self.naive_utc().format("%a, %d %b %Y %T GMT").to_string()
@@ -560,6 +560,8 @@ pub fn daemonize() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::OsStrExt;
+    use crate::util::DateTimeExt;
+    use chrono::{DateTime, NaiveDateTime, Utc};
     use std::ffi::{OsStr, OsString};
 
     #[test]
@@ -587,5 +589,12 @@ mod tests {
         assert_eq!(a.split_prefix("foo"), Some(OsString::from("")));
         assert_eq!(a.split_prefix("foo2"), None);
         assert_eq!(a.split_prefix("b"), None);
+    }
+
+    #[test]
+    fn rfc7231_format() {
+        let time = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
+
+        assert_eq!(time.to_rfc7231(), "Thu, 01 Jan 1970 00:00:00 GMT");
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -456,6 +456,19 @@ mod http_extension {
     }
 }
 
+pub trait DateTimeExt {
+    fn to_rfc7231(&self) -> String;
+}
+
+impl<Tz: chrono::TimeZone> DateTimeExt for chrono::DateTime<Tz>
+    where
+        Tz::Offset: core::fmt::Display,
+{
+    fn to_rfc7231(&self) -> String {
+        self.naive_utc().format("%a, %d %b %Y %T GMT").to_string()
+    }
+}
+
 /// Pipe `cmd`'s stdio to `/dev/null`, unless a specific env var is set.
 #[cfg(not(windows))]
 pub fn daemonize() -> Result<()> {


### PR DESCRIPTION
The `Date` header in s3 module doesn't obey the RFC7231 definition.
Causing s3-compatible server refuses sccache's request.

original request:
```
GET /0/1/2/012620f0a29db1fa159c8471bb82f9c25cad332cfffa5f680f7bb0cfd9c30e62 HTTP/1.1
date: Thu, 29 Jul 2021 06:56:44 +0000
authorization: AWS **RETRACTED**
user-agent: reqwest/0.9.24
accept: */*
accept-encoding: gzip
host: **RETRACTED**.oss-accelerate.aliyuncs.com
```
server response:
```
HTTP/1.1 403 Forbidden
Server: AliyunOSS
Date: Thu, 29 Jul 2021 06:56:44 GMT
Content-Type: application/xml
Content-Length: 252
Connection: keep-alive
x-amz-request-id: **RETRACTED**
x-oss-server-time: 0

<?xml version="1.0" encoding="UTF-8"?>
<Error>
  <Code>AccessDenied</Code>
  <Message>OSS authentication requires a valid Date.</Message>
  <RequestId>6102512CBB04C5A3079D59B5</RequestId>
  <HostId>sccache.oss-accelerate.aliyuncs.com</HostId>
</Error>
```

patched request:
```
GET /c/c/6/cc65e6de3e04ef4f9eaae65e71fbba04019c78792364467217248f1b06bc3e71 HTTP/1.1
date: Thu, 29 Jul 2021 07:28:02 GMT
authorization: AWS **RETRACTED**
user-agent: reqwest/0.9.24
accept: */*
accept-encoding: gzip
host: **RETRACTED**.oss-accelerate.aliyuncs.com
```