### PR TITLE
Fixed bug with -Fo and -c flags on MSVC Compiler

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -24,6 +24,7 @@ use crate::compiler::rust::{Rust, RustupProxy};
 use crate::dist;
 #[cfg(feature = "dist-client")]
 use crate::dist::pkg;
+#[cfg(feature = "dist-client")]
 use crate::lru_disk_cache;
 use crate::mock_command::{exit_status, CommandChild, CommandCreatorSync, RunCommand};
 use crate::util::{fmt_duration_as_secs, ref_env, run_input_output};

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -644,7 +644,11 @@ pub fn parse_arguments(
             outputs.insert("obj", Path::new(&input).with_extension("obj"));
         }
         Some(o) => {
-            outputs.insert("obj", o);
+            if o.extension().is_none() && compilation {
+                outputs.insert("obj", o.with_extension("obj"));
+            } else {
+                outputs.insert("obj", o);
+            }
         }
     }
     // -Fd is not taken into account unless -Zi or -ZI are given

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -103,7 +103,7 @@ fn test_basic_compile(compiler: Compiler, tempdir: &Path) {
     // Compile a source file.
     copy_to_tempdir(&[INPUT, INPUT_ERR], tempdir);
 
-    let out_file = tempdir.join("test.o");
+    let out_file = tempdir.join(OUTPUT);
     trace!("compile");
     sccache_command()
         .args(&compile_cmdline(name, &exe, INPUT, OUTPUT))


### PR DESCRIPTION
This pull request fixes #1078. I believe that this fix should not break in any other circumstances.