### PR TITLE
Support `-Xclang -no-opaque-pointers` in clang

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -448,7 +448,14 @@ mod test {
 
     #[test]
     fn test_parse_xclang_no_opaque_pointers() {
-        let a = parses!("-c", "foo.c", "-o", "foo.o", "-Xclang", "-no-opaque-pointers");
+        let a = parses!(
+            "-c",
+            "foo.c",
+            "-o",
+            "foo.o",
+            "-Xclang",
+            "-no-opaque-pointers"
+        );
         assert_eq!(ovec!["-Xclang", "-no-opaque-pointers"], a.preprocessor_args);
     }
 

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -181,6 +181,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("-include-pch", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
     take_arg!("-load", PathBuf, Separated, ExtraHashFile),
     take_arg!("-mllvm", OsString, Separated, PassThrough),
+    flag!("-no-opaque-pointers", PreprocessorArgumentFlag),
     take_arg!("-plugin-arg", OsString, Concatenated('-'), PassThrough),
     take_arg!("-target", OsString, Separated, PassThrough),
     flag!("-verify", PreprocessorArgumentFlag),
@@ -443,6 +444,12 @@ mod test {
     fn test_parse_xclang_verify() {
         let a = parses!("-c", "foo.c", "-o", "foo.o", "-Xclang", "-verify");
         assert_eq!(ovec!["-Xclang", "-verify"], a.preprocessor_args);
+    }
+
+    #[test]
+    fn test_parse_xclang_no_opaque_pointers() {
+        let a = parses!("-c", "foo.c", "-o", "foo.o", "-Xclang", "-no-opaque-pointers");
+        assert_eq!(ovec!["-Xclang", "-no-opaque-pointers"], a.preprocessor_args);
     }
 
     #[test]


### PR DESCRIPTION
Some projects, such as chromium, have recently been using
`-Xclang -no-opaque-pointers` [1] to deal with the issue of changing
opaque pointers in llvm[2], but the current sccache cannot handle that
flag.

This patch is to teach sccache to parse those flags so that it can solve
issues like [3].

[1] https://chromium-review.googlesource.com/c/chromium/src/+/3584317
[2] https://llvm.org/docs/OpaquePointers.html
[3] https://github.com/denoland/rusty_v8/issues/971