### PR TITLE
Fix aarch64-unknown-linux-musl build by puliing GCC 10 specifically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,10 @@ jobs:
           echo deb [arch=arm64] http://azure.ports.ubuntu.com/ubuntu-ports/ $(lsb_release -c -s) main restricted universe multiverse | sudo tee /etc/apt/sources.list.d/99ports.list > /dev/null
           sudo dpkg --add-architecture arm64
           sudo apt-get update || true
-          sudo apt-get install musl-dev:arm64 binutils-multiarch gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+          sudo apt-get install musl-dev:arm64 binutils-multiarch gcc-10-aarch64-linux-gnu libc6-dev-arm64-cross
           apt-get download musl-tools:arm64
           sudo dpkg-deb -x musl-tools_*_arm64.deb /
-          sed 2iREALGCC=aarch64-linux-gnu-gcc /usr/bin/musl-gcc | sudo tee /usr/bin/aarch64-linux-musl-gcc > /dev/null
+          sed 2iREALGCC=aarch64-linux-gnu-gcc-10 /usr/bin/musl-gcc | sudo tee /usr/bin/aarch64-linux-musl-gcc > /dev/null
           sudo chmod +x /usr/bin/aarch64-linux-musl-gcc
         if: ${{ matrix.target == 'aarch64-unknown-linux-musl' }}
 


### PR DESCRIPTION
Previously, there would occur a mismatch on the GCC 9 version,
preventing us from installing it properly. Instead of that, try just
pulling GCC 10 rather than both 9 and 10.

Upstreamed from https://github.com/paritytech/cachepot/pull/149.