### PR TITLE
Fix spawning excessive conhost processes on Windows

### DIFF
--- a/src/mock_command.rs
+++ b/src/mock_command.rs
@@ -104,8 +104,6 @@ pub trait RunCommand: fmt::Debug + Send {
     fn env_clear(&mut self) -> &mut Self;
     /// Set the working directory of the process to `dir`.
     fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self;
-    /// Create the proces without a visible console on Windows.
-    fn no_console(&mut self) -> &mut Self;
     /// Set the process' stdin from `cfg`.
     fn stdin(&mut self, cfg: Stdio) -> &mut Self;
     /// Set the process' stdout from `cfg`.
@@ -234,19 +232,6 @@ impl RunCommand for AsyncCommand {
     }
     fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut AsyncCommand {
         self.inner().current_dir(dir);
-        self
-    }
-
-    #[cfg(windows)]
-    fn no_console(&mut self) -> &mut AsyncCommand {
-        use std::os::windows::process::CommandExt;
-        const CREATE_NO_WINDOW: u32 = 0x08000000;
-        self.inner().creation_flags(CREATE_NO_WINDOW);
-        self
-    }
-
-    #[cfg(unix)]
-    fn no_console(&mut self) -> &mut AsyncCommand {
         self
     }
 
@@ -472,9 +457,6 @@ impl RunCommand for MockCommand {
     }
     fn current_dir<P: AsRef<Path>>(&mut self, _dir: P) -> &mut MockCommand {
         //TODO: assert value of dir
-        self
-    }
-    fn no_console(&mut self) -> &mut MockCommand {
         self
     }
     fn stdin(&mut self, _cfg: Stdio) -> &mut MockCommand {

--- a/src/util.rs
+++ b/src/util.rs
@@ -254,7 +254,6 @@ where
     C: RunCommand,
 {
     let child = command
-        .no_console()
         .stdin(if input.is_some() {
             Stdio::piped()
         } else {


### PR DESCRIPTION
Fixes https://github.com/mozilla/sccache/issues/514#issuecomment-1061945431 (comment 2022-03-08 by @mitchhentges)

Any console-based subprocess spawned with CREATE_NO_WINDOW actually has a hidden console, and thus an associated conhost process. Since the sccache server is already started with CREATE_NO_WINDOW, it's unnecessary to spawn further subprocesses with CREATE_NO_WINDOW. Removing this flag allows subprocesses to share the sccache server's hidden console, thus avoiding each subprocess from getting its own conhost.

For an extended explanation see this comment and its follow-ups:
https://github.com/mozilla/sccache/issues/514#issuecomment-1068961965