### PR TITLE
Support Azure Blob Storage key prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ To use Azure Blob Storage, you'll need your Azure connection string and an _exis
 environment variable to your connection string, and `SCCACHE_AZURE_BLOB_CONTAINER` to the name of the container to use.  Note that sccache will not create
 the container for you - you'll need to do that yourself.
 
+You can also define a prefix that will be prepended to the keys of all cache objects created and read within the container, effectively creating a scope. To do that use the `SCCACHE_AZURE_KEY_PREFIX` environment variable. This can be useful when sharing a bucket with another application.
+
 **Important:** The environment variables are only taken into account when the server starts, i.e. only on the first run.
 
 ---

--- a/src/cache/azure.rs
+++ b/src/cache/azure.rs
@@ -29,18 +29,7 @@ pub struct AzureBlobCache {
 }
 
 impl AzureBlobCache {
-    pub fn new(credentials: Option<AzureCredentials>, key_prefix: &str) -> Result<AzureBlobCache> {
-        let credentials = match credentials {
-            Some(creds) => creds,
-            None => match EnvironmentProvider.provide_credentials() {
-                Ok(creds) => creds,
-                Err(err) => bail!(
-                    "Could not find Azure credentials in the environment: {}",
-                    err
-                ),
-            },
-        };
-
+    pub fn new(credentials: AzureCredentials, key_prefix: &str) -> Result<AzureBlobCache> {
         let container = match BlobContainer::new(
             credentials.azure_blob_endpoint(),
             credentials.blob_container_name(),
@@ -124,10 +113,10 @@ fn normalize_key() {
         String::from("container name"),
     );
 
-    let cache = AzureBlobCache::new(Some(credentials.clone()), "").unwrap();
+    let cache = AzureBlobCache::new(credentials.clone(), "").unwrap();
     assert_eq!(cache.normalize_key("key"), String::from("key"));
 
-    let cache = AzureBlobCache::new(Some(credentials), "prefix").unwrap();
+    let cache = AzureBlobCache::new(credentials, "prefix").unwrap();
     assert_eq!(cache.normalize_key("key"), String::from("prefix/key"));
 }
 
@@ -140,15 +129,15 @@ fn location() {
         String::from("container name"),
     );
 
-    let cache = AzureBlobCache::new(Some(credentials.clone()), "").unwrap();
+    let cache = AzureBlobCache::new(credentials.clone(), "").unwrap();
     assert_eq!(
         cache.location(),
-        String::from("Azure, container: BlobContainer(url=blob endpoint/container name/), (none)")
+        String::from("Azure, container: BlobContainer(url=blob endpoint/container name/), key_prefix: (none)")
     );
 
-    let cache = AzureBlobCache::new(Some(credentials), "prefix").unwrap();
+    let cache = AzureBlobCache::new(credentials, "prefix").unwrap();
     assert_eq!(
         cache.location(),
-        String::from("Azure, container: BlobContainer(url=blob endpoint/container name/), prefix")
+        String::from("Azure, container: BlobContainer(url=blob endpoint/container name/), key_prefix: prefix")
     );
 }

--- a/src/cache/azure.rs
+++ b/src/cache/azure.rs
@@ -97,7 +97,7 @@ impl Storage for AzureBlobCache {
 
     fn location(&self) -> String {
         format!(
-            "Azure, container: {}, {}",
+            "Azure, container: {}, key_prefix: {}",
             self.container,
             if self.key_prefix.is_empty() {
                 "(none)"

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -296,10 +296,10 @@ pub trait Storage: Send + Sync {
 pub fn storage_from_config(config: &Config, pool: &tokio::runtime::Handle) -> Arc<dyn Storage> {
     for cache_type in config.caches.iter() {
         match *cache_type {
-            CacheType::Azure(config::AzureCacheConfig) => {
-                debug!("Trying Azure Blob Store account");
+            CacheType::Azure(config::AzureCacheConfig { ref key_prefix }) => {
+                debug!("Trying Azure Blob Store account({})", key_prefix);
                 #[cfg(feature = "azure")]
-                match AzureBlobCache::new() {
+                match AzureBlobCache::new(None, key_prefix) {
                     Ok(storage) => {
                         trace!("Using AzureBlobCache");
                         return Arc::new(storage);

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "azure")]
-use crate::{azure, azure::AzureCredentialsProvider, cache::azure::AzureBlobCache};
 use crate::cache::disk::DiskCache;
 #[cfg(feature = "gcs")]
 use crate::cache::gcs::{self, GCSCache, GCSCredentialProvider, RWMode, ServiceAccountInfo};
@@ -24,6 +22,8 @@ use crate::cache::redis::RedisCache;
 #[cfg(feature = "s3")]
 use crate::cache::s3::S3Cache;
 use crate::config::{self, CacheType, Config};
+#[cfg(feature = "azure")]
+use crate::{azure, azure::AzureCredentialsProvider, cache::azure::AzureBlobCache};
 use std::fmt;
 use std::fs;
 #[cfg(feature = "gcs")]


### PR DESCRIPTION
Similar to how we support key prefixes in S3 and Google Cloud Storage.

Introduces `SCCACHE_AZURE_KEY_PREFIX`.