### PR TITLE
Fix clippy lints and bump linter version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: ./.github/actions/rust-toolchain
         with:
           components: ${{ matrix.component }}
-          toolchain: 1.54.0
+          toolchain: 1.58.1
 
       - name: clippy version
         run: cargo clippy --version

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -25,12 +25,15 @@ dir = "/tmp/.cache/sccache"
 size = 7516192768 # 7 GiBytes
 
 [cache.gcs]
-# optional url
-url = "..."
+# optional oauth url
+oauth_url = "..."
+# optional deprecated url
+deprecated_url = "..."
 rw_mode = "READ_ONLY"
 # rw_mode = "READ_WRITE"
 cred_path = "/psst/secret/cred"
 bucket = "bucket"
+key_prefix = "prefix"
 
 [cache.memcached]
 url = "..."
@@ -42,6 +45,7 @@ url = "redis://user:passwd@1.2.3.4:6379/1"
 bucket = "name"
 endpoint = "s3-us-east-1.amazonaws.com"
 use_ssl = true
+key_prefix = "s3prefix"
 ```
 
 ## env

--- a/src/compiler/args.rs
+++ b/src/compiler/args.rs
@@ -307,6 +307,7 @@ macro_rules! ArgData {
     };
     { $( $tok:tt )+ } => {
         #[derive(Clone, Debug, PartialEq)]
+        #[allow(clippy::enum_variant_names)]
         enum ArgData {
             $($tok)+
         }

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -581,7 +581,7 @@ pub fn parse_arguments(
             let arg = try_or_cannot_cache!(arg, "argument parse");
             // Eagerly bail if it looks like we need to do more complicated work
             use crate::compiler::gcc::ArgData::*;
-            let mut args = match arg.get_data() {
+            let args = match arg.get_data() {
                 Some(SplitDwarf) | Some(TestCoverage) | Some(Coverage) | Some(DoCompilation)
                 | Some(Language(_)) | Some(Output(_)) | Some(TooHardFlag) | Some(XClang(_))
                 | Some(TooHard(_)) => cannot_cache!(arg
@@ -621,7 +621,7 @@ pub fn parse_arguments(
                 _ => NormalizedDisposition::Separated,
             };
             for arg in arg.normalize(norm).iter_os_strings() {
-                append_fn(arg, &mut args);
+                append_fn(arg, args);
             }
         }
     }

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -115,7 +115,6 @@ pub struct RustHasher {
 #[derive(Debug, Clone)]
 pub struct RustupProxy {
     proxy_executable: PathBuf,
-    filetime: FileTime,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -553,13 +552,8 @@ impl RustupProxy {
     where
         P: AsRef<Path>,
     {
-        let filetime = fs::metadata(proxy_executable.as_ref())
-            .map(|attr| FileTime::from_last_modification_time(&attr))?;
         let proxy_executable = proxy_executable.as_ref().to_owned();
-        Ok(Self {
-            proxy_executable,
-            filetime,
-        })
+        Ok(Self { proxy_executable })
     }
 
     pub async fn find_proxy_executable<T>(

--- a/src/config.rs
+++ b/src/config.rs
@@ -247,7 +247,7 @@ impl CacheConfigs {
             .chain(gcs.map(CacheType::GCS))
             .chain(azure.map(CacheType::Azure))
             .collect();
-        let fallback = disk.unwrap_or_else(Default::default);
+        let fallback = disk.unwrap_or_default();
 
         (caches, fallback)
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -684,6 +684,8 @@ where
     tx: mpsc::Sender<ServerMessage>,
 
     /// Information tracking how many services (connected clients) are active.
+    /// This field causes [WaitUntilZero] to wait until this struct drops.
+    #[allow(dead_code)]
     info: ActiveInfo,
 }
 
@@ -1748,6 +1750,7 @@ struct WaitUntilZero {
 }
 
 #[derive(Clone)]
+#[allow(dead_code)]
 struct ActiveInfo {
     info: Arc<Mutex<Info>>,
 }

--- a/src/simples3/s3.rs
+++ b/src/simples3/s3.rs
@@ -195,13 +195,14 @@ impl Bucket {
         creds: &AwsCredentials,
     ) -> String {
         let string = format!(
-            "{verb}\n{md5}\n{ty}\n{date}\n{headers}{resource}",
+            "{verb}\n{md5}\n{ty}\n{date}\n{headers}/{name}/{path}",
             verb = verb,
             md5 = md5,
             ty = content_type,
             date = date,
             headers = headers,
-            resource = format!("/{}/{}", self.name, path)
+            name = self.name,
+            path = path,
         );
         let signature = signature(&string, creds.aws_secret_access_key());
         format!("AWS {}:{}", creds.aws_access_key_id(), signature)

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -53,7 +53,7 @@ const TC_CACHE_SIZE: u64 = 1024 * 1024 * 1024; // 1 gig
 pub fn start_local_daemon(cfg_path: &Path, cached_cfg_path: &Path) {
     // Don't run this with run() because on Windows `wait_with_output`
     // will hang because the internal server process is not detached.
-    sccache_command()
+    let _ = sccache_command()
         .arg("--start-server")
         .env("SCCACHE_CONF", cfg_path)
         .env("SCCACHE_CACHED_CONF", cached_cfg_path)


### PR DESCRIPTION
- fixes clippy lints detected with rust 1.58.1
- Bumps the linter in CI to use rust 1.58.1

Closes #1111 
Closes #1112