### PR TITLE
Packaging clang: always add a clang-cl symlink to clang for convenience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 strip-ansi-escapes = "0.1"
-tar = "0.4"
+tar = "^0.4.38"
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "io-util", "time", "net", "process", "macros"] }
 tokio-serde = "0.8"

--- a/docs/DistributedQuickstart.md
+++ b/docs/DistributedQuickstart.md
@@ -190,10 +190,9 @@ sufficient to run the compiler without relying on any external files. If you hav
 compatible with icecream (created with `icecc-create-env`, like
 [these ones](https://github.com/jyavenard/mozilla-icecream) for macOS), they should also work
 with sccache. To create a Windows toolchain, it is recommended that you download the [Clang
-binaries for Ubuntu 16.04](http://releases.llvm.org/download.html) and extract them,
-package up the toolchain using the extracted `bin/clang` file (requires
-[PR #321](https://github.com/mozilla/sccache/pull/321)) and then insert `bin/clang-cl` at
-the appropriate path as a symlink to the `bin/clang` binary.
+binaries for Ubuntu](https://github.com/llvm/llvm-project/releases) and extract them,
+package up the toolchain using the extracted `bin/clang` file (`bin/clang-cl` would be created
+as a symlink to `bin/clang` during packaging.)
 
 Considerations when distributing from macOS
 -------------------------------------------

--- a/src/dist/pkg.rs
+++ b/src/dist/pkg.rs
@@ -169,8 +169,20 @@ mod toolchain_imp {
                 builder.append_dir(tar_path, dir_path)?
             }
             for (tar_path, file_path) in file_set.into_iter() {
-                let file = &mut fs::File::open(file_path)?;
-                builder.append_file(tar_path, file)?
+                let file = &mut fs::File::open(&file_path)?;
+                builder.append_file(&tar_path, file)?;
+                // Should have no need to package clang-cl.exe since the dist
+                // server must a Linux environemnt.
+                if file_path.file_name().unwrap_or_default() == "clang" {
+                    let mut header = tar::Header::new_gnu();
+                    header.set_entry_type(tar::EntryType::Symlink);
+                    header.set_size(0);
+                    builder.append_link(
+                        &mut header,
+                        tar_path.with_file_name("clang-cl"),
+                        "clang",
+                    )?;
+                }
             }
             builder.finish().map_err(Into::into)
         }


### PR DESCRIPTION
I don't see existing tests for packaging and I'm not sure it is worthwhile to add them just for this. I've tried locally that this works well.