### PR TITLE
Support `-gsplit-dwaf` without `-g` for the latest clang

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -15,7 +15,9 @@
 #![allow(unused_imports, dead_code, unused_variables)]
 
 use crate::compiler::args::*;
-use crate::compiler::c::{CCompilerImpl, CCompilerKind, Language, ParsedArguments};
+use crate::compiler::c::{
+    ArtifactDesciptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
+};
 use crate::compiler::gcc::ArgData::*;
 use crate::compiler::{gcc, write_temp_file, Cacheable, CompileCommand, CompilerArguments};
 use crate::dist;
@@ -247,7 +249,16 @@ mod test {
         let a = parses!("-c", "foo.c", "-o", "foo.o");
         assert_eq!(Some("foo.c"), a.input.to_str());
         assert_eq!(Language::C, a.language);
-        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: PathBuf::from("foo.o"),
+                    optional: false
+                }
+            )
+        );
         assert!(a.preprocessor_args.is_empty());
         assert!(a.common_args.is_empty());
     }
@@ -260,7 +271,16 @@ mod test {
         );
         assert_eq!(Some("foo.cxx"), a.input.to_str());
         assert_eq!(Language::Cxx, a.language);
-        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: PathBuf::from("foo.o"),
+                    optional: false
+                }
+            )
+        );
         assert_eq!(ovec!["-Iinclude", "-include", "file"], a.preprocessor_args);
         assert_eq!(ovec!["-arch", "xyz", "-fabc"], a.common_args);
     }

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use crate::compiler::args::*;
-use crate::compiler::c::{CCompilerImpl, CCompilerKind, Language, ParsedArguments};
+use crate::compiler::c::{
+    ArtifactDesciptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
+};
 use crate::compiler::{
     clang, gcc, write_temp_file, Cacheable, ColorMode, CompileCommand, CompilerArguments,
 };
@@ -661,13 +663,31 @@ pub fn parse_arguments(
     match output_arg {
         // If output file name is not given, use default naming rule
         None => {
-            outputs.insert("obj", Path::new(&input).with_extension("obj"));
+            outputs.insert(
+                "obj",
+                ArtifactDesciptor {
+                    path: Path::new(&input).with_extension("obj"),
+                    optional: false,
+                },
+            );
         }
         Some(o) => {
             if o.extension().is_none() && compilation {
-                outputs.insert("obj", o.with_extension("obj"));
+                outputs.insert(
+                    "obj",
+                    ArtifactDesciptor {
+                        path: o.with_extension("obj"),
+                        optional: false,
+                    },
+                );
             } else {
-                outputs.insert("obj", o);
+                outputs.insert(
+                    "obj",
+                    ArtifactDesciptor {
+                        path: o,
+                        optional: false,
+                    },
+                );
             }
         }
     }
@@ -675,7 +695,13 @@ pub fn parse_arguments(
     // Clang is currently unable to generate PDB files
     if debug_info && !is_clang {
         match pdb {
-            Some(p) => outputs.insert("pdb", p),
+            Some(p) => outputs.insert(
+                "pdb",
+                ArtifactDesciptor {
+                    path: p,
+                    optional: false,
+                },
+            ),
             None => {
                 // -Zi and -ZI without -Fd defaults to vcxxx.pdb (where xxx depends on the
                 // MSVC version), and that's used for all compilations with the same
@@ -793,9 +819,9 @@ where
     let output = run_input_output(cmd, None).await?;
 
     let parsed_args = &parsed_args;
-    if let (Some(ref objfile), &Some(ref depfile)) =
-        (parsed_args.outputs.get("obj"), &parsed_args.depfile)
+    if let (Some(obj), &Some(ref depfile)) = (parsed_args.outputs.get("obj"), &parsed_args.depfile)
     {
+        let objfile = &obj.path;
         let f = File::create(cwd.join(depfile))?;
         let mut f = BufWriter::new(f);
 
@@ -863,7 +889,7 @@ fn generate_compile_commands(
 
     trace!("compile");
     let out_file = match parsed_args.outputs.get("obj") {
-        Some(obj) => obj,
+        Some(obj) => &obj.path,
         None => bail!("Missing object file output"),
     };
 
@@ -874,7 +900,7 @@ fn generate_compile_commands(
         .map_or(Cacheable::Yes, |pdb| {
             // If the PDB exists, we don't know if it's shared with another
             // compilation. If it is, we can't cache.
-            if Path::new(&cwd).join(pdb).exists() {
+            if Path::new(&cwd).join(pdb.path.clone()).exists() {
                 Cacheable::No
             } else {
                 Cacheable::Yes
@@ -987,7 +1013,16 @@ mod test {
         assert_eq!(Some("foo.c"), input.to_str());
         assert_eq!(Language::C, language);
         assert_eq!(Some("-c"), compilation_flag.to_str());
-        assert_map_contains!(outputs, ("obj", PathBuf::from("foo.obj")));
+        assert_map_contains!(
+            outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: PathBuf::from("foo.obj"),
+                    optional: false
+                }
+            )
+        );
         assert!(preprocessor_args.is_empty());
         assert!(common_args.is_empty());
         assert!(!msvc_show_includes);
@@ -1012,7 +1047,16 @@ mod test {
         assert_eq!(Some("foo.c"), input.to_str());
         assert_eq!(Language::C, language);
         assert_eq!(Some("/c"), compilation_flag.to_str());
-        assert_map_contains!(outputs, ("obj", PathBuf::from("foo.obj")));
+        assert_map_contains!(
+            outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: PathBuf::from("foo.obj"),
+                    optional: false
+                }
+            )
+        );
         assert!(preprocessor_args.is_empty());
         assert!(common_args.is_empty());
         assert!(!msvc_show_includes);
@@ -1035,7 +1079,16 @@ mod test {
         };
         assert_eq!(Some("foo.c"), input.to_str());
         assert_eq!(Language::C, language);
-        assert_map_contains!(outputs, ("obj", PathBuf::from("foo.obj")));
+        assert_map_contains!(
+            outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: PathBuf::from("foo.obj"),
+                    optional: false
+                }
+            )
+        );
         assert!(preprocessor_args.is_empty());
         assert!(common_args.is_empty());
         assert!(!msvc_show_includes);
@@ -1058,7 +1111,16 @@ mod test {
         };
         assert_eq!(Some("foo.c"), input.to_str());
         assert_eq!(Language::C, language);
-        assert_map_contains!(outputs, ("obj", PathBuf::from("foo.obj")));
+        assert_map_contains!(
+            outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: PathBuf::from("foo.obj"),
+                    optional: false
+                }
+            )
+        );
         assert!(preprocessor_args.is_empty());
         assert!(common_args.is_empty());
         assert!(!msvc_show_includes);
@@ -1141,7 +1203,16 @@ mod test {
         };
         assert_eq!(Some("foo.c"), input.to_str());
         assert_eq!(Language::C, language);
-        assert_map_contains!(outputs, ("obj", PathBuf::from("foo.obj")));
+        assert_map_contains!(
+            outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: PathBuf::from("foo.obj"),
+                    optional: false
+                }
+            )
+        );
         assert!(preprocessor_args.is_empty());
         assert_eq!(common_args, ovec!["-foo", "-bar"]);
         assert!(!msvc_show_includes);
@@ -1174,7 +1245,16 @@ mod test {
         };
         assert_eq!(Some("foo.c"), input.to_str());
         assert_eq!(Language::C, language);
-        assert_map_contains!(outputs, ("obj", PathBuf::from("foo.obj")));
+        assert_map_contains!(
+            outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: PathBuf::from("foo.obj"),
+                    optional: false
+                }
+            )
+        );
         assert_eq!(preprocessor_args, ovec!["-FIfile", "-imsvc/a/b/c"]);
         assert_eq!(dependency_args, ovec!["/showIncludes"]);
         assert!(common_args.is_empty());
@@ -1200,8 +1280,20 @@ mod test {
         assert_eq!(Language::C, language);
         assert_map_contains!(
             outputs,
-            ("obj", PathBuf::from("foo.obj")),
-            ("pdb", PathBuf::from("foo.pdb"))
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: PathBuf::from("foo.obj"),
+                    optional: false
+                }
+            ),
+            (
+                "pdb",
+                ArtifactDesciptor {
+                    path: PathBuf::from("foo.pdb"),
+                    optional: false
+                }
+            )
         );
         assert!(preprocessor_args.is_empty());
         assert_eq!(common_args, ovec!["-Zi", "-Fdfoo.pdb"]);
@@ -1235,7 +1327,16 @@ mod test {
         };
         assert_eq!(Some("foo.c"), input.to_str());
         assert_eq!(Language::C, language);
-        assert_map_contains!(outputs, ("obj", PathBuf::from("foo.obj")));
+        assert_map_contains!(
+            outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: PathBuf::from("foo.obj"),
+                    optional: false
+                }
+            )
+        );
         assert_eq!(1, outputs.len());
         assert!(preprocessor_args.is_empty());
         assert_eq!(
@@ -1276,7 +1377,16 @@ mod test {
             };
             assert_eq!(Some("foo.c"), input.to_str());
             assert_eq!(Language::C, language);
-            assert_map_contains!(outputs, ("obj", PathBuf::from("foo.obj")));
+            assert_map_contains!(
+                outputs,
+                (
+                    "obj",
+                    ArtifactDesciptor {
+                        path: PathBuf::from("foo.obj"),
+                        optional: false
+                    }
+                )
+            );
             assert_eq!(1, outputs.len());
             assert!(preprocessor_args.is_empty());
             assert_eq!(
@@ -1390,7 +1500,15 @@ mod test {
             language: Language::C,
             compilation_flag: "-c".into(),
             depfile: None,
-            outputs: vec![("obj", "foo.obj".into())].into_iter().collect(),
+            outputs: vec![(
+                "obj",
+                ArtifactDesciptor {
+                    path: "foo.obj".into(),
+                    optional: false,
+                },
+            )]
+            .into_iter()
+            .collect(),
             dependency_args: vec![],
             preprocessor_args: vec![],
             common_args: vec![],
@@ -1432,9 +1550,24 @@ mod test {
             language: Language::C,
             compilation_flag: "/c".into(),
             depfile: None,
-            outputs: vec![("obj", "foo.obj".into()), ("pdb", pdb)]
-                .into_iter()
-                .collect(),
+            outputs: vec![
+                (
+                    "obj",
+                    ArtifactDesciptor {
+                        path: "foo.obj".into(),
+                        optional: false,
+                    },
+                ),
+                (
+                    "pdb",
+                    ArtifactDesciptor {
+                        path: pdb,
+                        optional: false,
+                    },
+                ),
+            ]
+            .into_iter()
+            .collect(),
             dependency_args: vec![],
             preprocessor_args: vec![],
             common_args: vec![],

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -15,7 +15,9 @@
 #![allow(unused_imports, dead_code, unused_variables)]
 
 use crate::compiler::args::*;
-use crate::compiler::c::{CCompilerImpl, CCompilerKind, Language, ParsedArguments};
+use crate::compiler::c::{
+    ArtifactDesciptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
+};
 use crate::compiler::gcc::ArgData::*;
 use crate::compiler::{gcc, write_temp_file, Cacheable, CompileCommand, CompilerArguments};
 use crate::dist;
@@ -246,7 +248,16 @@ mod test {
         let a = parses!("-c", "foo.c", "-o", "foo.o");
         assert_eq!(Some("foo.c"), a.input.to_str());
         assert_eq!(Language::C, a.language);
-        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
         assert!(a.preprocessor_args.is_empty());
         assert!(a.common_args.is_empty());
     }
@@ -256,7 +267,16 @@ mod test {
         let a = parses!("-c", "foo.cu", "-o", "foo.o");
         assert_eq!(Some("foo.cu"), a.input.to_str());
         assert_eq!(Language::Cuda, a.language);
-        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
         assert!(a.preprocessor_args.is_empty());
         assert!(a.common_args.is_empty());
     }
@@ -266,7 +286,16 @@ mod test {
         let a = parses!("-x", "cu", "-c", "foo.c", "-o", "foo.o");
         assert_eq!(Some("foo.c"), a.input.to_str());
         assert_eq!(Language::Cuda, a.language);
-        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
         assert!(a.preprocessor_args.is_empty());
         assert!(a.common_args.is_empty());
     }
@@ -277,7 +306,16 @@ mod test {
         assert_eq!(Some("foo.c"), a.input.to_str());
         assert_eq!(Language::Cuda, a.language);
         assert_eq!(Some("-dc"), a.compilation_flag.to_str());
-        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
         assert!(a.preprocessor_args.is_empty());
         assert!(a.common_args.is_empty());
     }
@@ -298,7 +336,16 @@ mod test {
         );
         assert_eq!(Some("foo.cpp"), a.input.to_str());
         assert_eq!(Language::Cxx, a.language);
-        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
         assert_eq!(
             ovec![
                 "-Iinclude-file",
@@ -322,7 +369,16 @@ mod test {
         assert_eq!(Some("foo.c"), a.input.to_str());
         assert_eq!(Language::Cuda, a.language);
         assert_eq!(Some("-c"), a.compilation_flag.to_str());
-        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
         assert_eq!(
             ovec!["-MD", "-MF", "foo.o.d", "-MT", "foo.o"],
             a.dependency_args
@@ -343,7 +399,16 @@ mod test {
         );
         assert_eq!(Some("foo.c"), a.input.to_str());
         assert_eq!(Language::Cuda, a.language);
-        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
         assert!(a.preprocessor_args.is_empty());
         assert_eq!(
             ovec!["--generate-code", "arch=compute_61,code=sm_61"],
@@ -370,7 +435,16 @@ mod test {
         );
         assert_eq!(Some("foo.c"), a.input.to_str());
         assert_eq!(Language::Cuda, a.language);
-        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
         assert_eq!(
             ovec![
                 "-Xcompiler",
@@ -411,7 +485,16 @@ mod test {
         );
         assert_eq!(Some("foo.c"), a.input.to_str());
         assert_eq!(Language::Cuda, a.language);
-        assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDesciptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
         assert_eq!(
             ovec!["--expt-relaxed-constexpr", "-Xcompiler", "-pthread"],
             a.preprocessor_args


### PR DESCRIPTION
Since https://reviews.llvm.org/D80391, -gsplit-dwarf is a no-op if -g is
specified. This means we can't assume the presence of .dwo output
if -gsplit-dwarf and no -g.

This patch makes .dwo output optional.

Without this patch, it fails like below.

```console
$ ./sccache-v0.3.0-x86_64-unknown-linux-musl/sccache ./clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04/bin/clang -gsplit-dwarf -c a.c
sccache: encountered fatal error
sccache: error: failed to zip up compiler outputs
sccache: caused by: failed to zip up compiler outputs
sccache: caused by: failed to open file `"/tmp/tmp.gfLlNOFb2c/a.dwo"`
sccache: caused by: No such file or directory (os error 2)
```

<details>
<summary>Reproducible Dockerfile</summary>

```dockerfile
FROM ubuntu:20.04

RUN apt-get update && apt-get install curl xz-utils -y
RUN curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz | tar Jx
RUN curl -L https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz | tar xz
RUN chmod +x ./sccache-v0.3.0-x86_64-unknown-linux-musl/sccache
RUN touch a.c
CMD ./sccache-v0.3.0-x86_64-unknown-linux-musl/sccache ./clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04/bin/clang -gsplit-dwarf -c a.c
```

</details>

Does this change make sense? Thanks.