### PR TITLE
Ignore profiling flag if no link is being emitted

### DIFF
--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -200,7 +200,8 @@ impl CacheWrite {
         pool.spawn_blocking(move || {
             let mut entry = CacheWrite::new();
             for (key, path) in objects {
-                let mut f = fs::File::open(&path)?;
+                let mut f = fs::File::open(&path)
+                    .with_context(|| format!("failed to open file `{:?}`", path))?;
                 let mode = get_file_mode(&f)?;
                 entry
                     .put_object(&key, &mut f, mode)

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1186,7 +1186,7 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
     };
 
     // Figure out the gcno filename, if producing gcno files with `-Zprofile`.
-    let gcno = if profile {
+    let gcno = if profile && emit.contains("link") {
         let mut gcno = crate_name.clone();
         if let Some(extra_filename) = extra_filename {
             gcno.push_str(&extra_filename[..]);

--- a/tests/sccache_cargo.rs
+++ b/tests/sccache_cargo.rs
@@ -17,9 +17,9 @@ fn test_rust_cargo() {
     test_rust_cargo_cmd("check", &[]);
     test_rust_cargo_cmd("build", &[]);
 
-    #[cfg(nightly)]
+    #[cfg(feature = "unstable")]
     test_rust_cargo_cmd("check", &[("RUSTFLAGS", std::ffi::OsStr::new("-Zprofile"))]);
-    #[cfg(nightly)]
+    #[cfg(feature = "unstable")]
     test_rust_cargo_cmd("build", &[("RUSTFLAGS", std::ffi::OsStr::new("-Zprofile"))]);
 }
 


### PR DESCRIPTION
1. Give the error some context;
2. If no `--emit=link` is passed to `rustc` (as it is in case of `cargo check`) `-Zprofile` flag has to be ignored since no `*gcno` file will be generated.