### PR TITLE
Add support for clang msvc 'winsysroot' flag

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -184,6 +184,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("-plugin-arg", OsString, Concatenated('-'), PassThrough),
     take_arg!("-target", OsString, Separated, PassThrough),
     flag!("-verify", PreprocessorArgumentFlag),
+    take_arg!("/winsysroot", PathBuf, CanBeSeparated, PassThroughPath),
 ]);
 
 // Maps the `-fprofile-use` argument to the actual path of the
@@ -250,14 +251,27 @@ mod test {
     #[test]
     fn test_parse_arguments_values() {
         let a = parses!(
-            "-c", "foo.cxx", "-arch", "xyz", "-fabc", "-I", "include", "-o", "foo.o", "-include",
-            "file"
+            "-c",
+            "foo.cxx",
+            "-arch",
+            "xyz",
+            "-fabc",
+            "-I",
+            "include",
+            "-o",
+            "foo.o",
+            "-include",
+            "file",
+            "/winsysroot../some/dir"
         );
         assert_eq!(Some("foo.cxx"), a.input.to_str());
         assert_eq!(Language::Cxx, a.language);
         assert_map_contains!(a.outputs, ("obj", PathBuf::from("foo.o")));
         assert_eq!(ovec!["-Iinclude", "-include", "file"], a.preprocessor_args);
-        assert_eq!(ovec!["-arch", "xyz", "-fabc"], a.common_args);
+        assert_eq!(
+            ovec!["-arch", "xyz", "-fabc", "/winsysroot", "../some/dir"],
+            a.common_args
+        );
     }
 
     #[test]

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -443,6 +443,7 @@ msvc_args!(static ARGS: [ArgInfo<ArgData>; _] = [
     msvc_take_arg!("w4", OsString, Concatenated, PassThroughWithSuffix),
     msvc_take_arg!("wd", OsString, Concatenated, PassThroughWithSuffix),
     msvc_take_arg!("we", OsString, Concatenated, PassThroughWithSuffix),
+    msvc_take_arg!("winsysroot", PathBuf, CanBeSeparated, PassThroughWithPath),
     msvc_take_arg!("wo", OsString, Concatenated, PassThroughWithSuffix),
     take_arg!("@", PathBuf, Concatenated, TooHardPath),
 ]);
@@ -1157,7 +1158,8 @@ mod test {
             "-imsvc",
             "/a/b/c",
             "-Fofoo.obj",
-            "/showIncludes"
+            "/showIncludes",
+            "/winsysroot../../some/dir"
         ];
         let ParsedArguments {
             input,
@@ -1177,7 +1179,7 @@ mod test {
         assert_map_contains!(outputs, ("obj", PathBuf::from("foo.obj")));
         assert_eq!(preprocessor_args, ovec!["-FIfile", "-imsvc/a/b/c"]);
         assert_eq!(dependency_args, ovec!["/showIncludes"]);
-        assert!(common_args.is_empty());
+        assert_eq!(common_args, ovec!["/winsysroot../../some/dir"]);
         assert!(msvc_show_includes);
     }
 


### PR DESCRIPTION
Clang has added a 'winsysroot' flag in https://reviews.llvm.org/D95534
to make cross-compile windows command line arguments less cumbersome.

Without support for this flag `sccache` treats the `/winsysroot<path>`
argument as an extra source file and refuses caching with a `multiple
input files` error.