### PR TITLE
reduce dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,5 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 5


### PR DESCRIPTION
Currently there are 1-4 daily PRs to review, often the same crates multiple times per week, which
is a lot of chore sinking time.

It also makes the history completely unreadable.