### PR TITLE
add more input file extensions

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -803,4 +803,48 @@ mod test {
             hash_key(digest, Language::C, &args, &[], &[], PREPROCESSED, false)
         );
     }
+
+    #[test]
+    fn test_language_from_file_name() {
+        fn t(extension: &str, expected: Language) {
+            let path_str = format!("input.{}", extension);
+            let path = Path::new(&path_str);
+            let actual = Language::from_file_name(path);
+            assert_eq!(actual, Some(expected));
+        }
+
+        t("c", Language::C);
+
+        t("C", Language::Cxx);
+        t("cc", Language::Cxx);
+        t("cp", Language::Cxx);
+        t("cpp", Language::Cxx);
+        t("CPP", Language::Cxx);
+        t("cxx", Language::Cxx);
+        t("c++", Language::Cxx);
+
+        t("m", Language::ObjectiveC);
+
+        t("M", Language::ObjectiveCxx);
+        t("mm", Language::ObjectiveCxx);
+
+        t("cu", Language::Cuda);
+    }
+
+    #[test]
+    fn test_language_from_file_name_none() {
+        fn t(extension: &str) {
+            let path_str = format!("input.{}", extension);
+            let path = Path::new(&path_str);
+            let actual = Language::from_file_name(path);
+            let expected = None;
+            assert_eq!(actual, expected);
+        }
+
+        // gcc parses file-extensions as case-sensitive
+        t("Cp");
+        t("Cpp");
+        t("Mm");
+        t("Cu");
+    }
 }

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -114,7 +114,8 @@ impl Language {
             // gcc: https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html
             Some("c") => Some(Language::C),
             // TODO i
-            Some("C") | Some("cc") | Some("cp") | Some("cpp") | Some("CPP") | Some("cxx") | Some("c++") => Some(Language::Cxx),
+            Some("C") | Some("cc") | Some("cp") | Some("cpp") | Some("CPP") | Some("cxx")
+            | Some("c++") => Some(Language::Cxx),
             // TODO ii
             // TODO H hh hp hpp HPP hxx h++
             // TODO tcc

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -111,10 +111,17 @@ impl ParsedArguments {
 impl Language {
     pub fn from_file_name(file: &Path) -> Option<Self> {
         match file.extension().and_then(|e| e.to_str()) {
+            // gcc: https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html
             Some("c") => Some(Language::C),
-            Some("C") | Some("cc") | Some("cpp") | Some("cxx") => Some(Language::Cxx),
+            // TODO i
+            Some("C") | Some("cc") | Some("cp") | Some("cpp") | Some("CPP") | Some("cxx") | Some("c++") => Some(Language::Cxx),
+            // TODO ii
+            // TODO H hh hp hpp HPP hxx h++
+            // TODO tcc
             Some("m") => Some(Language::ObjectiveC),
-            Some("mm") => Some(Language::ObjectiveCxx),
+            // TODO mi
+            Some("M") | Some("mm") => Some(Language::ObjectiveCxx),
+            // TODO mii
             Some("cu") => Some(Language::Cuda),
             e => {
                 trace!("Unknown source extension: {}", e.unwrap_or("(None)"));


### PR DESCRIPTION
add more file extensions from https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html

note: these are case-sensitive, so gcc does not recognize `input.CpP`
