### PR TITLE
Update CI Rust/Ubuntu versions and address build warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,17 +41,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             rustc: 1.43.0 # Oldest supported version, keep in sync with README.md
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             rustc: 1.43.0
             extra_desc: dist-server
             extra_args: --no-default-features --features=dist-tests test_dist_ -- --test-threads 1
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             rustc: stable
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             rustc: beta
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             rustc: nightly
             allow_failure: true
             extra_args: --features=unstable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
             cargo_cmd: fmt -- --check
             os: ubuntu-latest
           - component: clippy
-            cargo_cmd: clippy --locked --all-targets -- -D warnings -A clippy::unknown-clippy-lints -A clippy::type_complexity -A clippy::new-without-default
+            cargo_cmd: clippy --locked --all-targets -- -D warnings -A unknown-lints -A clippy::type_complexity -A clippy::new-without-default
     steps:
       - name: Clone repository
         uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: ./.github/actions/rust-toolchain
         with:
           components: ${{ matrix.component }}
-          toolchain: 1.50.0
+          toolchain: 1.54.0
 
       - name: clippy version
         run: cargo clippy --version

--- a/src/azure/blobstore.rs
+++ b/src/azure/blobstore.rs
@@ -266,7 +266,7 @@ fn compute_auth_header(
         format!(
             "SharedKey {}:{}",
             creds.azure_account_name(),
-            signature(&string_to_sign, &account_key)
+            signature(&string_to_sign, account_key)
         )
     })
 }
@@ -332,8 +332,8 @@ mod test {
 
         let container_name = "sccache";
         let creds = AzureCredentials::new(
-            &blob_endpoint,
-            &client_name,
+            blob_endpoint,
+            client_name,
             client_key,
             container_name.to_string(),
         );

--- a/src/azure/credentials.rs
+++ b/src/azure/credentials.rs
@@ -165,7 +165,7 @@ mod test {
     fn test_parse_connection_string() {
         let conn = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
 
-        let creds = parse_connection_string(&conn, "container".to_string()).unwrap();
+        let creds = parse_connection_string(conn, "container".to_string()).unwrap();
         assert_eq!(
             "http://127.0.0.1:10000/devstoreaccount1/",
             creds.azure_blob_endpoint()
@@ -179,7 +179,7 @@ mod test {
     fn test_parse_connection_string_without_account_key() {
         let conn = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
 
-        let creds = parse_connection_string(&conn, "container".to_string()).unwrap();
+        let creds = parse_connection_string(conn, "container".to_string()).unwrap();
         assert_eq!(
             "http://127.0.0.1:10000/devstoreaccount1/",
             creds.azure_blob_endpoint()
@@ -192,7 +192,7 @@ mod test {
     #[test]
     fn test_conn_str_with_endpoint_suffix_only() {
         let conn = "DefaultEndpointsProtocol=https;AccountName=foo;EndpointSuffix=core.windows.net;AccountKey=bar;";
-        let creds = parse_connection_string(&conn, "container".to_string()).unwrap();
+        let creds = parse_connection_string(conn, "container".to_string()).unwrap();
 
         assert_eq!(
             "https://foo.blob.core.windows.net/",

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -337,7 +337,7 @@ pub fn storage_from_config(config: &Config, pool: &ThreadPool) -> Arc<dyn Storag
                                 .ok()
                                 .map(ServiceAccountInfo::AccountKey)
                         } else if let Some(ref url) = *url {
-                            Some(ServiceAccountInfo::URL(url.clone()))
+                            Some(ServiceAccountInfo::Url(url.clone()))
                         } else {
                             warn!(
                             "No SCCACHE_GCS_KEY_PATH specified-- no authentication will be used."
@@ -365,7 +365,7 @@ pub fn storage_from_config(config: &Config, pool: &ThreadPool) -> Arc<dyn Storag
             CacheType::Memcached(config::MemcachedCacheConfig { ref url }) => {
                 debug!("Trying Memcached({})", url);
                 #[cfg(feature = "memcached")]
-                match MemcachedCache::new(&url, pool) {
+                match MemcachedCache::new(url, pool) {
                     Ok(s) => {
                         trace!("Using Memcached: {}", url);
                         return Arc::new(s);
@@ -376,7 +376,7 @@ pub fn storage_from_config(config: &Config, pool: &ThreadPool) -> Arc<dyn Storag
             CacheType::Redis(config::RedisCacheConfig { ref url }) => {
                 debug!("Trying Redis({})", url);
                 #[cfg(feature = "redis")]
-                match RedisCache::new(&url) {
+                match RedisCache::new(url) {
                     Ok(s) => {
                         trace!("Using Redis: {}", url);
                         return Arc::new(s);

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -176,7 +176,7 @@ pub struct GCSCredentialProvider {
 /// ServiceAccountInfo either contains a URL to fetch the oauth token
 /// or the service account key
 pub enum ServiceAccountInfo {
-    URL(String),
+    Url(String),
     AccountKey(ServiceAccountKey),
 }
 
@@ -466,7 +466,7 @@ impl GCSCredentialProvider {
                 ServiceAccountInfo::AccountKey(ref sa_key) => {
                     self.request_new_token(sa_key, client)
                 }
-                ServiceAccountInfo::URL(ref url) => self.request_new_token_from_tcauth(url, client),
+                ServiceAccountInfo::Url(ref url) => self.request_new_token_from_tcauth(url, client),
             };
             *future_opt = Some(credentials.shared());
         };
@@ -512,7 +512,7 @@ impl Storage for GCSCache {
     fn get(&self, key: &str) -> SFuture<Cache> {
         Box::new(
             self.bucket
-                .get(&key, &self.credential_provider)
+                .get(key, &self.credential_provider)
                 .then(|result| match result {
                     Ok(data) => {
                         let hit = CacheRead::from(io::Cursor::new(data))?;
@@ -538,7 +538,7 @@ impl Storage for GCSCache {
         };
         let bucket = self.bucket.clone();
         let response = bucket
-            .put(&key, data, &self.credential_provider)
+            .put(key, data, &self.credential_provider)
             .fcontext("failed to put cache entry in GCS");
 
         Box::new(response.map(move |_| start.elapsed()))
@@ -574,7 +574,7 @@ fn test_gcs_credential_provider() {
 
     let credential_provider = GCSCredentialProvider::new(
         RWMode::ReadWrite,
-        ServiceAccountInfo::URL("http://127.0.0.1:3000/".to_string()),
+        ServiceAccountInfo::Url("http://127.0.0.1:3000/".to_string()),
     );
 
     let client = Client::new();
@@ -590,7 +590,7 @@ fn test_gcs_credential_provider() {
                     .timestamp(),
             );
         })
-        .map_err(move |err| panic!(err.to_string()));
+        .map_err(move |err| panic!("{}", err.to_string()));
 
     server.with_graceful_shutdown(cred_fut);
 }

--- a/src/cache/memcached.rs
+++ b/src/cache/memcached.rs
@@ -71,7 +71,7 @@ impl Storage for MemcachedCache {
         let key = key.to_owned();
         let me = self.clone();
         Box::new(self.pool.spawn_fn(move || {
-            me.exec(|c| c.get(&key.as_bytes()))
+            me.exec(|c| c.get(key.as_bytes()))
                 .map(|(d, _)| CacheRead::from(Cursor::new(d)).map(Cache::Hit))
                 .unwrap_or(Ok(Cache::Miss))
         }))
@@ -83,7 +83,7 @@ impl Storage for MemcachedCache {
         Box::new(self.pool.spawn_fn(move || {
             let start = Instant::now();
             let d = entry.finish()?;
-            me.exec(|c| c.set_noreply(&key.as_bytes(), &d, 0, 0))?;
+            me.exec(|c| c.set_noreply(key.as_bytes(), &d, 0, 0))?;
             Ok(start.elapsed())
         }))
     }

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -102,7 +102,7 @@ impl Storage for S3Cache {
     }
 
     fn put(&self, key: &str, entry: CacheWrite) -> SFuture<Duration> {
-        let key = self.normalize_key(&key);
+        let key = self.normalize_key(key);
         let start = Instant::now();
         let data = match entry.finish() {
             Ok(data) => data,

--- a/src/compiler/args.rs
+++ b/src/compiler/args.rs
@@ -859,7 +859,7 @@ mod tests {
         // Try again with an even number of items
         let data = &data[..6];
         for item in data {
-            assert_eq!(bsearch(item.0, &data, |i, k| i.0.cmp(k)), Some(item));
+            assert_eq!(bsearch(item.0, data, |i, k| i.0.cmp(k)), Some(item));
         }
 
         // Once more, with prefix matches
@@ -887,7 +887,7 @@ mod tests {
         let data = &data[..6];
         for item in data {
             assert_eq!(
-                bsearch(item.0, &data, |i, k| if k.starts_with(i.0) {
+                bsearch(item.0, data, |i, k| if k.starts_with(i.0) {
                     Ordering::Equal
                 } else {
                     i.0.cmp(k)
@@ -979,8 +979,8 @@ mod tests {
                 CanBeSeparated('=')
             )),
         ];
-        match diff_with(iter, expected, |ref a, ref b| {
-            assert_eq!(a.as_ref().unwrap(), *b);
+        match diff_with(iter, expected, |a, b| {
+            assert_eq!(a.as_ref().unwrap(), b);
             true
         }) {
             None => {}

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -151,15 +151,15 @@ struct CCompilation<I: CCompilerImpl> {
 #[derive(Debug, PartialEq, Clone)]
 pub enum CCompilerKind {
     /// GCC
-    GCC,
+    Gcc,
     /// clang
     Clang,
     /// Diab
     Diab,
     /// Microsoft Visual C++
-    MSVC,
+    Msvc,
     /// NVIDIA cuda compiler
-    NVCC,
+    Nvcc,
 }
 
 /// An interface to a specific C compiler.
@@ -212,7 +212,7 @@ where
         pool: &ThreadPool,
     ) -> SFuture<CCompiler<I>> {
         Box::new(
-            Digest::file(executable.clone(), &pool).map(move |digest| CCompiler {
+            Digest::file(executable.clone(), pool).map(move |digest| CCompiler {
                 executable,
                 executable_digest: {
                     if let Some(version) = version {
@@ -612,7 +612,7 @@ impl pkg::ToolchainPackager for CToolchainPackager {
                 }
             }
 
-            CCompilerKind::GCC => {
+            CCompilerKind::Gcc => {
                 // Various external programs / files which may be needed by gcc
                 add_named_prog(&mut package_builder, "cc1")?;
                 add_named_prog(&mut package_builder, "cc1plus")?;
@@ -620,7 +620,7 @@ impl pkg::ToolchainPackager for CToolchainPackager {
                 add_named_file(&mut package_builder, "liblto_plugin.so")?;
             }
 
-            CCompilerKind::NVCC => {
+            CCompilerKind::Nvcc => {
                 // Various programs called by the nvcc front end.
                 // presumes the underlying host compiler is consistent
                 add_named_file(&mut package_builder, "cudafe++")?;
@@ -693,8 +693,8 @@ mod test {
         let args = ovec!["a", "b", "c"];
         const PREPROCESSED: &[u8] = b"hello world";
         assert_eq!(
-            hash_key("abcd", Language::C, &args, &[], &[], &PREPROCESSED, false),
-            hash_key("abcd", Language::C, &args, &[], &[], &PREPROCESSED, false)
+            hash_key("abcd", Language::C, &args, &[], &[], PREPROCESSED, false),
+            hash_key("abcd", Language::C, &args, &[], &[], PREPROCESSED, false)
         );
     }
 
@@ -703,8 +703,8 @@ mod test {
         let args = ovec!["a", "b", "c"];
         const PREPROCESSED: &[u8] = b"hello world";
         assert_neq!(
-            hash_key("abcd", Language::C, &args, &[], &[], &PREPROCESSED, false),
-            hash_key("abcd", Language::C, &args, &[], &[], &PREPROCESSED, true)
+            hash_key("abcd", Language::C, &args, &[], &[], PREPROCESSED, false),
+            hash_key("abcd", Language::C, &args, &[], &[], PREPROCESSED, true)
         );
     }
 
@@ -713,8 +713,8 @@ mod test {
         let args = ovec!["a", "b", "c"];
         const PREPROCESSED: &[u8] = b"hello world";
         assert_neq!(
-            hash_key("abcd", Language::C, &args, &[], &[], &PREPROCESSED, false),
-            hash_key("wxyz", Language::C, &args, &[], &[], &PREPROCESSED, false)
+            hash_key("abcd", Language::C, &args, &[], &[], PREPROCESSED, false),
+            hash_key("wxyz", Language::C, &args, &[], &[], PREPROCESSED, false)
         );
     }
 
@@ -727,18 +727,18 @@ mod test {
         let a = ovec!["a"];
         const PREPROCESSED: &[u8] = b"hello world";
         assert_neq!(
-            hash_key(digest, Language::C, &abc, &[], &[], &PREPROCESSED, false),
-            hash_key(digest, Language::C, &xyz, &[], &[], &PREPROCESSED, false)
+            hash_key(digest, Language::C, &abc, &[], &[], PREPROCESSED, false),
+            hash_key(digest, Language::C, &xyz, &[], &[], PREPROCESSED, false)
         );
 
         assert_neq!(
-            hash_key(digest, Language::C, &abc, &[], &[], &PREPROCESSED, false),
-            hash_key(digest, Language::C, &ab, &[], &[], &PREPROCESSED, false)
+            hash_key(digest, Language::C, &abc, &[], &[], PREPROCESSED, false),
+            hash_key(digest, Language::C, &ab, &[], &[], PREPROCESSED, false)
         );
 
         assert_neq!(
-            hash_key(digest, Language::C, &abc, &[], &[], &PREPROCESSED, false),
-            hash_key(digest, Language::C, &a, &[], &[], &PREPROCESSED, false)
+            hash_key(digest, Language::C, &abc, &[], &[], PREPROCESSED, false),
+            hash_key(digest, Language::C, &a, &[], &[], PREPROCESSED, false)
         );
     }
 
@@ -765,11 +765,11 @@ mod test {
         let digest = "abcd";
         const PREPROCESSED: &[u8] = b"hello world";
         for var in CACHED_ENV_VARS.iter() {
-            let h1 = hash_key(digest, Language::C, &args, &[], &[], &PREPROCESSED, false);
+            let h1 = hash_key(digest, Language::C, &args, &[], &[], PREPROCESSED, false);
             let vars = vec![(OsString::from(var), OsString::from("something"))];
-            let h2 = hash_key(digest, Language::C, &args, &[], &vars, &PREPROCESSED, false);
+            let h2 = hash_key(digest, Language::C, &args, &[], &vars, PREPROCESSED, false);
             let vars = vec![(OsString::from(var), OsString::from("something else"))];
-            let h3 = hash_key(digest, Language::C, &args, &[], &vars, &PREPROCESSED, false);
+            let h3 = hash_key(digest, Language::C, &args, &[], &vars, PREPROCESSED, false);
             assert_neq!(h1, h2);
             assert_neq!(h2, h3);
         }
@@ -789,10 +789,10 @@ mod test {
                 &args,
                 &extra_data,
                 &[],
-                &PREPROCESSED,
+                PREPROCESSED,
                 false
             ),
-            hash_key(digest, Language::C, &args, &[], &[], &PREPROCESSED, false)
+            hash_key(digest, Language::C, &args, &[], &[], PREPROCESSED, false)
         );
     }
 }

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -16,10 +16,10 @@ use crate::cache::{Cache, CacheWrite, DecompressionFailure, Storage};
 use crate::compiler::c::{CCompiler, CCompilerKind};
 use crate::compiler::clang::Clang;
 use crate::compiler::diab::Diab;
-use crate::compiler::gcc::GCC;
+use crate::compiler::gcc::Gcc;
 use crate::compiler::msvc;
-use crate::compiler::msvc::MSVC;
-use crate::compiler::nvcc::NVCC;
+use crate::compiler::msvc::Msvc;
+use crate::compiler::nvcc::Nvcc;
 use crate::compiler::rust::{Rust, RustupProxy};
 use crate::dist;
 #[cfg(feature = "dist-client")]
@@ -91,7 +91,7 @@ pub enum CompilerKind {
 impl CompilerKind {
     pub fn lang_kind(&self) -> String {
         match self {
-            CompilerKind::C(CCompilerKind::NVCC) => "CUDA",
+            CompilerKind::C(CCompilerKind::Nvcc) => "CUDA",
             CompilerKind::C(_) => "C/C++",
             CompilerKind::Rust => "Rust",
         }
@@ -1084,7 +1084,7 @@ __VERSION__
                     debug!("Found {}", kind);
                     return Box::new(
                         CCompiler::new(
-                            GCC {
+                            Gcc {
                                 gplusplus: kind == "g++",
                             },
                             executable,
@@ -1107,7 +1107,7 @@ __VERSION__
                     return Box::new(prefix.and_then(move |prefix| {
                         trace!("showIncludes prefix: '{}'", prefix);
                         CCompiler::new(
-                            MSVC {
+                            Msvc {
                                 includes_prefix: prefix,
                                 is_clang,
                             },
@@ -1121,7 +1121,7 @@ __VERSION__
                 "nvcc" => {
                     debug!("Found NVCC");
                     return Box::new(
-                        CCompiler::new(NVCC, executable, version, &pool)
+                        CCompiler::new(Nvcc, executable, version, &pool)
                             .map(|c| Box::new(c) as Box<dyn Compiler<T>>),
                     );
                 }
@@ -1181,7 +1181,7 @@ mod test {
             .wait()
             .unwrap()
             .0;
-        assert_eq!(CompilerKind::C(CCompilerKind::GCC), c.kind());
+        assert_eq!(CompilerKind::C(CCompilerKind::Gcc), c.kind());
     }
 
     #[test]
@@ -1221,7 +1221,7 @@ mod test {
             .wait()
             .unwrap()
             .0;
-        assert_eq!(CompilerKind::C(CCompilerKind::MSVC), c.kind());
+        assert_eq!(CompilerKind::C(CCompilerKind::Msvc), c.kind());
     }
 
     #[test]
@@ -1234,7 +1234,7 @@ mod test {
             .wait()
             .unwrap()
             .0;
-        assert_eq!(CompilerKind::C(CCompilerKind::NVCC), c.kind());
+        assert_eq!(CompilerKind::C(CCompilerKind::Nvcc), c.kind());
     }
 
     #[test]
@@ -1380,7 +1380,7 @@ LLVM version: 6.0",
             .unwrap()
             .0;
         // digest of an empty file.
-        assert_eq!(CompilerKind::C(CCompilerKind::GCC), c.kind());
+        assert_eq!(CompilerKind::C(CCompilerKind::Gcc), c.kind());
     }
 
     #[test]
@@ -1845,7 +1845,7 @@ LLVM version: 6.0",
         assert_eq!(b"", res.stdout.as_slice());
         assert_eq!(PREPROCESSOR_STDERR, res.stderr.as_slice());
         // Errors in preprocessing should remove the object file.
-        assert_eq!(fs::metadata(&obj).is_ok(), false);
+        assert!(!fs::metadata(&obj).is_ok());
     }
 
     #[test]
@@ -1993,7 +1993,7 @@ mod test_dist {
         fn rewrite_includes_only(&self) -> bool {
             false
         }
-        fn get_custom_toolchain(&self, _exe: &PathBuf) -> Option<PathBuf> {
+        fn get_custom_toolchain(&self, _exe: &Path) -> Option<PathBuf> {
             None
         }
     }
@@ -2042,7 +2042,7 @@ mod test_dist {
         fn rewrite_includes_only(&self) -> bool {
             false
         }
-        fn get_custom_toolchain(&self, _exe: &PathBuf) -> Option<PathBuf> {
+        fn get_custom_toolchain(&self, _exe: &Path) -> Option<PathBuf> {
             None
         }
     }
@@ -2107,7 +2107,7 @@ mod test_dist {
         fn rewrite_includes_only(&self) -> bool {
             false
         }
-        fn get_custom_toolchain(&self, _exe: &PathBuf) -> Option<PathBuf> {
+        fn get_custom_toolchain(&self, _exe: &Path) -> Option<PathBuf> {
             None
         }
     }
@@ -2180,7 +2180,7 @@ mod test_dist {
         fn rewrite_includes_only(&self) -> bool {
             false
         }
-        fn get_custom_toolchain(&self, _exe: &PathBuf) -> Option<PathBuf> {
+        fn get_custom_toolchain(&self, _exe: &Path) -> Option<PathBuf> {
             None
         }
     }
@@ -2274,7 +2274,7 @@ mod test_dist {
         fn rewrite_includes_only(&self) -> bool {
             false
         }
-        fn get_custom_toolchain(&self, _exe: &PathBuf) -> Option<PathBuf> {
+        fn get_custom_toolchain(&self, _exe: &Path) -> Option<PathBuf> {
             None
         }
     }

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -687,7 +687,7 @@ mod test {
         let mut path_transformer = dist::PathTransformer::default();
         let (command, _, cacheable) = generate_compile_commands(
             &mut path_transformer,
-            &compiler,
+            compiler,
             &parsed_args,
             f.tempdir.path(),
             &[],

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -30,13 +30,13 @@ use crate::errors::*;
 
 /// A struct on which to implement `CCompilerImpl`.
 #[derive(Clone, Debug)]
-pub struct GCC {
+pub struct Gcc {
     pub gplusplus: bool,
 }
 
-impl CCompilerImpl for GCC {
+impl CCompilerImpl for Gcc {
     fn kind(&self) -> CCompilerKind {
-        CCompilerKind::GCC
+        CCompilerKind::Gcc
     }
     fn plusplus(&self) -> bool {
         self.gplusplus
@@ -530,7 +530,7 @@ where
             CCompilerKind::Clang => {
                 cmd.arg("-frewrite-includes");
             }
-            CCompilerKind::GCC => {
+            CCompilerKind::Gcc => {
                 cmd.arg("-fdirectives-only");
             }
             _ => {}
@@ -627,7 +627,7 @@ pub fn generate_compile_commands(
             "-o".into(),
             path_transformer.as_dist(out_file)?,
         ];
-        if let CCompilerKind::GCC = kind {
+        if let CCompilerKind::Gcc = kind {
             // From https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html:
             //
             // -fdirectives-only
@@ -648,7 +648,7 @@ pub fn generate_compile_commands(
         }
         arguments.extend(dist::osstrings_to_strings(&parsed_args.common_args)?);
         Some(dist::CompileCommand {
-            executable: path_transformer.as_dist(&executable)?,
+            executable: path_transformer.as_dist(executable)?,
             arguments,
             env_vars: dist::osstring_tuples_to_strings(env_vars)?,
             cwd: path_transformer.as_dist_abs(cwd)?,
@@ -1321,11 +1321,11 @@ mod test {
         let mut path_transformer = dist::PathTransformer::default();
         let (command, dist_command, cacheable) = generate_compile_commands(
             &mut path_transformer,
-            &compiler,
+            compiler,
             &parsed_args,
             f.tempdir.path(),
             &[],
-            CCompilerKind::GCC,
+            CCompilerKind::Gcc,
             false,
         )
         .unwrap();

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -37,15 +37,15 @@ use crate::errors::*;
 ///
 /// Needs a little bit of state just to persist `includes_prefix`.
 #[derive(Debug, PartialEq, Clone)]
-pub struct MSVC {
+pub struct Msvc {
     /// The prefix used in the output of `-showIncludes`.
     pub includes_prefix: String,
     pub is_clang: bool,
 }
 
-impl CCompilerImpl for MSVC {
+impl CCompilerImpl for Msvc {
     fn kind(&self) -> CCompilerKind {
-        CCompilerKind::MSVC
+        CCompilerKind::Msvc
     }
     fn plusplus(&self) -> bool {
         false
@@ -777,7 +777,7 @@ where
             let f = File::create(cwd.join(depfile))?;
             let mut f = BufWriter::new(f);
 
-            encode_path(&mut f, &objfile)
+            encode_path(&mut f, objfile)
                 .with_context(|| format!("Couldn't encode objfile filename: '{:?}'", objfile))?;
             write!(f, ": ")?;
             encode_path(&mut f, &parsed_args.input)
@@ -900,7 +900,7 @@ fn generate_compile_commands(
         arguments.extend(dist::osstrings_to_strings(&parsed_args.common_args)?);
 
         Some(dist::CompileCommand {
-            executable: path_transformer.as_dist(&executable)?,
+            executable: path_transformer.as_dist(executable)?,
             arguments,
             env_vars: dist::osstring_tuples_to_strings(env_vars)?,
             cwd: path_transformer.as_dist(cwd)?,
@@ -1327,7 +1327,7 @@ mod test {
         let mut path_transformer = dist::PathTransformer::default();
         let (command, dist_command, cacheable) = generate_compile_commands(
             &mut path_transformer,
-            &compiler,
+            compiler,
             &parsed_args,
             f.tempdir.path(),
             &[],
@@ -1370,7 +1370,7 @@ mod test {
         let mut path_transformer = dist::PathTransformer::default();
         let (command, dist_command, cacheable) = generate_compile_commands(
             &mut path_transformer,
-            &compiler,
+            compiler,
             &parsed_args,
             f.tempdir.path(),
             &[],

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -33,11 +33,11 @@ use crate::errors::*;
 
 /// A unit struct on which to implement `CCompilerImpl`.
 #[derive(Clone, Debug)]
-pub struct NVCC;
+pub struct Nvcc;
 
-impl CCompilerImpl for NVCC {
+impl CCompilerImpl for Nvcc {
     fn kind(&self) -> CCompilerKind {
-        CCompilerKind::NVCC
+        CCompilerKind::Nvcc
     }
     fn plusplus(&self) -> bool {
         false
@@ -211,7 +211,7 @@ mod test {
 
     fn parse_arguments_(arguments: Vec<String>) -> CompilerArguments<ParsedArguments> {
         let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
-        NVCC.parse_arguments(&arguments, ".".as_ref())
+        Nvcc.parse_arguments(&arguments, ".".as_ref())
     }
 
     macro_rules! parses {

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1131,7 +1131,7 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
                 cannot_cache!(concat!("missing ", stringify!($x)));
             };
         };
-    };
+    }
     // We don't actually save the input value, but there needs to be one.
     req!(input);
     drop(input);

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -217,7 +217,7 @@ where
         .context("Failed to create temp dir"));
     let dep_file = temp_dir.path().join("deps.d");
     let mut cmd = creator.clone().new_command_sync(executable);
-    cmd.args(&arguments)
+    cmd.args(arguments)
         .args(&["--emit", "dep-info"])
         .arg("-o")
         .arg(&dep_file)
@@ -510,7 +510,7 @@ where
         child
             .current_dir(&cwd)
             .env_clear()
-            .envs(ref_env(&env))
+            .envs(ref_env(env))
             .args(&["which", "rustc"]);
 
         let lookup = run_input_output(child, None)
@@ -1616,7 +1616,7 @@ impl Compilation for RustCompilation {
             // probably seen all drives (e.g. on Windows), so let's just transform those rather than
             // trying to do every single path.
             let mut remapped_disks = HashSet::new();
-            for (local_path, dist_path) in get_path_mappings(&path_transformer) {
+            for (local_path, dist_path) in get_path_mappings(path_transformer) {
                 let local_path = local_path.to_str()?;
                 // "The from=to parameter is scanned from right to left, so from may contain '=', but to may not."
                 if local_path.contains('=') {
@@ -2237,7 +2237,7 @@ fn parse_rustc_z_ls(stdout: &str) -> Result<Vec<&str>> {
 
     let mut dep_names = vec![];
 
-    while let Some(line) = lines.next() {
+    for line in &mut lines {
         if line.is_empty() {
             break;
         }
@@ -2751,7 +2751,7 @@ bar.rs:
 ";
         assert_eq!(
             pathvec!["abc.rs", "bar.rs", "baz.rs"],
-            parse_dep_info(&deps, "")
+            parse_dep_info(deps, "")
         );
     }
 
@@ -2763,7 +2763,7 @@ baz.rs:
 
 abc def.rs:
 "#;
-        assert_eq!(pathvec!["abc def.rs", "baz.rs"], parse_dep_info(&deps, ""));
+        assert_eq!(pathvec!["abc def.rs", "baz.rs"], parse_dep_info(deps, ""));
     }
 
     #[cfg(not(windows))]
@@ -2818,7 +2818,7 @@ bar.rs:
 ";
         assert_eq!(
             pathvec!["foo/abc.rs", "foo/bar.rs", "foo/baz.rs"],
-            parse_dep_info(&deps, "foo/")
+            parse_dep_info(deps, "foo/")
         );
 
         assert_eq!(
@@ -2827,7 +2827,7 @@ bar.rs:
                 "c:/foo/bar/bar.rs",
                 "c:/foo/bar/baz.rs"
             ],
-            parse_dep_info(&deps, "c:/foo/bar/")
+            parse_dep_info(deps, "c:/foo/bar/")
         );
     }
 
@@ -2842,7 +2842,7 @@ c:/foo/bar.rs:
 ";
         assert_eq!(
             pathvec!["c:/foo/abc.rs", "c:/foo/bar.rs", "c:/foo/baz.rs"],
-            parse_dep_info(&deps, "c:/bar/")
+            parse_dep_info(deps, "c:/bar/")
         );
     }
 
@@ -2856,7 +2856,7 @@ c:/foo/bar.rs:
 
 
 ";
-        let res = parse_rustc_z_ls(&output);
+        let res = parse_rustc_z_ls(output);
         assert!(res.is_ok());
         let res = res.unwrap();
         assert_eq!(res.len(), 3);
@@ -2895,7 +2895,7 @@ c:/foo/bar.rs:
     fn mock_file_names(creator: &Arc<Mutex<MockCommandCreator>>, filenames: &[&str]) {
         // Mock the `rustc --print=file-names` process output.
         next_command(
-            &creator,
+            creator,
             Ok(MockChild::new(
                 exit_status(0),
                 filenames.iter().join("\n"),
@@ -3020,7 +3020,7 @@ c:/foo/bar.rs:
         F: Fn(&Path) -> Result<()>,
     {
         let oargs = args.iter().map(OsString::from).collect::<Vec<OsString>>();
-        let parsed_args = match parse_arguments(&oargs, &f.tempdir.path()) {
+        let parsed_args = match parse_arguments(&oargs, f.tempdir.path()) {
             CompilerArguments::Ok(parsed_args) => parsed_args,
             o => panic!("Got unexpected parse result: {:?}", o),
         };
@@ -3034,7 +3034,7 @@ c:/foo/bar.rs:
             let s = format!("Failed to create {:?}", e);
             f.touch(e.to_str().unwrap()).expect(&s);
         }
-        pre_func(&f.tempdir.path()).expect("Failed to execute pre_func");
+        pre_func(f.tempdir.path()).expect("Failed to execute pre_func");
         let hasher = Box::new(RustHasher {
             executable: "rustc".into(),
             host: "x86-64-unknown-unknown-unknown".to_owned(),

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -2779,12 +2779,12 @@ bar.rs:
 ";
         assert_eq!(
             pathvec!["foo/abc.rs", "foo/bar.rs", "foo/baz.rs"],
-            parse_dep_info(&deps, "foo/")
+            parse_dep_info(deps, "foo/")
         );
 
         assert_eq!(
             pathvec!["/foo/bar/abc.rs", "/foo/bar/bar.rs", "/foo/bar/baz.rs"],
-            parse_dep_info(&deps, "/foo/bar/")
+            parse_dep_info(deps, "/foo/bar/")
         );
     }
 
@@ -2801,7 +2801,7 @@ bar.rs:
 ";
         assert_eq!(
             pathvec!["/foo/abc.rs", "/foo/bar.rs", "/foo/baz.rs"],
-            parse_dep_info(&deps, "/bar/")
+            parse_dep_info(deps, "/bar/")
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -644,7 +644,7 @@ impl CachedConfig {
         let cached_file_config = CACHED_CONFIG.lock().unwrap();
         let cached_file_config = cached_file_config.as_ref().unwrap();
 
-        f(&cached_file_config)
+        f(cached_file_config)
     }
     pub fn with_mut<F: FnOnce(&mut CachedFileConfig)>(&self, f: F) -> Result<()> {
         let mut cached_file_config = CACHED_CONFIG.lock().unwrap();
@@ -678,7 +678,7 @@ impl CachedConfig {
                 )
             })?
         }
-        try_read_config_file(&file_conf_path)
+        try_read_config_file(file_conf_path)
             .context("Failed to load cached config file")?
             .with_context(|| format!("Failed to load from {}", file_conf_path.display()))
     }

--- a/src/dist/cache.rs
+++ b/src/dist/cache.rs
@@ -497,7 +497,7 @@ impl TcCache {
 
     #[cfg(feature = "dist-client")]
     fn insert_file(&mut self, path: &Path) -> Result<Toolchain> {
-        let archive_id = path_key(&path)?;
+        let archive_id = path_key(path)?;
         self.inner
             .insert_file(make_lru_key_path(&archive_id), path)?;
         Ok(Toolchain { archive_id })

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -1310,7 +1310,7 @@ mod client {
         fn rewrite_includes_only(&self) -> bool {
             self.rewrite_includes_only
         }
-        fn get_custom_toolchain(&self, exe: &PathBuf) -> Option<PathBuf> {
+        fn get_custom_toolchain(&self, exe: &Path) -> Option<PathBuf> {
             match self.tc_cache.get_custom_toolchain(exe) {
                 Some(Ok((_, _, path))) => Some(path),
                 _ => None,

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -737,5 +737,5 @@ pub trait Client {
         toolchain_packager: Box<dyn pkg::ToolchainPackager>,
     ) -> SFuture<(Toolchain, Option<(String, PathBuf)>)>;
     fn rewrite_includes_only(&self) -> bool;
-    fn get_custom_toolchain(&self, exe: &PathBuf) -> Option<PathBuf>;
+    fn get_custom_toolchain(&self, exe: &Path) -> Option<PathBuf>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ fn init_logging() {
     if env::var(LOGGING_ENV).is_ok() {
         match env_logger::Builder::from_env(LOGGING_ENV).try_init() {
             Ok(_) => (),
-            Err(e) => panic!(format!("Failed to initalize logging: {:?}", e)),
+            Err(e) => panic!("Failed to initalize logging: {:?}", e),
         }
     }
 }

--- a/src/simples3/s3.rs
+++ b/src/simples3/s3.rs
@@ -64,7 +64,7 @@ impl fmt::Display for Bucket {
 
 impl Bucket {
     pub fn new(name: &str, endpoint: &str, ssl: Ssl) -> Result<Bucket> {
-        let base_url = base_url(&endpoint, ssl);
+        let base_url = base_url(endpoint, ssl);
         Ok(Bucket {
             name: name.to_owned(),
             base_url,

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -101,7 +101,7 @@ where
 #[test]
 fn test_server_shutdown() {
     let f = TestFixture::new();
-    let (port, _sender, _storage, child) = run_server_thread(&f.tempdir.path(), None);
+    let (port, _sender, _storage, child) = run_server_thread(f.tempdir.path(), None);
     // Connect to the server.
     let conn = connect_to_server(port).unwrap();
     // Ask it to shut down
@@ -116,7 +116,7 @@ fn test_server_shutdown_no_idle() {
     let f = TestFixture::new();
     // Set a ridiculously low idle timeout.
     let (port, _sender, _storage, child) = run_server_thread(
-        &f.tempdir.path(),
+        f.tempdir.path(),
         ServerOptions {
             idle_timeout: Some(0),
             ..Default::default()
@@ -133,7 +133,7 @@ fn test_server_idle_timeout() {
     let f = TestFixture::new();
     // Set a ridiculously low idle timeout.
     let (_port, _sender, _storage, child) = run_server_thread(
-        &f.tempdir.path(),
+        f.tempdir.path(),
         ServerOptions {
             idle_timeout: Some(1),
             ..Default::default()
@@ -149,7 +149,7 @@ fn test_server_idle_timeout() {
 #[test]
 fn test_server_stats() {
     let f = TestFixture::new();
-    let (port, sender, _storage, child) = run_server_thread(&f.tempdir.path(), None);
+    let (port, sender, _storage, child) = run_server_thread(f.tempdir.path(), None);
     // Connect to the server.
     let conn = connect_to_server(port).unwrap();
     // Ask it for stats.
@@ -164,7 +164,7 @@ fn test_server_stats() {
 #[test]
 fn test_server_unsupported_compiler() {
     let f = TestFixture::new();
-    let (port, sender, server_creator, child) = run_server_thread(&f.tempdir.path(), None);
+    let (port, sender, server_creator, child) = run_server_thread(f.tempdir.path(), None);
     // Connect to the server.
     let conn = connect_to_server(port).unwrap();
     {
@@ -213,7 +213,7 @@ fn test_server_unsupported_compiler() {
 fn test_server_compile() {
     let _ = env_logger::try_init();
     let f = TestFixture::new();
-    let (port, sender, server_creator, child) = run_server_thread(&f.tempdir.path(), None);
+    let (port, sender, server_creator, child) = run_server_thread(f.tempdir.path(), None);
     // Connect to the server.
     const PREPROCESSOR_STDOUT: &[u8] = b"preprocessor stdout";
     const PREPROCESSOR_STDERR: &[u8] = b"preprocessor stderr";

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -209,7 +209,7 @@ impl TestFixture {
         for d in SUBDIRS.iter() {
             let p = tempdir.path().join(d);
             builder.create(&p).unwrap();
-            bins.push(mk_bin(&p, &BIN_NAME).unwrap());
+            bins.push(mk_bin(&p, BIN_NAME).unwrap());
             paths.push(p);
         }
         TestFixture {
@@ -221,12 +221,12 @@ impl TestFixture {
 
     #[allow(dead_code)]
     pub fn touch(&self, path: &str) -> io::Result<PathBuf> {
-        touch(self.tempdir.path(), &path)
+        touch(self.tempdir.path(), path)
     }
 
     #[allow(dead_code)]
     pub fn mk_bin(&self, path: &str) -> io::Result<PathBuf> {
-        mk_bin(self.tempdir.path(), &path)
+        mk_bin(self.tempdir.path(), path)
     }
 }
 

--- a/tests/oauth.rs
+++ b/tests/oauth.rs
@@ -94,7 +94,7 @@ impl DriverExt for WebDriver {
         let start = Instant::now();
         while start.elapsed() < BROWSER_MAX_WAIT {
             match self.get_current_url() {
-                Ok(ref url) if condition(&url) => return Ok(()),
+                Ok(ref url) if condition(url) => return Ok(()),
                 Ok(_) | Err(_) => thread::sleep(BROWSER_RETRY_WAIT),
             }
         }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -234,7 +234,7 @@ fn test_gcc_fprofile_generate_source_changes(compiler: Compiler, tempdir: &Path)
     zero_stats();
     const SRC: &str = "source.c";
     write_source(
-        &tempdir,
+        tempdir,
         SRC,
         "/*line 1*/
 #ifndef UNDEFINED
@@ -278,7 +278,7 @@ int main(int argc, char** argv) {
     // modulo line numbers. This should not be a cache hit because line numbers are important
     // with -fprofile-generate.
     write_source(
-        &tempdir,
+        tempdir,
         SRC,
         "/*line 1*/
 #ifndef UNDEFINED


### PR DESCRIPTION
* Update Rust version from `1.50.0` to `1.54.0`
* Update Ubuntu CI version to `18.04` because Github no longer supports version `16.04`
* Fix incorrect usage of `panic!(&str)` instead of `panic!("{}", &str)`
* Replace usage of outdated clippy options
* Refactor codebase to bring it in line with rustfmt standards
* Refactor codebase to remove needless borrowing
* Refactor enum/struct names to be Camel Case instead of UPPER CASE
* Refactor code which creates a reference to a reference
* Refactor usages of redundant semicolons
* Refactor usages of outdated `panic!(format!(...))`