### PR TITLE
Add -fminimize-whitespace preprocessor flag when Clang >= 14 to increase cache hits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,16 @@ jobs:
         with:
           toolchain: ${{ matrix.rustc }}
 
+      - name: Install LLVM/Clang
+        if: contains(matrix.os, 'ubuntu')
+        run: 
+          sudo apt-get update || true
+          sudo apt-get install wget
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 13
+          sudo ./llvm.sh 14
+
       - name: Build tests
         run: cargo test --no-run --locked --all-targets --verbose ${{ matrix.extra_args }}
 

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -35,12 +35,16 @@ use crate::errors::*;
 pub struct Clang {
     /// true iff this is clang++.
     pub clangplusplus: bool,
+    pub version: Option<String>,
 }
 
 #[async_trait]
 impl CCompilerImpl for Clang {
     fn kind(&self) -> CCompilerKind {
         CCompilerKind::Clang
+    }
+    fn version(&self) -> Option<String> {
+        self.version.clone()
     }
     fn plusplus(&self) -> bool {
         self.clangplusplus
@@ -68,6 +72,7 @@ impl CCompilerImpl for Clang {
         env_vars: &[(OsString, OsString)],
         may_dist: bool,
         rewrite_includes_only: bool,
+        version: Option<String>,
     ) -> Result<process::Output>
     where
         T: CommandCreatorSync,
@@ -81,6 +86,7 @@ impl CCompilerImpl for Clang {
             may_dist,
             self.kind(),
             rewrite_includes_only,
+            version,
         )
         .await
     }
@@ -147,6 +153,7 @@ mod test {
         let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
         Clang {
             clangplusplus: false,
+            version: None,
         }
         .parse_arguments(&arguments, &std::env::current_dir().unwrap())
     }

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1055,6 +1055,7 @@ __VERSION__
                 return CCompiler::new(
                     Clang {
                         clangplusplus: kind == "clang++",
+                        version: version.clone(),
                     },
                     executable,
                     version,
@@ -1065,15 +1066,23 @@ __VERSION__
             }
             "diab" => {
                 debug!("Found diab");
-                return CCompiler::new(Diab, executable, version, &pool)
-                    .await
-                    .map(|c| Box::new(c) as Box<dyn Compiler<T>>);
+                return CCompiler::new(
+                    Diab {
+                        version: version.clone(),
+                    },
+                    executable,
+                    version,
+                    &pool,
+                )
+                .await
+                .map(|c| Box::new(c) as Box<dyn Compiler<T>>);
             }
             "gcc" | "g++" => {
                 debug!("Found {}", kind);
                 return CCompiler::new(
                     Gcc {
                         gplusplus: kind == "g++",
+                        version: version.clone(),
                     },
                     executable,
                     version,
@@ -1099,6 +1108,7 @@ __VERSION__
                     Msvc {
                         includes_prefix: prefix,
                         is_clang,
+                        version: version.clone(),
                     },
                     executable,
                     version,
@@ -1109,9 +1119,16 @@ __VERSION__
             }
             "nvcc" => {
                 debug!("Found NVCC");
-                return CCompiler::new(Nvcc, executable, version, &pool)
-                    .await
-                    .map(|c| Box::new(c) as Box<dyn Compiler<T>>);
+                return CCompiler::new(
+                    Nvcc {
+                        version: version.clone(),
+                    },
+                    executable,
+                    version,
+                    &pool,
+                )
+                .await
+                .map(|c| Box::new(c) as Box<dyn Compiler<T>>);
             }
             _ => (),
         }

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -32,12 +32,17 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 #[derive(Clone, Debug)]
-pub struct Diab;
+pub struct Diab {
+    pub version: Option<String>,
+}
 
 #[async_trait]
 impl CCompilerImpl for Diab {
     fn kind(&self) -> CCompilerKind {
         CCompilerKind::Diab
+    }
+    fn version(&self) -> Option<String> {
+        self.version.clone()
     }
     fn plusplus(&self) -> bool {
         false
@@ -60,6 +65,7 @@ impl CCompilerImpl for Diab {
         env_vars: &[(OsString, OsString)],
         may_dist: bool,
         _rewrite_includes_only: bool,
+        _version: Option<String>,
     ) -> Result<process::Output>
     where
         T: CommandCreatorSync,

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -39,12 +39,16 @@ pub struct Msvc {
     /// The prefix used in the output of `-showIncludes`.
     pub includes_prefix: String,
     pub is_clang: bool,
+    pub version: Option<String>,
 }
 
 #[async_trait]
 impl CCompilerImpl for Msvc {
     fn kind(&self) -> CCompilerKind {
         CCompilerKind::Msvc
+    }
+    fn version(&self) -> Option<String> {
+        self.version.clone()
     }
     fn plusplus(&self) -> bool {
         false
@@ -67,6 +71,7 @@ impl CCompilerImpl for Msvc {
         env_vars: &[(OsString, OsString)],
         may_dist: bool,
         rewrite_includes_only: bool,
+        _version: Option<String>,
     ) -> Result<process::Output>
     where
         T: CommandCreatorSync,

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -33,12 +33,17 @@ use crate::errors::*;
 
 /// A unit struct on which to implement `CCompilerImpl`.
 #[derive(Clone, Debug)]
-pub struct Nvcc;
+pub struct Nvcc {
+    pub version: Option<String>,
+}
 
 #[async_trait]
 impl CCompilerImpl for Nvcc {
     fn kind(&self) -> CCompilerKind {
         CCompilerKind::Nvcc
+    }
+    fn version(&self) -> Option<String> {
+        self.version.clone()
     }
     fn plusplus(&self) -> bool {
         false
@@ -61,6 +66,7 @@ impl CCompilerImpl for Nvcc {
         env_vars: &[(OsString, OsString)],
         may_dist: bool,
         rewrite_includes_only: bool,
+        version: Option<String>,
     ) -> Result<process::Output>
     where
         T: CommandCreatorSync,
@@ -216,7 +222,7 @@ mod test {
 
     fn parse_arguments_(arguments: Vec<String>) -> CompilerArguments<ParsedArguments> {
         let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
-        Nvcc.parse_arguments(&arguments, ".".as_ref())
+        Nvcc { version: None }.parse_arguments(&arguments, ".".as_ref())
     }
 
     macro_rules! parses {

--- a/src/config.rs
+++ b/src/config.rs
@@ -243,7 +243,7 @@ impl CacheConfigs {
             .chain(gcs.map(CacheType::GCS))
             .chain(azure.map(CacheType::Azure))
             .collect();
-        let fallback = disk.unwrap_or_else(Default::default);
+        let fallback = disk.unwrap_or_default();
 
         (caches, fallback)
     }

--- a/tests/test_whitespace.c
+++ b/tests/test_whitespace.c
@@ -1,0 +1,3 @@
+#include <stdio.h>
+
+int main() {printf("Hello world!");return 0;}

--- a/tests/test_whitespace_alt.c
+++ b/tests/test_whitespace_alt.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+int main() 
+
+
+{
+
+
+   printf("Hello world!");
+return 0;
+}


### PR DESCRIPTION
This proof of concept tries to take advantage of the new `-fminimize-whitespace` preprocessor option in Clang (14.0.0, not released yet). `-fminimize-whitespace` was added to Clang with the intention to help increase the chance of a cache hit in tools like `sccache` when only whitespace changes.

To illustrate this change, here are two sample C programs that previously wouldn't trigger a cache hit before this PR, but now do (when using Clang >= 14):
```c
#include <stdio.h>

int main() 


{


   printf("Hello World!");
return 0;
}
```
```c
#include <stdio.h>

int main() {printf("Hello World!");return 0;}
```

I also added some code to expose the compiler version to the preprocessor. This could be useful if version-dependent features are added to `sccache` in the future.

Feedback on this is definitely welcome! Note that Clang 14.0.0 is still in progress, so there is no rush to merge in this PR.