### PR TITLE
GCC: suppress rewrite_includes_only with pedantic flags

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -96,6 +96,8 @@ pub struct ParsedArguments {
     pub profile_generate: bool,
     /// The color mode.
     pub color_mode: ColorMode,
+    /// arguments are incompatible with rewrite_includes_only
+    pub suppress_rewrite_includes_only: bool,
 }
 
 impl ParsedArguments {

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -55,6 +55,7 @@ impl CCompilerImpl for Clang {
             cwd,
             (&gcc::ARGS[..], &ARGS[..]),
             self.clangplusplus,
+            self.kind(),
         )
     }
 

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -283,6 +283,7 @@ where
         profile_generate: false,
         // FIXME: Implement me.
         color_mode: ColorMode::Auto,
+        suppress_rewrite_includes_only: false,
     })
 }
 
@@ -681,6 +682,7 @@ mod test {
             msvc_show_includes: false,
             profile_generate: false,
             color_mode: ColorMode::Auto,
+            suppress_rewrite_includes_only: false,
         };
         let compiler = &f.bins[0];
         // Compiler invocation.

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -47,7 +47,7 @@ impl CCompilerImpl for Gcc {
         arguments: &[OsString],
         cwd: &Path,
     ) -> CompilerArguments<ParsedArguments> {
-        parse_arguments(arguments, cwd, &ARGS[..], self.gplusplus)
+        parse_arguments(arguments, cwd, &ARGS[..], self.gplusplus, self.kind())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -129,6 +129,8 @@ ArgData! { pub
     // Only valid for clang, but this needs to be here since clang shares gcc's arg parsing.
     XClang(OsString),
     Arch(OsString),
+    PedanticFlag,
+    Standard(OsString),
 }
 
 use self::ArgData::*;
@@ -160,6 +162,8 @@ counted_array!(pub static ARGS: [ArgInfo<ArgData>; _] = [
     flag!("-P", TooHardFlag),
     take_arg!("-U", OsString, CanBeSeparated, PassThrough),
     take_arg!("-V", OsString, Separated, PassThrough),
+    flag!("-Werror=pedantic", PedanticFlag),
+    flag!("-Wpedantic", PedanticFlag),
     take_arg!("-Xassembler", OsString, Separated, PassThrough),
     take_arg!("-Xlinker", OsString, Separated, PassThrough),
     take_arg!("-Xpreprocessor", OsString, Separated, PreprocessorArgument),
@@ -196,8 +200,11 @@ counted_array!(pub static ARGS: [ArgInfo<ArgData>; _] = [
     flag!("-nostdinc", PreprocessorArgumentFlag),
     flag!("-nostdinc++", PreprocessorArgumentFlag),
     take_arg!("-o", PathBuf, CanBeSeparated, Output),
+    flag!("-pedantic", PedanticFlag),
+    flag!("-pedantic-errors", PedanticFlag),
     flag!("-remap", PreprocessorArgumentFlag),
     flag!("-save-temps", TooHardFlag),
+    take_arg!("-std", OsString, Concatenated('='), Standard),
     take_arg!("-stdlib", OsString, Concatenated('='), PreprocessorArgument),
     flag!("-trigraphs", PreprocessorArgumentFlag),
     take_arg!("-u", OsString, CanBeSeparated, PassThrough),
@@ -220,6 +227,7 @@ pub fn parse_arguments<S>(
     cwd: &Path,
     arg_info: S,
     plusplus: bool,
+    kind: CCompilerKind,
 ) -> CompilerArguments<ParsedArguments>
 where
     S: SearchableArgInfo<ArgData>,
@@ -234,6 +242,8 @@ where
     let mut extra_hash_files = vec![];
     let mut compilation = false;
     let mut multiple_input = false;
+    let mut pedantic_flag = false;
+    let mut language_extensions = true; // by default, GCC allows extensions
     let mut split_dwarf = false;
     let mut need_explicit_dep_target = false;
     let mut language = None;
@@ -274,6 +284,9 @@ where
             Some(TooHardFlag) | Some(TooHard(_)) => {
                 cannot_cache!(arg.flag_str().expect("Can't be Argument::Raw/UnknownFlag",))
             }
+            Some(PedanticFlag) => pedantic_flag = true,
+            // standard values vary, but extension values all start with "gnu"
+            Some(Standard(version)) => language_extensions = version.starts_with("gnu"),
             Some(SplitDwarf) => split_dwarf = true,
             Some(DoCompilation) => {
                 compilation = true;
@@ -342,6 +355,8 @@ where
         }
         let args = match arg.get_data() {
             Some(SplitDwarf)
+            | Some(PedanticFlag)
+            | Some(Standard(_))
             | Some(ProfileGenerate)
             | Some(ClangProfileUse(_))
             | Some(TestCoverage)
@@ -386,6 +401,8 @@ where
         let arg = try_or_cannot_cache!(arg, "argument parse");
         let args = match arg.get_data() {
             Some(SplitDwarf)
+            | Some(PedanticFlag)
+            | Some(Standard(_))
             | Some(ProfileGenerate)
             | Some(ClangProfileUse(_))
             | Some(TestCoverage)
@@ -478,6 +495,10 @@ where
         let dwo = output.with_extension("dwo");
         outputs.insert("dwo", dwo);
     }
+    let suppress_rewrite_includes_only = match kind {
+        CCompilerKind::Gcc => language_extensions && pedantic_flag,
+        _ => false,
+    };
     if outputs_gcno {
         let gcno = output.with_extension("gcno");
         outputs.insert("gcno", gcno);
@@ -502,6 +523,7 @@ where
         msvc_show_includes: false,
         profile_generate,
         color_mode,
+        suppress_rewrite_includes_only,
     })
 }
 
@@ -537,14 +559,20 @@ where
         cmd.arg("-P");
     }
     if rewrite_includes_only {
-        match kind {
-            CCompilerKind::Clang => {
-                cmd.arg("-frewrite-includes");
+        if parsed_args.suppress_rewrite_includes_only {
+            if log_enabled!(Trace) {
+                trace!("preprocess: pedantic arguments disable rewrite_includes_only");
             }
-            CCompilerKind::Gcc => {
-                cmd.arg("-fdirectives-only");
+        } else {
+            match kind {
+                CCompilerKind::Clang => {
+                    cmd.arg("-frewrite-includes");
+                }
+                CCompilerKind::Gcc => {
+                    cmd.arg("-fdirectives-only");
+                }
+                _ => {}
             }
-            _ => {}
         }
     }
     cmd.arg(&parsed_args.input)
@@ -652,7 +680,7 @@ pub fn generate_compile_commands(
             //     -fdirectives-only.
             //
             // Which is exactly what we do :-)
-            if rewrite_includes_only {
+            if rewrite_includes_only && !parsed_args.suppress_rewrite_includes_only {
                 arguments.push("-fdirectives-only".into());
             }
             arguments.push("-fpreprocessed".into());
@@ -753,7 +781,7 @@ mod test {
         plusplus: bool,
     ) -> CompilerArguments<ParsedArguments> {
         let args = arguments.iter().map(OsString::from).collect::<Vec<_>>();
-        parse_arguments(&args, ".".as_ref(), &ARGS[..], plusplus)
+        parse_arguments(&args, ".".as_ref(), &ARGS[..], plusplus, CCompilerKind::Gcc)
     }
 
     #[test]
@@ -1324,6 +1352,7 @@ mod test {
             msvc_show_includes: false,
             profile_generate: false,
             color_mode: ColorMode::Auto,
+            suppress_rewrite_includes_only: false,
         };
         let compiler = &f.bins[0];
         // Compiler invocation.

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -584,8 +584,8 @@ pub fn parse_arguments(
             use crate::compiler::gcc::ArgData::*;
             let args = match arg.get_data() {
                 Some(SplitDwarf) | Some(TestCoverage) | Some(Coverage) | Some(DoCompilation)
-                | Some(Language(_)) | Some(Output(_)) | Some(TooHardFlag) | Some(XClang(_))
-                | Some(TooHard(_)) => cannot_cache!(arg
+                | Some(PedanticFlag) | Some(Standard(_)) | Some(Language(_)) | Some(Output(_))
+                | Some(TooHardFlag) | Some(XClang(_)) | Some(TooHard(_)) => cannot_cache!(arg
                     .flag_str()
                     .unwrap_or("Can't handle complex arguments through clang",)),
                 None => match arg {
@@ -687,6 +687,7 @@ pub fn parse_arguments(
         profile_generate,
         // FIXME: implement color_mode for msvc.
         color_mode: ColorMode::Auto,
+        suppress_rewrite_includes_only: false,
     })
 }
 
@@ -1348,6 +1349,7 @@ mod test {
             msvc_show_includes: false,
             profile_generate: false,
             color_mode: ColorMode::Auto,
+            suppress_rewrite_includes_only: false,
         };
         let compiler = &f.bins[0];
         // Compiler invocation.
@@ -1391,6 +1393,7 @@ mod test {
             msvc_show_includes: false,
             profile_generate: false,
             color_mode: ColorMode::Auto,
+            suppress_rewrite_includes_only: false,
         };
         let compiler = &f.bins[0];
         // Compiler invocation.

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -48,7 +48,13 @@ impl CCompilerImpl for Nvcc {
         arguments: &[OsString],
         cwd: &Path,
     ) -> CompilerArguments<ParsedArguments> {
-        gcc::parse_arguments(arguments, cwd, (&gcc::ARGS[..], &ARGS[..]), false)
+        gcc::parse_arguments(
+            arguments,
+            cwd,
+            (&gcc::ARGS[..], &ARGS[..]),
+            false,
+            self.kind(),
+        )
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
CoinMP/CoinUtils configure checks the <cmath> header:
```

configure:9903: sccache g++ -c -O3 -pipe -DNDEBUG -pedantic-errors -Wparentheses -Wreturn-type -Wcast-qual -Wall -Wpointer-arith -Wwrite-strings -Wconversion -Wno-unknown-pragmas -Wno-long-long   -DCOINUTILS_BUILD  conftest.cc >&5
<built-in>: error: ISO C++ does not support '__int128' for '__x' [-Wpedantic]
<built-in>: error: ISO C++ does not support '__int128' for 'abs' [-Wpedantic]
In file included from /usr/include/c++/10/cmath:42,
                 from conftest.cc:64:
<built-in>: error: ISO C++ does not support '__int128' for 'type name' [-Wpedantic]

```
The problem is that in GCC 10, the bits/std_abs.h declares abs() for
GCC extension __int128, which -pedantic then complains about.

Implement the same solution that icecream has for this problem: for GCC,
if any -pedantic etc. flag is given and GNU extensions are enabled, don't
use -fdirectives-only.