### PR TITLE
Fix clippy lints for dist-server

### DIFF
--- a/src/bin/sccache-dist/build.rs
+++ b/src/bin/sccache-dist/build.rs
@@ -477,7 +477,7 @@ fn docker_diff(cid: &str) -> Result<String> {
 // Force remove the container
 fn docker_rm(cid: &str) -> Result<()> {
     Command::new("docker")
-        .args(&["rm", "-f", &cid])
+        .args(&["rm", "-f", cid])
         .check_run()
         .context("Failed to force delete container")
 }
@@ -511,7 +511,7 @@ impl DockerBuilder {
             .args(&["ps", "-a", "--format", "{{.ID}} {{.Image}}"])
             .check_stdout_trim()
             .context("Unable to list all Docker containers")?;
-        if containers != "" {
+        if !containers.is_empty() {
             let mut containers_to_rm = vec![];
             for line in containers.split(|c| c == '\n') {
                 let mut iter = line.splitn(2, ' ');
@@ -541,7 +541,7 @@ impl DockerBuilder {
             .args(&["images", "--format", "{{.ID}} {{.Repository}}"])
             .check_stdout_trim()
             .context("Failed to list all docker images")?;
-        if images != "" {
+        if !images.is_empty() {
             let mut images_to_rm = vec![];
             for line in images.split(|c| c == '\n') {
                 let mut iter = line.splitn(2, ' ');
@@ -604,12 +604,12 @@ impl DockerBuilder {
     fn clean_container(&self, cid: &str) -> Result<()> {
         // Clean up any running processes
         Command::new("docker")
-            .args(&["exec", &cid, "/busybox", "kill", "-9", "-1"])
+            .args(&["exec", cid, "/busybox", "kill", "-9", "-1"])
             .check_run()
             .context("Failed to run kill on all processes in container")?;
 
-        let diff = docker_diff(&cid)?;
-        if diff != "" {
+        let diff = docker_diff(cid)?;
+        if !diff.is_empty() {
             let mut lastpath = None;
             for line in diff.split(|c| c == '\n') {
                 let mut iter = line.splitn(2, ' ');
@@ -643,7 +643,7 @@ impl DockerBuilder {
                 }
                 lastpath = Some(changepath);
                 if let Err(e) = Command::new("docker")
-                    .args(&["exec", &cid, "/busybox", "rm", "-rf", changepath])
+                    .args(&["exec", cid, "/busybox", "rm", "-rf", changepath])
                     .check_run()
                 {
                     // We do a final check anyway, so just continue
@@ -651,9 +651,9 @@ impl DockerBuilder {
                 }
             }
 
-            let newdiff = docker_diff(&cid)?;
+            let newdiff = docker_diff(cid)?;
             // See note about changepath == "/tmp" above
-            if newdiff != "" && newdiff != "C /tmp" {
+            if !newdiff.is_empty() && newdiff != "C /tmp" {
                 bail!(
                     "Attempted to delete files, but container still has a diff: {:?}",
                     newdiff
@@ -814,7 +814,7 @@ impl DockerBuilder {
             cmd.arg("-e").arg(env);
         }
         let shell_cmd = "cd \"$1\" && shift && exec \"$@\"";
-        cmd.args(&[cid, "/busybox", "sh", "-c", &shell_cmd]);
+        cmd.args(&[cid, "/busybox", "sh", "-c", shell_cmd]);
         cmd.arg(&executable);
         cmd.arg(cwd);
         cmd.arg(executable);

--- a/src/bin/sccache-dist/main.rs
+++ b/src/bin/sccache-dist/main.rs
@@ -215,7 +215,7 @@ fn parse() -> Result<Command> {
                     .value_of("config")
                     .expect("missing config in parsed subcommand"),
             );
-            check_init_syslog("sccache-scheduler", &matches);
+            check_init_syslog("sccache-scheduler", matches);
             if let Some(config) = scheduler_config::from_path(config_path)? {
                 Command::Scheduler(config)
             } else {
@@ -228,7 +228,7 @@ fn parse() -> Result<Command> {
                     .value_of("config")
                     .expect("missing config in parsed subcommand"),
             );
-            check_init_syslog("sccache-buildserver", &matches);
+            check_init_syslog("sccache-buildserver", matches);
             if let Some(config) = server_config::from_path(config_path)? {
                 Command::Server(config)
             } else {
@@ -262,10 +262,10 @@ fn create_jwt_server_token(
     key: &[u8],
 ) -> Result<String> {
     let key = jwt::EncodingKey::from_secret(key);
-    jwt::encode(&header, &ServerJwt { server_id }, &key).map_err(Into::into)
+    jwt::encode(header, &ServerJwt { server_id }, &key).map_err(Into::into)
 }
 fn dangerous_insecure_extract_jwt_server_token(server_token: &str) -> Option<ServerId> {
-    jwt::dangerous_insecure_decode::<ServerJwt>(&server_token)
+    jwt::dangerous_insecure_decode::<ServerJwt>(server_token)
         .map(|res| res.claims.server_id)
         .ok()
 }
@@ -333,7 +333,7 @@ fn run(command: Command) -> Result<i32> {
                 scheduler_config::ServerAuth::Insecure => {
                     warn!("Scheduler starting with DANGEROUSLY_INSECURE server authentication");
                     let token = INSECURE_DIST_SERVER_TOKEN;
-                    Box::new(move |server_token| check_server_token(server_token, &token))
+                    Box::new(move |server_token| check_server_token(server_token, token))
                 }
                 scheduler_config::ServerAuth::Token { token } => {
                     Box::new(move |server_token| check_server_token(server_token, &token))
@@ -395,7 +395,7 @@ fn run(command: Command) -> Result<i32> {
             let scheduler_auth = match scheduler_auth {
                 server_config::SchedulerAuth::Insecure => {
                     warn!("Server starting with DANGEROUSLY_INSECURE scheduler authentication");
-                    create_server_token(server_id, &INSECURE_DIST_SERVER_TOKEN)
+                    create_server_token(server_id, INSECURE_DIST_SERVER_TOKEN)
                 }
                 server_config::SchedulerAuth::Token { token } => {
                     create_server_token(server_id, &token)
@@ -519,6 +519,12 @@ impl Scheduler {
                 }
             }
         }
+    }
+}
+
+impl Default for Scheduler {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -742,7 +748,7 @@ impl SchedulerIncoming for Scheduler {
             }
             Some(ref mut details) if details.server_nonce != server_nonce => {
                 for job_id in details.jobs_assigned.iter() {
-                    if jobs.remove(&job_id).is_none() {
+                    if jobs.remove(job_id).is_none() {
                         warn!(
                             "Unknown job found when replacing server {}: {}",
                             server_id.addr(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -762,7 +762,7 @@ pub mod scheduler {
     }
 
     pub fn from_path(conf_path: &Path) -> Result<Option<Config>> {
-        super::try_read_config_file(&conf_path).context("Failed to load scheduler config file")
+        super::try_read_config_file(conf_path).context("Failed to load scheduler config file")
     }
 }
 
@@ -817,7 +817,7 @@ pub mod server {
     }
 
     pub fn from_path(conf_path: &Path) -> Result<Option<Config>> {
-        super::try_read_config_file(&conf_path).context("Failed to load server config file")
+        super::try_read_config_file(conf_path).context("Failed to load server config file")
     }
 }
 

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -608,7 +608,7 @@ mod server {
         fn verify_token(&self, job_id: JobId, token: &str) -> Result<()> {
             let valid_claims = JobJwt { job_id };
             let key = jwt::DecodingKey::from_secret(&self.server_key);
-            jwt::decode(&token, &key, &JWT_VALIDATION)
+            jwt::decode(token, &key, &JWT_VALIDATION)
                 .map_err(|e| anyhow!("JWT decode failed: {}", e))
                 .and_then(|res| {
                     fn identical_t<T>(_: &T, _: &T) {}
@@ -778,7 +778,7 @@ mod server {
                         let alloc_job_res: AllocJobResult = try_or_500_log!(req_id, handler.handle_alloc_job(&requester, toolchain));
                         let certs = server_certificates.lock().unwrap();
                         let res = AllocJobHttpResponse::from_alloc_job_result(alloc_job_res, &certs);
-                        prepare_response(&request, &res)
+                        prepare_response(request, &res)
                     },
                     (GET) (/api/v1/scheduler/server_certificate/{server_id: ServerId}) => {
                         let certs = server_certificates.lock().unwrap();
@@ -788,7 +788,7 @@ mod server {
                             cert_digest: cert_digest.clone(),
                             cert_pem: cert_pem.clone(),
                         };
-                        prepare_response(&request, &res)
+                        prepare_response(request, &res)
                     },
                     (POST) (/api/v1/scheduler/heartbeat_server) => {
                         let server_id = check_server_auth_or_err!(request);
@@ -807,7 +807,7 @@ mod server {
                             num_cpus,
                             job_authorizer
                         ));
-                        prepare_response(&request, &res)
+                        prepare_response(request, &res)
                     },
                     (POST) (/api/v1/scheduler/job_state/{job_id: JobId}) => {
                         let server_id = check_server_auth_or_err!(request);
@@ -817,11 +817,11 @@ mod server {
                         let res: UpdateJobStateResult = try_or_500_log!(req_id, handler.handle_update_job_state(
                             job_id, server_id, job_state
                         ));
-                        prepare_response(&request, &res)
+                        prepare_response(request, &res)
                     },
                     (GET) (/api/v1/scheduler/status) => {
                         let res: SchedulerStatusResult = try_or_500_log!(req_id, handler.handle_status());
-                        prepare_response(&request, &res)
+                        prepare_response(request, &res)
                     },
                     _ => {
                         warn!("Unknown request {:?}", request);
@@ -968,7 +968,7 @@ mod server {
                         trace!("Req {}: assign_job({}): {:?}", req_id, job_id, toolchain);
 
                         let res: AssignJobResult = try_or_500_log!(req_id, handler.handle_assign_job(job_id, toolchain));
-                        prepare_response(&request, &res)
+                        prepare_response(request, &res)
                     },
                     (POST) (/api/v1/distserver/submit_toolchain/{job_id: JobId}) => {
                         job_auth_or_401!(request, &job_authorizer, job_id);
@@ -977,7 +977,7 @@ mod server {
                         let body = request.data().expect("body was already read in submit_toolchain");
                         let toolchain_rdr = ToolchainReader(Box::new(body));
                         let res: SubmitToolchainResult = try_or_500_log!(req_id, handler.handle_submit_toolchain(&requester, job_id, toolchain_rdr));
-                        prepare_response(&request, &res)
+                        prepare_response(request, &res)
                     },
                     (POST) (/api/v1/distserver/run_job/{job_id: JobId}) => {
                         job_auth_or_401!(request, &job_authorizer, job_id);
@@ -996,7 +996,7 @@ mod server {
                         let outputs = outputs.into_iter().collect();
 
                         let res: RunJobResult = try_or_500_log!(req_id, handler.handle_run_job(&requester, job_id, command, outputs, inputs_rdr));
-                        prepare_response(&request, &res)
+                        prepare_response(request, &res)
                     },
                     _ => {
                         warn!("Unknown request {:?}", request);

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -34,7 +34,9 @@ fn basic_compile(tmpdir: &Path, sccache_cfg_path: &Path, sccache_cached_cfg_path
     write_source(tmpdir, source_file, "#if !defined(SCCACHE_TEST_DEFINE)\n#error SCCACHE_TEST_DEFINE is not defined\n#endif\nint x() { return 5; }");
     sccache_command()
         .args(&[
-            std::env::var("CC").unwrap_or("gcc".to_string()).as_str(),
+            std::env::var("CC")
+                .unwrap_or_else(|_| "gcc".to_string())
+                .as_str(),
             "-c",
             "-DSCCACHE_TEST_DEFINE",
         ])


### PR DESCRIPTION
With the dist-server feature enabled, additional clippy
warnings are emitted. Those are fixed by this commit.
Lints were:
- unneccessary borrow
- string != "" should be !string.is_empty()
- unwrap_or followed by a function call -> unwrap_or_else