### PR TITLE
Support Google Cloud Storage bucket key prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ If you're using authentication, either set `SCCACHE_GCS_KEY_PATH` to the locatio
 a URL that returns the oauth token.
 By default, SCCACHE on GCS will be read-only. To change this, set `SCCACHE_GCS_RW_MODE` to either `READ_ONLY` or `READ_WRITE`.
 
+You can also define a prefix that will be prepended to the keys of all cache objects created and read within the GCS bucket, effectively creating a scope. To do that use the `SCCACHE_GCS_KEY_PREFIX` environment variable. This can be useful when sharing a bucket with another application.
+
 ### Azure
 To use Azure Blob Storage, you'll need your Azure connection string and an _existing_ Blob Storage container name.  Set the `SCCACHE_AZURE_CONNECTION_STRING`
 environment variable to your connection string, and `SCCACHE_AZURE_BLOB_CONTAINER` to the name of the container to use.  Note that sccache will not create

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -309,13 +309,14 @@ pub fn storage_from_config(config: &Config, pool: &tokio::runtime::Handle) -> Ar
             }
             CacheType::GCS(config::GCSCacheConfig {
                 ref bucket,
+                ref key_prefix,
                 ref cred_path,
                 ref url,
                 rw_mode,
             }) => {
                 debug!(
-                    "Trying GCS bucket({}, {:?}, {:?}, {:?})",
-                    bucket, cred_path, url, rw_mode
+                    "Trying GCS bucket({}, {}, {:?}, {:?}, {:?})",
+                    bucket, key_prefix, cred_path, url, rw_mode
                 );
                 #[cfg(feature = "gcs")]
                 {
@@ -359,7 +360,12 @@ pub fn storage_from_config(config: &Config, pool: &tokio::runtime::Handle) -> Ar
                     let gcs_cred_provider = service_account_info_opt
                         .map(|info| GCSCredentialProvider::new(gcs_read_write_mode, info));
 
-                    match GCSCache::new(bucket.to_owned(), gcs_cred_provider, gcs_read_write_mode) {
+                    match GCSCache::new(
+                        bucket.to_owned(),
+                        key_prefix.to_owned(),
+                        gcs_cred_provider,
+                        gcs_read_write_mode,
+                    ) {
                         Ok(s) => {
                             trace!("Using GCSCache");
                             return Arc::new(s);

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,6 +176,7 @@ pub enum GCSCacheRWMode {
 #[serde(deny_unknown_fields)]
 pub struct GCSCacheConfig {
     pub bucket: String,
+    pub key_prefix: String,
     pub cred_path: Option<PathBuf>,
     pub url: Option<String>,
     pub rw_mode: GCSCacheRWMode,
@@ -485,6 +486,13 @@ fn config_from_env() -> EnvConfig {
         .map(|url| MemcachedCacheConfig { url });
 
     let gcs = env::var("SCCACHE_GCS_BUCKET").ok().map(|bucket| {
+        let key_prefix = env::var("SCCACHE_GCS_KEY_PREFIX")
+            .ok()
+            .as_ref()
+            .map(|s| s.trim_end_matches('/'))
+            .filter(|s| !s.is_empty())
+            .unwrap_or_default()
+            .to_owned();
         let url = env::var("SCCACHE_GCS_CREDENTIALS_URL").ok();
         let cred_path = env::var_os("SCCACHE_GCS_KEY_PATH").map(PathBuf::from);
 
@@ -510,6 +518,7 @@ fn config_from_env() -> EnvConfig {
         };
         GCSCacheConfig {
             bucket,
+            key_prefix,
             cred_path,
             url,
             rw_mode,


### PR DESCRIPTION
Adds support for Google Cloud Storage bucket key prefixes, similar to `SCCACHE_S3_KEY_PREFIX`.