### PR TITLE
Display error details when Azure connection string parsing fails

### DIFF
--- a/src/cache/azure.rs
+++ b/src/cache/azure.rs
@@ -31,7 +31,10 @@ impl AzureBlobCache {
     pub fn new() -> Result<AzureBlobCache> {
         let credentials = match EnvironmentProvider.provide_credentials() {
             Ok(creds) => creds,
-            Err(_) => bail!("Could not find Azure credentials in the environment"),
+            Err(err) => bail!(
+                "Could not find Azure credentials in the environment: {}",
+                err
+            ),
         };
 
         let container = match BlobContainer::new(


### PR DESCRIPTION
When using the Azure backend, and there is a problem with the connection string, then sccache does not report what's wrong with the connection string:

~~~
[2022-02-03T16:23:34Z WARN  sccache::cache::cache] Failed to create Azure cache: Could not find Azure credentials in the environment
~~~

After this fix, sccache properly includes the reason:

~~~
[2022-02-03T16:27:07Z WARN  sccache::cache::cache] Failed to create Azure cache: Could not find Azure credentials in the environment: Can not infer blob endpoint; connection string is missing BlobEndpoint, AccountName, and/or EndpointSuffix.
~~~