### PR TITLE
Clippy and typo fixes

### DIFF
--- a/src/compiler/args.rs
+++ b/src/compiler/args.rs
@@ -11,7 +11,7 @@ pub type ArgParseResult<T> = StdResult<T, ArgParseError>;
 pub type ArgToStringResult = StdResult<String, ArgToStringError>;
 pub type PathTransformerFn<'a> = &'a mut dyn FnMut(&Path) -> Option<String>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ArgParseError {
     UnexpectedEndOfArgs,
     InvalidUnicode(OsString),
@@ -35,7 +35,7 @@ impl Error for ArgParseError {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ArgToStringError {
     FailedPathTransform(PathBuf),
     InvalidUnicode(OsString),
@@ -69,7 +69,7 @@ pub type Delimiter = Option<u8>;
 /// on the different kinds of argument). `Flag`s may contain a simple
 /// variant which influences how to do caching, whereas `WithValue`s could
 /// be a struct variant with parsed data from the value.
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum Argument<T> {
     /// Unknown non-flag argument ; e.g. "foo"
     Raw(OsString),
@@ -83,7 +83,7 @@ pub enum Argument<T> {
 }
 
 /// How a value is passed to an argument with a value.
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum ArgDisposition {
     /// As "-arg value"
     Separated,
@@ -299,7 +299,7 @@ macro_rules! ArgData {
 
     // PartialEq necessary for tests
     { pub $( $tok:tt )+ } => {
-        #[derive(Clone, Debug, PartialEq)]
+        #[derive(Clone, Debug, PartialEq, Eq)]
         pub enum ArgData {
             $($tok)+
         }
@@ -387,7 +387,7 @@ pub fn split_os_string_arg(val: OsString, split: &str) -> ArgParseResult<(String
 }
 
 /// The description of how an argument may be parsed
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum ArgInfo<T> {
     /// An simple flag argument, of the form "-foo"
     Flag(&'static str, T),

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -71,7 +71,7 @@ pub enum Language {
 
 /// Artifact produced by a C/C++ compiler.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ArtifactDesciptor {
+pub struct ArtifactDescriptor {
     /// Path to the artifact.
     pub path: PathBuf,
     /// Whether the artifact is an optional object file.
@@ -91,7 +91,7 @@ pub struct ParsedArguments {
     /// The file in which to generate dependencies.
     pub depfile: Option<PathBuf>,
     /// Output files and whether it's optional, keyed by a simple name, like "obj".
-    pub outputs: HashMap<&'static str, ArtifactDesciptor>,
+    pub outputs: HashMap<&'static str, ArtifactDescriptor>,
     /// Commandline arguments for dependency generation.
     pub dependency_args: Vec<OsString>,
     /// Commandline arguments for the preprocessor (not including common_args).

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -60,7 +60,7 @@ where
     compiler: I,
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Language {
     C,
     Cxx,
@@ -70,7 +70,7 @@ pub enum Language {
 }
 
 /// Artifact produced by a C/C++ compiler.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ArtifactDesciptor {
     /// Path to the artifact.
     pub path: PathBuf,
@@ -80,7 +80,7 @@ pub struct ArtifactDesciptor {
 
 /// The results of parsing a compiler commandline.
 #[allow(dead_code)]
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ParsedArguments {
     /// The input source file.
     pub input: PathBuf,
@@ -166,7 +166,7 @@ struct CCompilation<I: CCompilerImpl> {
 }
 
 /// Supported C compilers.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum CCompilerKind {
     /// GCC
     Gcc,

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -16,7 +16,7 @@
 
 use crate::compiler::args::*;
 use crate::compiler::c::{
-    ArtifactDesciptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
+    ArtifactDescriptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
 };
 use crate::compiler::gcc::ArgData::*;
 use crate::compiler::{gcc, write_temp_file, Cacheable, CompileCommand, CompilerArguments};
@@ -254,7 +254,7 @@ mod test {
             a.outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: PathBuf::from("foo.o"),
                     optional: false
                 }
@@ -286,7 +286,7 @@ mod test {
             a.outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: PathBuf::from("foo.o"),
                     optional: false
                 }

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -79,7 +79,7 @@ impl CompileCommand {
 }
 
 /// Supported compilers.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum CompilerKind {
     /// A C compiler.
     C(CCompilerKind),
@@ -691,7 +691,7 @@ pub struct HashResult {
 }
 
 /// Possible results of parsing compiler arguments.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum CompilerArguments<T> {
     /// Commandline can be handled.
     Ok(T),
@@ -720,7 +720,7 @@ macro_rules! try_or_cannot_cache {
 }
 
 /// Specifics about distributed compilation.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DistType {
     /// Distribution was not enabled.
     NoDist,
@@ -731,7 +731,7 @@ pub enum DistType {
 }
 
 /// Specifics about cache misses.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum MissType {
     /// The compilation was not found in the cache, nothing more.
     Normal,
@@ -772,7 +772,7 @@ pub enum CompileResult {
 }
 
 /// The state of `--color` options passed to a compiler.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ColorMode {
     Off,
     On,
@@ -818,14 +818,14 @@ impl PartialEq<CompileResult> for CompileResult {
 }
 
 /// Can this result be stored in cache?
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Cacheable {
     Yes,
     No,
 }
 
 /// Control of caching behavior.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum CacheControl {
     /// Default caching behavior.
     Default,

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -18,7 +18,7 @@ use crate::compiler::args::{
     NormalizedDisposition, PathTransformerFn, SearchableArgInfo,
 };
 use crate::compiler::c::{
-    ArtifactDesciptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
+    ArtifactDescriptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
 };
 use crate::compiler::{Cacheable, ColorMode, CompileCommand, CompilerArguments};
 use crate::dist;
@@ -276,7 +276,7 @@ where
     let mut outputs = HashMap::new();
     outputs.insert(
         "obj",
-        ArtifactDesciptor {
+        ArtifactDescriptor {
             path: output,
             optional: false,
         },
@@ -434,7 +434,7 @@ mod test {
     use super::{
         dist, generate_compile_commands, parse_arguments, Language, OsString, ParsedArguments, ARGS,
     };
-    use crate::compiler::c::ArtifactDesciptor;
+    use crate::compiler::c::ArtifactDescriptor;
     use crate::compiler::*;
     use crate::mock_command::*;
     use crate::test::utils::*;
@@ -467,7 +467,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -499,7 +499,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -531,7 +531,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -565,7 +565,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -607,7 +607,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -721,7 +721,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -743,7 +743,7 @@ mod test {
             depfile: None,
             outputs: vec![(
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false,
                 },

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -14,7 +14,7 @@
 
 use crate::compiler::args::*;
 use crate::compiler::c::{
-    ArtifactDesciptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
+    ArtifactDescriptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
 };
 use crate::compiler::{clang, Cacheable, ColorMode, CompileCommand, CompilerArguments};
 use crate::dist;
@@ -516,7 +516,7 @@ where
         // -gsplit-dwarf doesn't guarantee .dwo file if no -g is specified
         outputs.insert(
             "dwo",
-            ArtifactDesciptor {
+            ArtifactDescriptor {
                 path: dwo,
                 optional: true,
             },
@@ -530,7 +530,7 @@ where
         let gcno = output.with_extension("gcno");
         outputs.insert(
             "gcno",
-            ArtifactDesciptor {
+            ArtifactDescriptor {
                 path: gcno,
                 optional: false,
             },
@@ -547,7 +547,7 @@ where
     }
     outputs.insert(
         "obj",
-        ArtifactDesciptor {
+        ArtifactDescriptor {
             path: output,
             optional: false,
         },
@@ -875,7 +875,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -907,7 +907,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -929,7 +929,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -958,14 +958,14 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
             ),
             (
                 "dwo",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.dwo".into(),
                     optional: true
                 }
@@ -1009,7 +1009,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -1042,14 +1042,14 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
             ),
             (
                 "gcno",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: PathBuf::from("foo.gcno"),
                     optional: false
                 }
@@ -1083,14 +1083,14 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
             ),
             (
                 "gcno",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: PathBuf::from("foo.gcno"),
                     optional: false
                 }
@@ -1124,7 +1124,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -1157,7 +1157,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -1191,7 +1191,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -1235,7 +1235,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -1269,7 +1269,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -1304,7 +1304,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -1343,7 +1343,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -1482,7 +1482,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -1514,7 +1514,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: PathBuf::from("foo/bar.o"),
                     optional: false
                 }
@@ -1655,7 +1655,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -1677,7 +1677,7 @@ mod test {
             depfile: None,
             outputs: vec![(
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false,
                 },
@@ -1740,7 +1740,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -36,7 +36,7 @@ use crate::errors::*;
 /// A struct on which to implement `CCompilerImpl`.
 ///
 /// Needs a little bit of state just to persist `includes_prefix`.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Msvc {
     /// The prefix used in the output of `-showIncludes`.
     pub includes_prefix: String,

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -14,7 +14,7 @@
 
 use crate::compiler::args::*;
 use crate::compiler::c::{
-    ArtifactDesciptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
+    ArtifactDescriptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
 };
 use crate::compiler::{
     clang, gcc, write_temp_file, Cacheable, ColorMode, CompileCommand, CompilerArguments,
@@ -666,7 +666,7 @@ pub fn parse_arguments(
         None => {
             outputs.insert(
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: Path::new(&input).with_extension("obj"),
                     optional: false,
                 },
@@ -676,7 +676,7 @@ pub fn parse_arguments(
             if o.extension().is_none() && compilation {
                 outputs.insert(
                     "obj",
-                    ArtifactDesciptor {
+                    ArtifactDescriptor {
                         path: o.with_extension("obj"),
                         optional: false,
                     },
@@ -684,7 +684,7 @@ pub fn parse_arguments(
             } else {
                 outputs.insert(
                     "obj",
-                    ArtifactDesciptor {
+                    ArtifactDescriptor {
                         path: o,
                         optional: false,
                     },
@@ -698,7 +698,7 @@ pub fn parse_arguments(
         match pdb {
             Some(p) => outputs.insert(
                 "pdb",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: p,
                     optional: false,
                 },
@@ -1018,7 +1018,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: PathBuf::from("foo.obj"),
                     optional: false
                 }
@@ -1052,7 +1052,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: PathBuf::from("foo.obj"),
                     optional: false
                 }
@@ -1084,7 +1084,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: PathBuf::from("foo.obj"),
                     optional: false
                 }
@@ -1116,7 +1116,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: PathBuf::from("foo.obj"),
                     optional: false
                 }
@@ -1208,7 +1208,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: PathBuf::from("foo.obj"),
                     optional: false
                 }
@@ -1251,7 +1251,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: PathBuf::from("foo.obj"),
                     optional: false
                 }
@@ -1284,14 +1284,14 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: PathBuf::from("foo.obj"),
                     optional: false
                 }
             ),
             (
                 "pdb",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: PathBuf::from("foo.pdb"),
                     optional: false
                 }
@@ -1333,7 +1333,7 @@ mod test {
             outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: PathBuf::from("foo.obj"),
                     optional: false
                 }
@@ -1383,7 +1383,7 @@ mod test {
                 outputs,
                 (
                     "obj",
-                    ArtifactDesciptor {
+                    ArtifactDescriptor {
                         path: PathBuf::from("foo.obj"),
                         optional: false
                     }
@@ -1504,7 +1504,7 @@ mod test {
             depfile: None,
             outputs: vec![(
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.obj".into(),
                     optional: false,
                 },
@@ -1555,14 +1555,14 @@ mod test {
             outputs: vec![
                 (
                     "obj",
-                    ArtifactDesciptor {
+                    ArtifactDescriptor {
                         path: "foo.obj".into(),
                         optional: false,
                     },
                 ),
                 (
                     "pdb",
-                    ArtifactDesciptor {
+                    ArtifactDescriptor {
                         path: pdb,
                         optional: false,
                     },

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -16,7 +16,7 @@
 
 use crate::compiler::args::*;
 use crate::compiler::c::{
-    ArtifactDesciptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
+    ArtifactDescriptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
 };
 use crate::compiler::gcc::ArgData::*;
 use crate::compiler::{gcc, write_temp_file, Cacheable, CompileCommand, CompilerArguments};
@@ -252,7 +252,7 @@ mod test {
             a.outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -271,7 +271,7 @@ mod test {
             a.outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -290,7 +290,7 @@ mod test {
             a.outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -310,7 +310,7 @@ mod test {
             a.outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -340,7 +340,7 @@ mod test {
             a.outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -373,7 +373,7 @@ mod test {
             a.outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -403,7 +403,7 @@ mod test {
             a.outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -439,7 +439,7 @@ mod test {
             a.outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }
@@ -489,7 +489,7 @@ mod test {
             a.outputs,
             (
                 "obj",
-                ArtifactDesciptor {
+                ArtifactDescriptor {
                     path: "foo.o".into(),
                     optional: false
                 }

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -180,7 +180,7 @@ pub struct RustCompilation {
 }
 
 // The selection of crate types for this compilation
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CrateTypes {
     rlib: bool,
     staticlib: bool,
@@ -3148,7 +3148,8 @@ proc_macro false
             o => panic!("Got unexpected parse result: {:?}", o),
         };
         // Just use empty files for sources.
-        for src in ["foo.rs"].iter() {
+        {
+            let src = &"foo.rs";
             let s = format!("Failed to create {}", src);
             f.touch(src).expect(&s);
         }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -89,7 +89,7 @@ const OUTPUT: &str = "test.o";
 // Copy the source files into the tempdir so we can compile with relative paths, since the commandline winds up in the hash key.
 fn copy_to_tempdir(inputs: &[&str], tempdir: &Path) {
     for f in inputs {
-        let original_source_file = Path::new(file!()).parent().unwrap().join(&*f);
+        let original_source_file = Path::new(file!()).parent().unwrap().join(f);
         let source_file = tempdir.join(f);
         trace!("fs::copy({:?}, {:?})", original_source_file, source_file);
         fs::copy(&original_source_file, &source_file).unwrap();


### PR DESCRIPTION
Fix clippy links from 1.63.0. Fix typo in `ArtifactDescriptor` struct definition. 