### PR TITLE
Replace usages of blocking `reqwest` to be async instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,6 +1778,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ percent-encoding = { version = "2", optional = true }
 rand = "0.8.4"
 redis = { version = "0.21", optional = true, default-features = false, features = ["aio", "tokio-comp", "tokio-native-tls-comp"] }
 regex = "1"
-reqwest = { version = "0.11", features = ["json", "blocking"], optional = true }
+reqwest = { version = "0.11", features = ["json", "blocking", "stream"], optional = true }
 retry = "1"
 ring = { version = "0.16", optional = true, features = ["std"] }
 sha-1 = { version = "0.10.0", optional = true }
@@ -69,7 +69,7 @@ tar = "0.4"
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "io-util", "time", "net", "process", "macros"] }
 tokio-serde = "0.8"
-tokio-util = { version = "0.6", features = ["codec"] }
+tokio-util = { version = "0.6", features = ["codec", "io"] }
 tower = "0.4"
 toml = "0.5"
 url = { version = "2", optional = true }


### PR DESCRIPTION
The blocking implementation of `reqwest` now uses an internal `tokio`
runtime as of `0.10`. `tokio` doesn't like having nested runtimes, so it
raises an error when `request>=0.10` is used from a tokio-`async`
function.

The primary rationale for continuing to use "blocking" `reqwest` was
because its async implementation was "extremely limited" and didn't
support streamed data from a file.

However, now, we're able to leverage
`tokio::fs::File -> AsyncRead -> ReaderStream -> Body::wrap_stream()`,
which obsoletes this one use case for blocking `reqwest`.

Convert all blocking usages of `reqwest` to `async` accordingly.