### PR TITLE
bump semver to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,7 @@ dependencies = [
  "conhash",
  "log",
  "rand 0.7.3",
- "semver",
+ "semver 0.9.0",
  "unix_socket",
 ]
 
@@ -1980,7 +1980,7 @@ dependencies = [
  "retry",
  "ring",
  "rouille",
- "semver",
+ "semver 1.0.13",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2056,6 +2056,12 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "semver-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ reqwest = { version = "0.11", features = ["json", "blocking", "stream"], optiona
 retry = "1"
 ring = { version = "0.16", optional = true, features = ["std"] }
 rredis = { package = "redis", version = "0.21", optional = true, default-features = false, features = ["aio", "tokio-comp", "tokio-native-tls-comp"] }
-semver = "0.9"
+semver = "1.0"
 sha-1 = { version = "0.10.0", optional = true }
 sha2 = { version = "0.10.1", optional = true }
 serde = "1.0"

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -21,7 +21,7 @@ use crate::compiler::{gcc, write_temp_file, Cacheable, CompileCommand, CompilerA
 use crate::dist;
 use crate::mock_command::{CommandCreator, CommandCreatorSync, RunCommand};
 use crate::util::{run_input_output, OsStrExt};
-use semver::Version;
+use semver::{BuildMetadata, Prerelease, Version};
 use std::ffi::OsString;
 use std::fs::File;
 use std::future::Future;
@@ -69,8 +69,8 @@ impl Clang {
                 major,
                 minor: 0,
                 patch: 0,
-                pre: vec![],
-                build: vec![],
+                pre: Prerelease::default(),
+                build: BuildMetadata::default(),
             })
     }
 }


### PR DESCRIPTION
Since memcached-rs still depends on 0.9.0, this adds an extra dependency
to be compiled. Upstream already included the semver bump but no release
was slated so far.

Closes #1259 