### PR TITLE
Allow building individual storage features without 'azure'

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -511,7 +511,7 @@ pub trait DateTimeExt {
     fn to_rfc7231(&self) -> String;
 }
 
-#[cfg(feature = "azure")]
+#[cfg(any(feature = "azure", feature = "gcs", feature = "s3"))]
 impl<Tz: chrono::TimeZone> DateTimeExt for chrono::DateTime<Tz>
 where
     Tz::Offset: core::fmt::Display,


### PR DESCRIPTION
All storage features import and use `chrono` from the `util` module.
Alas, the definition of `chrono` is declared behind the *azure* feature
flag which makes building any individual storage feature without *azure*
enabled impossible.

Since the `chrono` definition is used in multiple modules it should not
be hidden behind any feature flags.