### PR TITLE
Parse env-deps from dep-info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
         env:
           CARGO_INCREMENTAL: '0'
           RUSTC_WRAPPER: ''
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off'
 
       - name: Generate coverage data (via `grcov`)
         id: coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,6 +973,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1262,31 @@ dependencies = [
  "log",
  "rand 0.7.3",
  "tokio",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
  "winapi 0.3.9",
 ]
 
@@ -1718,6 +1752,7 @@ dependencies = [
  "nix 0.23.1",
  "num_cpus",
  "number_prefix",
+ "once_cell",
  "openssl",
  "parity-tokio-ipc",
  "percent-encoding",
@@ -1732,6 +1767,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serial_test",
  "sha-1",
  "sha2",
  "strip-ansi-escapes",
@@ -1764,6 +1800,12 @@ dependencies = [
  "lazy_static",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
@@ -1859,6 +1901,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,6 +1994,12 @@ name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+
+[[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,8 @@ chrono = "0.4"
 itertools = "0.10"
 predicates = "=2.1.1"
 thirtyfour_sync = "0.27"
+once_cell = "1.9"
+serial_test = "0.5"
 
 [target.'cfg(unix)'.dependencies]
 daemonize = "0.4"

--- a/docs/Rust.md
+++ b/docs/Rust.md
@@ -5,7 +5,7 @@ sccache includes support for caching Rust compilation. This includes many caveat
 * `--out-dir` is required.
 * `-o file` is not supported.
 * Compilation from stdin is not supported, a source file must be provided.
-* Values from `env!` will not be tracked in caching.
+* Values from `env!` require Rust >= 1.46 to be tracked in caching.
 * Procedural macros that read files from the filesystem may not be cached properly
 * Target specs aren't hashed (e.g. custom target specs)
 

--- a/tests/sccache_cargo.rs
+++ b/tests/sccache_cargo.rs
@@ -3,135 +3,198 @@
 //! Any copyright is dedicated to the Public Domain.
 //! http://creativecommons.org/publicdomain/zero/1.0/
 
-#![deny(rust_2018_idioms)]
+use anyhow::{Context, Result};
+use once_cell::sync::Lazy;
+
+use assert_cmd::prelude::*;
+use chrono::Local;
+use predicates::prelude::*;
+use serial_test::serial;
+use std::convert::Infallible;
+use std::ffi::OsString;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
 #[macro_use]
 extern crate log;
 
-/// Test that building a simple Rust crate with cargo using sccache results in a cache hit
-/// when built a second time.
-#[test]
-#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
-fn test_rust_cargo() {
-    test_rust_cargo_cmd("check", &[]);
-    test_rust_cargo_cmd("build", &[]);
+static SCCACHE_BIN: Lazy<PathBuf> = Lazy::new(|| assert_cmd::cargo::cargo_bin("sccache"));
+static CARGO: Lazy<OsString> = Lazy::new(|| std::env::var_os("CARGO").unwrap());
+static CRATE_DIR: Lazy<PathBuf> =
+    Lazy::new(|| Path::new(file!()).parent().unwrap().join("test-crate"));
+/// Ensures the logger is only initialized once. Panics if initialization fails.
+static LOGGER: Lazy<Result<(), Infallible>> = Lazy::new(|| {
+    env_logger::Builder::new()
+        .format(|f, record| {
+            writeln!(
+                f,
+                "{} [{}] - {}",
+                Local::now().format("%Y-%m-%dT%H:%M:%S%.3f"),
+                record.level(),
+                record.args()
+            )
+        })
+        .parse_env("RUST_LOG")
+        .init();
+    Ok(())
+});
 
-    #[cfg(feature = "unstable")]
-    test_rust_cargo_cmd("check", &[("RUSTFLAGS", std::ffi::OsStr::new("-Zprofile"))]);
-    #[cfg(feature = "unstable")]
-    test_rust_cargo_cmd("build", &[("RUSTFLAGS", std::ffi::OsStr::new("-Zprofile"))]);
+/// Used as a test setup fixture. The drop implementation cleans up after a _successful_ test.
+/// We catch the panic to ensure that the drop runs and the TempDir is cleaned up.
+struct SccacheTest<'a> {
+    /// Tempdir used for Sccache cache and cargo output. It is kept in the struct only to have the
+    /// destructor run when SccacheTest goes out of scope, but is never used otherwise.
+    #[allow(dead_code)]
+    tempdir: tempfile::TempDir,
+    env: Vec<(&'a str, std::ffi::OsString)>,
 }
 
-#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
-fn test_rust_cargo_cmd(cmd: &str, extra_envs: &[(&str, &std::ffi::OsStr)]) {
-    use assert_cmd::prelude::*;
-    use chrono::Local;
-    use predicates::prelude::*;
-    use std::env;
-    use std::ffi::OsStr;
-    use std::fs;
-    use std::io::Write;
-    use std::path::Path;
-    use std::process::{Command, Stdio};
+impl SccacheTest<'_> {
+    fn new(additional_envs: Option<&[(&'static str, std::ffi::OsString)]>) -> Result<Self> {
+        assert!(LOGGER.is_ok());
 
-    fn sccache_command() -> Command {
-        Command::new(assert_cmd::cargo::cargo_bin("sccache"))
+        // Create a temp directory to use for the disk cache.
+        let tempdir = tempfile::Builder::new()
+            .prefix("sccache_test_rust_cargo")
+            .tempdir()
+            .context("Failed to create tempdir")?;
+        let cache_dir = tempdir.path().join("cache");
+        fs::create_dir(&cache_dir)?;
+        let cargo_dir = tempdir.path().join("cargo");
+        fs::create_dir(&cargo_dir)?;
+
+        // Ensure there's no existing sccache server running.
+        stop_sccache()?;
+
+        trace!("sccache --start-server");
+
+        Command::new(SCCACHE_BIN.as_os_str())
+            .arg("--start-server")
+            .env("SCCACHE_DIR", &cache_dir)
+            .assert()
+            .try_success()
+            .context("Failed to start sccache server")?;
+
+        let mut env = vec![
+            ("CARGO_TARGET_DIR", cargo_dir.as_os_str().to_owned()),
+            ("RUSTC_WRAPPER", SCCACHE_BIN.as_os_str().to_owned()),
+            // Explicitly disable incremental compilation because sccache is unable to cache it at
+            // the time of writing.
+            ("CARGO_INCREMENTAL", OsString::from("0")),
+        ];
+
+        if let Some(vec) = additional_envs {
+            env.extend_from_slice(vec);
+        }
+
+        Ok(SccacheTest {
+            tempdir,
+            env: env.to_owned(),
+        })
     }
 
-    fn stop() {
-        trace!("sccache --stop-server");
-        drop(
-            sccache_command()
-                .arg("--stop-server")
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status(),
-        );
+    /// Show the statistics for sccache. This will be called at the end of a test and making this
+    /// an associated function will ensure that the struct lives until the end of the test.
+    fn show_stats(&self) -> assert_cmd::assert::AssertResult {
+        trace!("sccache --show-stats");
+        Command::new(SCCACHE_BIN.as_os_str())
+            .args(&["--show-stats", "--stats-format=json"])
+            .assert()
+            .try_success()
     }
+}
 
-    drop(
-        env_logger::Builder::new()
-            .format(|f, record| {
-                write!(
-                    f,
-                    "{} [{}] - {}",
-                    Local::now().format("%Y-%m-%dT%H:%M:%S%.3f"),
-                    record.level(),
-                    record.args()
-                )
-            })
-            .parse_env("RUST_LOG")
-            .try_init(),
-    );
-    let cargo = env!("CARGO");
-    debug!("cargo: {}", cargo);
-    let sccache = assert_cmd::cargo::cargo_bin("sccache");
-    debug!("sccache: {:?}", sccache);
-    let crate_dir = Path::new(file!()).parent().unwrap().join("test-crate");
-    // Ensure there's no existing sccache server running.
-    stop();
-    // Create a temp directory to use for the disk cache.
-    let tempdir = tempfile::Builder::new()
-        .prefix("sccache_test_rust_cargo")
-        .tempdir()
-        .unwrap();
-    let cache_dir = tempdir.path().join("cache");
-    fs::create_dir(&cache_dir).unwrap();
-    let cargo_dir = tempdir.path().join("cargo");
-    fs::create_dir(&cargo_dir).unwrap();
-    // Start a new sccache server.
-    trace!("sccache --start-server");
-    sccache_command()
-        .arg("--start-server")
-        .env("SCCACHE_DIR", &cache_dir)
-        .assert()
-        .success();
+impl Drop for SccacheTest<'_> {
+    fn drop(&mut self) {
+        stop_sccache().expect("Stopping Sccache server failed");
+    }
+}
+
+fn stop_sccache() -> Result<()> {
+    trace!("sccache --stop-server");
+
+    Command::new(SCCACHE_BIN.as_os_str())
+        .arg("--stop-server")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("Failed to stop sccache server")?;
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rust_cargo_check() -> Result<()> {
+    test_rust_cargo_cmd("check", SccacheTest::new(None)?)
+}
+
+#[test]
+#[serial]
+fn test_rust_cargo_build() -> Result<()> {
+    test_rust_cargo_cmd("build", SccacheTest::new(None)?)
+}
+
+#[cfg(feature = "unstable")]
+#[test]
+#[serial]
+fn test_rust_cargo_check_nightly() -> Result<()> {
+    test_rust_cargo_cmd(
+        "check",
+        SccacheTest::new(Some(&[("RUSTFLAGS", OsString::from("-Zprofile"))]))?,
+    )
+}
+
+#[cfg(feature = "unstable")]
+#[test]
+#[serial]
+fn test_rust_cargo_build_nightly() -> Result<()> {
+    test_rust_cargo_cmd(
+        "build",
+        SccacheTest::new(Some(&[("RUSTFLAGS", OsString::from("-Zprofile"))]))?,
+    )
+}
+
+/// Test that building a simple Rust crate with cargo using sccache results in a cache hit
+/// when built a second time and a cache miss, when the environment variable referenced via
+/// env! is changed.
+fn test_rust_cargo_cmd(cmd: &str, test_info: SccacheTest) -> Result<()> {
     // `cargo clean` first, just to be sure there's no leftover build objects.
-    let mut envs = vec![
-        ("RUSTC_WRAPPER", sccache.as_ref()),
-        ("CARGO_TARGET_DIR", cargo_dir.as_ref()),
-        // Explicitly disable incremental compilation because sccache is unable
-        // to cache it at the time of writing.
-        ("CARGO_INCREMENTAL", OsStr::new("0")),
-    ];
-    envs.extend_from_slice(extra_envs);
-    Command::new(&cargo)
+    Command::new(CARGO.as_os_str())
         .args(&["clean"])
-        .envs(envs.iter().copied())
-        .current_dir(&crate_dir)
+        .envs(test_info.env.iter().cloned())
+        .current_dir(CRATE_DIR.as_os_str())
         .assert()
-        .success();
+        .try_success()?;
     // Now build the crate with cargo.
-    Command::new(&cargo)
+    Command::new(CARGO.as_os_str())
         .args(&[cmd, "--color=never"])
-        .envs(envs.iter().copied())
-        .current_dir(&crate_dir)
+        .envs(test_info.env.iter().cloned())
+        .current_dir(CRATE_DIR.as_os_str())
         .assert()
-        .stderr(predicates::str::contains("\x1b[").from_utf8().not())
-        .success();
+        .try_stderr(predicates::str::contains("\x1b[").from_utf8().not())?
+        .try_success()?;
     // Clean it so we can build it again.
-    Command::new(&cargo)
+    Command::new(CARGO.as_os_str())
         .args(&["clean"])
-        .envs(envs.iter().copied())
-        .current_dir(&crate_dir)
+        .envs(test_info.env.iter().cloned())
+        .current_dir(CRATE_DIR.as_os_str())
         .assert()
-        .success();
-    Command::new(&cargo)
+        .try_success()?;
+    Command::new(CARGO.as_os_str())
         .args(&[cmd, "--color=always"])
-        .envs(envs.iter().copied())
-        .current_dir(&crate_dir)
+        .envs(test_info.env.iter().cloned())
+        .current_dir(CRATE_DIR.as_os_str())
         .assert()
-        .stderr(predicates::str::contains("\x1b[").from_utf8())
-        .success();
-    // Now get the stats and ensure that we had a cache hit for the second build.
-    // The test crate has one dependency (itoa) so there are two separate
-    // compilations.
-    trace!("sccache --show-stats");
-    sccache_command()
-        .args(&["--show-stats", "--stats-format=json"])
-        .assert()
-        .stdout(predicates::str::contains(r#""cache_hits":{"counts":{"Rust":2}}"#).from_utf8())
-        .success();
-    stop();
+        .try_stderr(predicates::str::contains("\x1b[").from_utf8())?
+        .try_success()?;
+
+    test_info
+        .show_stats()?
+        .try_stdout(predicates::str::contains(r#""cache_hits":{"counts":{"Rust":2}}"#).from_utf8())?
+        .try_success()?;
+
+    Ok(())
 }

--- a/tests/test-crate/Cargo.toml
+++ b/tests/test-crate/Cargo.toml
@@ -6,3 +6,11 @@ authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 [dependencies]
 # Arbitrary crate dependency that doesn't pull in any transitive dependencies.
 itoa = "0.3.4"
+
+[lib]
+name = "mylib"
+path = "src/lib.rs"
+
+[[bin]]
+name = "mybin"
+path = "src/bin.rs"

--- a/tests/test-crate/src/bin.rs
+++ b/tests/test-crate/src/bin.rs
@@ -1,0 +1,5 @@
+extern crate mylib;
+
+fn main() {
+    mylib::env_dep_test();
+}

--- a/tests/test-crate/src/lib.rs
+++ b/tests/test-crate/src/lib.rs
@@ -1,5 +1,9 @@
 fn unused() {}
 
+pub fn env_dep_test() {
+    println!("Env var: {}", env!("TEST_ENV_VAR"));
+}
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
Parse the environment variables (and their values) referenced in rust code via `env!` or `option_env!` from the `dep-info` file and add them to the hash. The `CARGO_` env variables apparently still have to be blanket added to the hash, since they don't appear in the `dep-info` file.

Closes #972 
Closes #804