### PR TITLE
Remove outdated badges from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,6 @@ categories = ["command-line-utilities", "development-tools::build-utils"]
 keywords = ["ccache"]
 edition = "2018"
 
-[badges]
-travis-ci = { repository = "mozilla/sccache" }
-appveyor = { repository = "mozilla/sccache" }
-
 [[bin]]
 name = "sccache"
 


### PR DESCRIPTION
- travis-ci and appveyor don't seem to be used anymore.
- The cargo reference now recommends putting badges into
  the Readme file, where we already a github CI badge.