### PR TITLE
Set chrono minimum version to v0.4.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bincode = "1"
 blake3 = "1"
 byteorder = "1.0"
 bytes = "1"
-chrono = { version = "0.4.20", optional = true }
+chrono = { version = "0.4.21", optional = true }
 clap = "2.23.0"
 counted-array = "0.1"
 directories = "4.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bincode = "1"
 blake3 = "1"
 byteorder = "1.0"
 bytes = "1"
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4.20", optional = true }
 clap = "2.23.0"
 counted-array = "0.1"
 directories = "4.0.1"


### PR DESCRIPTION
Per [RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159.html), `chrono` may segfault under certain circumstances. This bumps `chrono`'s version to `0.4.20` to mitigate the issue.