### PR TITLE
Add support for clang 'no-opaque-pointers' flag

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -181,6 +181,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("-include-pch", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
     take_arg!("-load", PathBuf, Separated, ExtraHashFile),
     take_arg!("-mllvm", OsString, Separated, PassThrough),
+    flag!("-no-opaque-pointers", PassThroughFlag),
     take_arg!("-plugin-arg", OsString, Concatenated('-'), PassThrough),
     take_arg!("-target", OsString, Separated, PassThrough),
     flag!("-verify", PreprocessorArgumentFlag),

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -111,6 +111,7 @@ ArgData! { pub
     NoDiagnosticsColorFlag,
     // Should only be necessary for -Xclang flags - unknown flags not hidden behind
     // that are assumed to not affect compilation
+    PassThroughFlag,
     PassThrough(OsString),
     PassThroughPath(PathBuf),
     PreprocessorArgumentFlag,
@@ -327,6 +328,7 @@ where
             | Some(PreprocessorArgumentFlag)
             | Some(PreprocessorArgument(_))
             | Some(PreprocessorArgumentPath(_))
+            | Some(PassThroughFlag)
             | Some(PassThrough(_))
             | Some(PassThroughPath(_)) => {}
             Some(Language(lang)) => {
@@ -370,6 +372,7 @@ where
             | Some(DiagnosticsColorFlag)
             | Some(NoDiagnosticsColorFlag)
             | Some(Arch(_))
+            | Some(PassThroughFlag)
             | Some(PassThrough(_))
             | Some(PassThroughPath(_)) => &mut common_args,
             Some(ExtraHashFile(path)) => {
@@ -432,6 +435,7 @@ where
             | Some(DiagnosticsColorFlag)
             | Some(NoDiagnosticsColorFlag)
             | Some(Arch(_))
+            | Some(PassThroughFlag)
             | Some(PassThrough(_))
             | Some(PassThroughPath(_)) => &mut common_args,
             Some(ExtraHashFile(path)) => {

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -606,6 +606,7 @@ pub fn parse_arguments(
                 | Some(DiagnosticsColorFlag)
                 | Some(NoDiagnosticsColorFlag)
                 | Some(Arch(_))
+                | Some(PassThroughFlag)
                 | Some(PassThrough(_))
                 | Some(PassThroughPath(_))
                 | Some(PedanticFlag)


### PR DESCRIPTION
LLVM is transitioning to _opaque pointers_ but in the meanwhile provides
a way to allow old-style pointers usage: `-Xclang -no-opaque-pointers`
flag.

To support caching in projects that make use of this feature `sccache`
needs to know about this flag. Otherwise all compiler invocations using
it result in the *Can't handle UnknownFlag arguments with -Xclang* and
the output objects are not cached.