### PR TITLE
Adds support for rust coverage (-Zprofile)

### DIFF
--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -136,6 +136,8 @@ pub struct ParsedArguments {
     crate_types: CrateTypes,
     /// If dependency info is being emitted, the name of the dep info file.
     dep_info: Option<PathBuf>,
+    /// If gcno info is being emitted, the name of the gcno file.
+    gcno: Option<PathBuf>,
     /// rustc says that emits .rlib for --emit=metadata
     /// https://github.com/rust-lang/rust/issues/54852
     emit: HashSet<String>,
@@ -836,6 +838,36 @@ impl IntoArg for ArgCodegen {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+struct ArgUnstable {
+    opt: String,
+    value: Option<String>,
+}
+impl FromArg for ArgUnstable {
+    fn process(arg: OsString) -> ArgParseResult<Self> {
+        let (opt, value) = split_os_string_arg(arg, "=")?;
+        Ok(ArgUnstable { opt, value })
+    }
+}
+impl IntoArg for ArgUnstable {
+    fn into_arg_os_string(self) -> OsString {
+        let ArgUnstable { opt, value } = self;
+        if let Some(value) = value {
+            make_os_string!(opt, "=", value)
+        } else {
+            make_os_string!(opt)
+        }
+    }
+    fn into_arg_string(self, transformer: PathTransformerFn<'_>) -> ArgToStringResult {
+        let ArgUnstable { opt, value } = self;
+        Ok(if let Some(value) = value {
+            format!("{}={}", opt, value.into_arg_string(transformer)?)
+        } else {
+            opt
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 struct ArgExtern {
     name: String,
     path: PathBuf,
@@ -930,6 +962,7 @@ ArgData! {
     CodeGen(ArgCodegen),
     PassThrough(OsString),
     Target(ArgTarget),
+    Unstable(ArgUnstable),
 }
 
 use self::ArgData::*;
@@ -968,7 +1001,7 @@ counted_array!(static ARGS: [ArgInfo<ArgData>; _] = [
     take_arg!("-L", ArgLinkPath, CanBeSeparated, LinkPath),
     flag!("-V", NotCompilationFlag),
     take_arg!("-W", OsString, CanBeSeparated, PassThrough),
-    take_arg!("-Z", OsString, CanBeSeparated, PassThrough),
+    take_arg!("-Z", ArgUnstable, CanBeSeparated, Unstable),
     take_arg!("-l", ArgLinkLibrary, CanBeSeparated, LinkLibrary),
     take_arg!("-o", PathBuf, CanBeSeparated, TooHardPath),
 ]);
@@ -991,6 +1024,7 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
     let mut static_link_paths: Vec<PathBuf> = vec![];
     let mut color_mode = ColorMode::Auto;
     let mut has_json = false;
+    let mut profile = false;
 
     for arg in ArgsIter::new(arguments.iter().cloned(), &ARGS[..]) {
         let arg = try_or_cannot_cache!(arg, "argument parse");
@@ -1057,6 +1091,12 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
                     (_, _) => (),
                 }
             }
+            Some(Unstable(ArgUnstable { opt, value })) => match value.as_deref() {
+                Some("y") | Some("yes") | Some("on") | None if opt == "profile" => {
+                    profile = true;
+                }
+                _ => (),
+            },
             Some(Color(value)) => {
                 // We'll just assume the last specified value wins.
                 color_mode = match value.as_ref() {
@@ -1136,7 +1176,7 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
     // Figure out the dep-info filename, if emitting dep-info.
     let dep_info = if emit.contains("dep-info") {
         let mut dep_info = crate_name.clone();
-        if let Some(extra_filename) = extra_filename {
+        if let Some(extra_filename) = extra_filename.clone() {
             dep_info.push_str(&extra_filename[..]);
         }
         dep_info.push_str(".d");
@@ -1144,6 +1184,19 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
     } else {
         None
     };
+
+    // Figure out the gcno filename, if producing gcno files with `-Zprofile`.
+    let gcno = if profile {
+        let mut gcno = crate_name.clone();
+        if let Some(extra_filename) = extra_filename {
+            gcno.push_str(&extra_filename[..]);
+        }
+        gcno.push_str(".gcno");
+        Some(gcno)
+    } else {
+        None
+    };
+
     // Locate all static libs specified on the commandline.
     let staticlibs = static_lib_names
         .into_iter()
@@ -1179,6 +1232,7 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
         staticlibs,
         crate_name,
         dep_info: dep_info.map(|s| s.into()),
+        gcno: gcno.map(|s| s.into()),
         emit,
         color_mode,
         has_json,
@@ -1219,6 +1273,7 @@ where
                     dep_info,
                     emit,
                     has_json,
+                    gcno,
                     ..
                 },
         } = *self;
@@ -1421,6 +1476,10 @@ where
         } else {
             None
         };
+        if let Some(gcno) = gcno {
+            let p = output_dir.join(&gcno);
+            outputs.insert(gcno.to_string_lossy().into_owned(), p);
+        }
         let mut arguments = arguments;
         // Request color output unless json was requested. The client will strip colors if needed.
         if !has_json {
@@ -2923,6 +2982,7 @@ c:/foo/bar.rs:
                 emit,
                 color_mode: ColorMode::Auto,
                 has_json: false,
+                gcno: None,
             },
         });
         let creator = new_creator();
@@ -3240,5 +3300,38 @@ c:/foo/bar.rs:
                 nothing
             )
         );
+    }
+
+    #[test]
+    fn test_parse_unstable_profile_flag() {
+        let h = parses!(
+            "--crate-name",
+            "foo",
+            "--crate-type",
+            "lib",
+            "./src/lib.rs",
+            "--emit=dep-info,link",
+            "--out-dir",
+            "/out",
+            "-Zprofile"
+        );
+
+        assert_eq!(h.gcno, Some("foo.gcno".into()));
+
+        let h = parses!(
+            "--crate-name",
+            "foo",
+            "--crate-type",
+            "lib",
+            "./src/lib.rs",
+            "--emit=dep-info,link",
+            "-C",
+            "extra-filename=-a1b6419f8321841f",
+            "--out-dir",
+            "/out",
+            "-Zprofile"
+        );
+
+        assert_eq!(h.gcno, Some("foo-a1b6419f8321841f.gcno".into()));
     }
 }


### PR DESCRIPTION
Closes #1021 

The `*.gcno` files now are added to cache objects:

```
extracting: libfutures_lite-0a22b489c21d5041.rmeta
 extracting: futures_lite-0a22b489c21d5041.gcno
 extracting: libfutures_lite-0a22b489c21d5041.rlib
 extracting: futures_lite-0a22b489c21d5041.d
 extracting: stderr
```

Not sure if this should bump `CACHE_VERSION` though