### PR TITLE
[FIX] Always pass `-x cu` to nvcc

### DIFF
--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -616,6 +616,7 @@ pub fn generate_compile_commands(
         if !rewrite_includes_only {
             match parsed_args.language {
                 Language::C => language = "cpp-output".into(),
+                Language::Cuda => language = "cu".into(),
                 _ => language.push_str("-cpp-output"),
             }
         }


### PR DESCRIPTION
This PR ensures the `-x cu` language flag is not modified when constructing an nvcc compile string. When `rewrite_includes_only` is false, the `-x cu` argument is transformed to `-x cu-cpp-output`, causing nvcc to error with:
```
nvcc fatal   : Value 'cu-cpp-output' is not defined for option 'x'
```

Curiously this only seems to show up when attempting to do a distributed compilation with `sccache-dist`. I have not encountered this issue doing local-only `sccache` builds. Does `rewrite_includes_only` only affect sccache-dist servers (or is set to false in the server job request)?