### PR TITLE
More informative 'multiple files' non-cacheable error log

### DIFF
--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -249,6 +249,7 @@ where
     let mut extra_hash_files = vec![];
     let mut compilation = false;
     let mut multiple_input = false;
+    let mut multiple_input_files = Vec::new();
     let mut pedantic_flag = false;
     let mut language_extensions = true; // by default, GCC allows extensions
     let mut split_dwarf = false;
@@ -366,6 +367,7 @@ where
                 Argument::Raw(ref val) => {
                     if input_arg.is_some() {
                         multiple_input = true;
+                        multiple_input_files.push(val.clone());
                     }
                     input_arg = Some(val.clone());
                 }
@@ -484,7 +486,10 @@ where
     }
     // Can't cache compilations with multiple inputs.
     if multiple_input {
-        cannot_cache!("multiple input files");
+        cannot_cache!(
+            "multiple input files",
+            format!("{:?}", multiple_input_files)
+        );
     }
     let input = match input_arg {
         Some(i) => i,
@@ -1545,10 +1550,24 @@ mod test {
     }
 
     #[test]
-    fn test_parse_arguments_too_many_inputs() {
+    fn test_parse_arguments_too_many_inputs_single() {
         assert_eq!(
-            CompilerArguments::CannotCache("multiple input files", None),
+            CompilerArguments::CannotCache("multiple input files", Some("[\"bar.c\"]".to_string())),
             parse_arguments_(stringvec!["-c", "foo.c", "-o", "foo.o", "bar.c"], false)
+        );
+    }
+
+    #[test]
+    fn test_parse_arguments_too_many_inputs_multiple() {
+        assert_eq!(
+            CompilerArguments::CannotCache(
+                "multiple input files",
+                Some("[\"bar.c\", \"baz.c\"]".to_string())
+            ),
+            parse_arguments_(
+                stringvec!["-c", "foo.c", "-o", "foo.o", "bar.c", "baz.c"],
+                false
+            )
         );
     }
 


### PR DESCRIPTION
Sccache tends to log non-cacheable reasons with only a generic message
without providing any details as to what triggered the problem. This
makes it harder to troubleshoot caching issues.

This commit adds a list of compiler arguments that caused the *multiple
files* non-cacheable result to the logged error message.