### PR TITLE
More complete unit tests for Azure Blob Storage backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +212,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+
+[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +288,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
+name = "config"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
+dependencies = [
+ "lazy_static",
+ "nom",
+ "serde",
+]
+
+[[package]]
 name = "conhash"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +364,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd435b205a4842da59efd07628f921c096bc1cc0a156835b4fa0bcb9a19bcce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +410,20 @@ checksum = "70c24513e34f53b640819f0ac9f705b673fcf4006d7aab8778bee72ebfc89815"
 dependencies = [
  "boxfnonce",
  "libc",
+]
+
+[[package]]
+name = "deadpool"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d126179d86aee4556e54f5f3c6bf6d9884e7cc52cef82f77ee6f90a7747616d"
+dependencies = [
+ "async-trait",
+ "config",
+ "crossbeam-queue",
+ "num_cpus",
+ "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -470,6 +531,12 @@ checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "fastrand"
@@ -599,6 +666,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-locks"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,6 +713,12 @@ name = "futures-task"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -757,6 +845,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "base64 0.13.0",
+ "futures-lite",
+ "http",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url",
+]
+
+[[package]]
 name = "httparse"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +958,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +1052,19 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -1152,6 +1280,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,6 +1403,12 @@ dependencies = [
  "tokio",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -1787,6 +1932,7 @@ dependencies = [
  "walkdir",
  "which",
  "winapi 0.3.9",
+ "wiremock",
  "zip",
  "zstd",
 ]
@@ -1875,6 +2021,17 @@ dependencies = [
  "itoa 1.0.1",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -2016,6 +2173,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringmatch"
@@ -2459,6 +2622,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2541,6 +2705,12 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -2712,6 +2882,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "860c1b991b29b6bc5096b46bdaaea904417ed12fda814d38ccf1b869c13629c8"
+dependencies = [
+ "async-trait",
+ "deadpool",
+ "futures",
+ "futures-timer",
+ "http-types",
+ "hyper",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ predicates = "=2.1.1"
 thirtyfour_sync = "0.27"
 once_cell = "1.9"
 serial_test = "0.5"
+wiremock = "0.4.9"
 
 [target.'cfg(unix)'.dependencies]
 daemonize = "0.4"

--- a/src/cache/azure.rs
+++ b/src/cache/azure.rs
@@ -19,22 +19,18 @@ use crate::cache::{Cache, CacheRead, CacheWrite, Storage};
 use std::io;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-#[cfg(test)]
-use wiremock::matchers::{body_bytes, method, path};
-#[cfg(test)]
-use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::errors::*;
 
-pub struct AzureBlobCache {
-    container: Arc<BlobContainer>,
+pub struct AzureBlobCache<ConcreteBlobContainer: BlobContainer> {
+    container: Arc<ConcreteBlobContainer>,
     credentials: AzureCredentials,
     key_prefix: String,
 }
 
-impl AzureBlobCache {
-    pub fn new(credentials: AzureCredentials, key_prefix: &str) -> Result<AzureBlobCache> {
-        let container = match BlobContainer::new(
+impl AzureBlobCache<HttpBlobContainer> {
+    pub fn new(credentials: AzureCredentials, key_prefix: &str) -> Result<Self> {
+        let container = match HttpBlobContainer::new(
             credentials.azure_blob_endpoint(),
             credentials.blob_container_name(),
         ) {
@@ -42,13 +38,15 @@ impl AzureBlobCache {
             Err(e) => bail!("Error instantiating BlobContainer: {:?}", e),
         };
 
-        Ok(AzureBlobCache {
+        Ok(Self {
             container: Arc::new(container),
             credentials,
             key_prefix: key_prefix.to_owned(),
         })
     }
+}
 
+impl<ConcreteBlobContainer: BlobContainer> AzureBlobCache<ConcreteBlobContainer> {
     fn normalize_key(&self, key: &str) -> String {
         if self.key_prefix.is_empty() {
             key.to_string()
@@ -59,7 +57,7 @@ impl AzureBlobCache {
 }
 
 #[async_trait]
-impl Storage for AzureBlobCache {
+impl<ConcreteBlobContainer: BlobContainer> Storage for AzureBlobCache<ConcreteBlobContainer> {
     async fn get(&self, key: &str) -> Result<Cache> {
         let key = self.normalize_key(key);
         match self.container.get(&key, &self.credentials).await {
@@ -108,152 +106,138 @@ impl Storage for AzureBlobCache {
     }
 }
 
-#[test]
-fn location() {
-    let credentials = AzureCredentials::new(
-        "blob endpoint",
-        "account name",
-        None,
-        String::from("container name"),
-    );
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::cell::RefCell;
+    use std::fmt;
+    use std::sync::Mutex;
 
-    let cache = AzureBlobCache::new(credentials.clone(), "").unwrap();
-    assert_eq!(
-        cache.location(),
-        String::from("Azure, container: BlobContainer(url=blob endpoint/container name/), key_prefix: (none)")
-    );
-
-    let cache = AzureBlobCache::new(credentials, "prefix").unwrap();
-    assert_eq!(
-        cache.location(),
-        String::from("Azure, container: BlobContainer(url=blob endpoint/container name/), key_prefix: prefix")
-    );
-}
-
-#[tokio::test]
-async fn get_cache_hit() -> Result<()> {
-    let server = MockServer::start().await;
-    let credentials = AzureCredentials::new(
-        &server.uri(),
-        "account name",
-        None,
-        String::from("container name"),
-    );
-
-    Mock::given(method("GET"))
-        .and(path("/container%20name/foo/bar"))
-        .respond_with(ResponseTemplate::new(200).set_body_bytes(CacheWrite::new().finish()?))
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    let cache = AzureBlobCache::new(credentials, "").unwrap();
-    let result = cache.get("foo/bar").await;
-    assert!(result.is_ok());
-    match result.unwrap() {
-        Cache::Hit(_) => Ok(()),
-        x => bail!("Result {:?} is not Cache::Hit", x),
+    struct MockBlobContainer {
+        last_key: Mutex<RefCell<String>>,
     }
-}
 
-#[tokio::test]
-async fn get_cache_miss() -> Result<()> {
-    let server = MockServer::start().await;
-    let credentials = AzureCredentials::new(
-        &server.uri(),
-        "account name",
-        None,
-        String::from("container name"),
-    );
+    impl MockBlobContainer {
+        pub fn new() -> Self {
+            Self {
+                last_key: Mutex::new(RefCell::new(String::new())),
+            }
+        }
 
-    Mock::given(method("GET"))
-        .and(path("/container%20name/foo/bar"))
-        .respond_with(ResponseTemplate::new(404))
-        .expect(1)
-        .mount(&server)
-        .await;
+        pub fn get_last_key(&self) -> String {
+            let cell_guard = self.last_key.lock().unwrap();
+            let last_key = cell_guard.borrow();
+            last_key.clone()
+        }
 
-    let cache = AzureBlobCache::new(credentials, "").unwrap();
-    let result = cache.get("foo/bar").await;
-    assert!(result.is_ok());
-    match result.unwrap() {
-        Cache::Miss => Ok(()),
-        x => bail!("Result {:?} is not Cache::Miss", x),
+        pub fn set_last_key(&self, key: String) {
+            let last_key = self.last_key.lock().unwrap();
+            last_key.replace(key);
+        }
     }
-}
 
-#[tokio::test]
-async fn get_with_key_prefix() -> Result<()> {
-    let server = MockServer::start().await;
-    let credentials = AzureCredentials::new(
-        &server.uri(),
-        "account name",
-        None,
-        String::from("container name"),
-    );
-
-    Mock::given(method("GET"))
-        .and(path("/container%20name/prefix/foo/bar"))
-        .respond_with(ResponseTemplate::new(404))
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    let cache = AzureBlobCache::new(credentials, "prefix").unwrap();
-    let result = cache.get("foo/bar").await;
-    assert!(result.is_ok());
-    match result.unwrap() {
-        Cache::Miss => Ok(()),
-        x => bail!("Result {:?} is not Cache::Miss", x),
+    impl fmt::Display for MockBlobContainer {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "MockBlobContainer")
+        }
     }
-}
 
-#[tokio::test]
-async fn put() -> Result<()> {
-    let server = MockServer::start().await;
-    let credentials = AzureCredentials::new(
-        &server.uri(),
-        "account name",
-        None,
-        String::from("container name"),
-    );
+    #[async_trait]
+    impl BlobContainer for MockBlobContainer {
+        async fn get(&self, key: &str, _creds: &AzureCredentials) -> Result<Vec<u8>> {
+            self.set_last_key(key.to_owned());
+            Err(BadHttpStatusError(http::StatusCode::NOT_FOUND).into())
+        }
 
-    Mock::given(method("PUT"))
-        .and(path("/container%20name/foo/bar"))
-        .and(body_bytes(CacheWrite::new().finish()?))
-        .respond_with(ResponseTemplate::new(200))
-        .expect(1)
-        .mount(&server)
-        .await;
+        async fn put(&self, key: &str, _content: Vec<u8>, _creds: &AzureCredentials) -> Result<()> {
+            self.set_last_key(key.to_owned());
+            Ok(())
+        }
+    }
 
-    let cache = AzureBlobCache::new(credentials, "").unwrap();
-    let result = cache.put("foo/bar", CacheWrite::new()).await;
-    assert!(result.is_ok());
+    #[test]
+    fn normalize_key() {
+        let credentials = AzureCredentials::new(
+            "blob endpoint",
+            "account name",
+            None,
+            String::from("container name"),
+        );
 
-    Ok(())
-}
+        let cache = AzureBlobCache::new(credentials.clone(), "").unwrap();
+        assert_eq!(cache.normalize_key("key"), String::from("key"));
 
-#[tokio::test]
-async fn put_with_key_prefix() -> Result<()> {
-    let server = MockServer::start().await;
-    let credentials = AzureCredentials::new(
-        &server.uri(),
-        "account name",
-        None,
-        String::from("container name"),
-    );
+        let cache = AzureBlobCache::new(credentials, "prefix").unwrap();
+        assert_eq!(cache.normalize_key("key"), String::from("prefix/key"));
+    }
 
-    Mock::given(method("PUT"))
-        .and(path("/container%20name/prefix/foo/bar"))
-        .and(body_bytes(CacheWrite::new().finish()?))
-        .respond_with(ResponseTemplate::new(200))
-        .expect(1)
-        .mount(&server)
-        .await;
+    #[test]
+    fn location() {
+        let credentials = AzureCredentials::new(
+            "blob endpoint",
+            "account name",
+            None,
+            String::from("container name"),
+        );
 
-    let cache = AzureBlobCache::new(credentials, "prefix").unwrap();
-    let result = cache.put("foo/bar", CacheWrite::new()).await;
-    assert!(result.is_ok());
+        let cache = AzureBlobCache::new(credentials.clone(), "").unwrap();
+        assert_eq!(
+            cache.location(),
+            String::from("Azure, container: BlobContainer(url=blob endpoint/container name/), key_prefix: (none)")
+        );
 
-    Ok(())
+        let cache = AzureBlobCache::new(credentials, "prefix").unwrap();
+        assert_eq!(
+            cache.location(),
+            String::from("Azure, container: BlobContainer(url=blob endpoint/container name/), key_prefix: prefix")
+        );
+    }
+
+    #[tokio::test]
+    async fn get_with_key_prefix() -> Result<()> {
+        let credentials = AzureCredentials::new(
+            "endpoint",
+            "account name",
+            None,
+            String::from("container name"),
+        );
+        let container = Arc::new(MockBlobContainer::new());
+        let cache = AzureBlobCache {
+            container: container.clone(),
+            credentials,
+            key_prefix: String::from("prefix"),
+        };
+
+        let result = cache.get("foo/bar").await;
+        assert!(result.is_ok());
+        match result.unwrap() {
+            Cache::Miss => (),
+            x => bail!("Result {:?} is not Cache::Miss", x),
+        }
+        assert_eq!(container.get_last_key(), "prefix/foo/bar");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn put_with_key_prefix() -> Result<()> {
+        let credentials = AzureCredentials::new(
+            "endpoint",
+            "account name",
+            None,
+            String::from("container name"),
+        );
+        let container = Arc::new(MockBlobContainer::new());
+        let cache = AzureBlobCache {
+            container: container.clone(),
+            credentials,
+            key_prefix: String::from("prefix"),
+        };
+
+        let result = cache.put("foo/bar", CacheWrite::new()).await;
+        assert!(result.is_ok());
+        assert_eq!(container.get_last_key(), "prefix/foo/bar");
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Pull request #1109 introduced key prefix support for the Azure backend, with unit tests for `normalize_key()`, but those tests didn't test whether the Storage impl *actually* used `normalize_key()` when constructing an API request to Azure.

This change makes the unit tests more complete, by testing the Storage impl directly through the use of a mock HTTP server as Azure API endpoint.