### PR TITLE
Handle use of RUSTC_WORKSPACE_WRAPPER

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -680,13 +680,14 @@ pub fn run_command(cmd: Command) -> Result<i32> {
             let runtime = Runtime::new()?;
             let jobserver = unsafe { Client::new() };
             let creator = ProcessCommandCreator::new(&jobserver);
+            let args: Vec<_> = env::args_os().collect();
             let env: Vec<_> = env::vars_os().collect();
             let out_file = File::create(out)?;
             let cwd = env::current_dir().expect("A current working dir should exist");
 
             let pool = runtime.handle().clone();
             runtime.block_on(async move {
-                compiler::get_compiler_info(creator, &executable, &cwd, &env, &pool, None)
+                compiler::get_compiler_info(creator, &executable, &cwd, &args, &env, &pool, None)
                     .await
                     .map(|compiler| compiler.0.get_toolchain_packager())
                     .and_then(|packager| packager.write_pkg(out_file))

--- a/src/server.rs
+++ b/src/server.rs
@@ -880,7 +880,9 @@ where
         let env_vars = compile.env_vars;
         let me = self.clone();
 
-        let info = self.compiler_info(exe.into(), cwd.clone(), &env_vars).await;
+        let info = self
+            .compiler_info(exe.into(), cwd.clone(), &cmd, &env_vars)
+            .await;
         Ok(me.check_compiler(info, cmd, cwd, env_vars).await)
     }
 
@@ -890,6 +892,7 @@ where
         &self,
         path: PathBuf,
         cwd: PathBuf,
+        args: &[OsString],
         env: &[(OsString, OsString)],
     ) -> Result<Box<dyn Compiler<C>>> {
         trace!("compiler_info");
@@ -981,6 +984,7 @@ where
                     me.creator.clone(),
                     &path1,
                     &cwd,
+                    args,
                     env.as_slice(),
                     &me.rt,
                     dist_info.clone().map(|(p, _)| p),


### PR DESCRIPTION
Fixes https://github.com/mozilla/sccache/issues/1274

Handle the scenario where cargo is being used with sccache as a RUSTC_WRAPPER and another tool is being used as a
RUSTC_WORKSPACE_WRAPPER, by inspecting the first argument.

In this case `rustc` will be the first argument passed to the workspace wrapper, and the `rustc` version check will need to also do `<wrapper> rustc -vV` rather than `<wrapper> -vV`.

As a precaution against inadvertently identifying a c compiler as a rustc workspace wrapper, I also checked for the presence of the CARGO env which cargo sets for all processes it runs.