### PR TITLE
Remove `counted_array` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,12 +361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "counted-array"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384f8c53175c890920b6e0127b730709d2a173ca6c4dfdc81618ac9b46f648fe"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1971,7 +1965,6 @@ dependencies = [
  "cc",
  "chrono",
  "clap",
- "counted-array",
  "crossbeam-utils",
  "daemonize",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ byteorder = "1.0"
 bytes = "1"
 chrono = { version = "0.4.22", optional = true }
 clap = "2.23.0"
-counted-array = "0.1"
 directories = "4.0.1"
 env_logger = "0.9"
 filetime = "0.2"

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -20,9 +20,9 @@ use crate::compiler::c::{
 };
 use crate::compiler::gcc::ArgData::*;
 use crate::compiler::{gcc, write_temp_file, Cacheable, CompileCommand, CompilerArguments};
-use crate::dist;
 use crate::mock_command::{CommandCreator, CommandCreatorSync, RunCommand};
 use crate::util::{run_input_output, OsStrExt};
+use crate::{counted_array, dist};
 use semver::{BuildMetadata, Prerelease, Version};
 use std::ffi::OsString;
 use std::fs::File;

--- a/src/compiler/counted_array.rs
+++ b/src/compiler/counted_array.rs
@@ -1,0 +1,91 @@
+// Copyright 2022 Mozilla Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Partially sub-licensed under the MIT license
+// Copyright (c) 2016 Alex Burka
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+/**
+ * Helper macro to create fixed-length arrays without specifying a static size
+ */
+#[macro_export]
+macro_rules! counted_array {
+
+    // Entry points (specialized for public/private arrays)
+    (pub $s:ident $n:ident: [$t:ty; _] = [$($vals:expr),* $(,)*]) => {
+        counted_array!(@unroll 0usize, ($($vals),*) -> [] ((pub) $s $n $t));
+    };
+    ($s:ident $n:ident: [$t:ty; _] = [$($vals:expr),* $(,)*]) => {
+        counted_array!(@unroll 0usize, ($($vals),*) -> [] (() $s $n $t));
+    };
+
+    // Unrolls expressions into tokens
+    (@unroll $size:expr, ($val:expr) -> [$($accs:expr),*] $thru:tt) => {
+        counted_array!(@output $size + 1usize, [$($accs,)* $val] $thru);
+    };
+    (@unroll $size:expr, ($val:expr, $($vals:expr),*) -> [$($accs:expr),*] $thru:tt) => {
+        counted_array!(@unroll $size + 1usize, ($($vals),*) -> [$($accs,)* $val] $thru);
+    };
+
+    // Counts the unrolled tokens and renders our fixed-array output tokens
+    (@output $size:expr, $acc:tt (($($p:tt)*) $s:ident $n:ident $t:ty)) => {
+        $($p)* $s $n: [$t; $size] = $acc;
+    };
+}
+
+#[cfg(test)]
+mod counted_array_test {
+
+    #[test]
+    fn verify_accurate_length() {
+        counted_array!(static ARR_QUAD: [u8;_] = [1,2,3,4]);
+        assert_eq!(ARR_QUAD.len(), 4);
+    }
+
+    #[test]
+    fn verify_tolerates_comma() {
+        counted_array!(static ARR_QUAD: [u8;_] = [1,2,3,4,]);
+        assert_eq!(ARR_QUAD.len(), 4);
+    }
+
+    #[test]
+    fn verify_tolerates_whitespace() {
+        counted_array!(static ARR_QUAD: [u8;_] = [1 , 2 , 3 , 4]);
+        assert_eq!(ARR_QUAD.len(), 4);
+    }
+
+    #[test]
+    fn verify_tolerates_whitespace_and_comma() {
+        counted_array!(static ARR_QUAD: [u8;_] = [1 , 2 , 3 , 4, ]);
+        assert_eq!(ARR_QUAD.len(), 4);
+    }
+
+    counted_array!(pub const CONST_ARR: [i32; _] = [1, 2, 3]);
+    counted_array!(pub static STATIC_ARR: [i32; _] = [7, 8, 9, 10]);
+
+    #[test]
+    fn public_scope_arrays() {
+        assert_eq!(CONST_ARR, [1, 2, 3]);
+        assert_eq!(STATIC_ARR, [7, 8, 9, 10]);
+    }
+}

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -21,10 +21,10 @@ use crate::compiler::c::{
     ArtifactDescriptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
 };
 use crate::compiler::{Cacheable, ColorMode, CompileCommand, CompilerArguments};
-use crate::dist;
 use crate::errors::*;
 use crate::mock_command::{CommandCreatorSync, RunCommand};
 use crate::util::{run_input_output, OsStrExt};
+use crate::{counted_array, dist};
 use log::Level::Trace;
 use std::collections::HashMap;
 use std::ffi::OsString;

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -17,9 +17,9 @@ use crate::compiler::c::{
     ArtifactDescriptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
 };
 use crate::compiler::{clang, Cacheable, ColorMode, CompileCommand, CompilerArguments};
-use crate::dist;
 use crate::mock_command::{CommandCreatorSync, RunCommand};
 use crate::util::{run_input_output, OsStrExt};
+use crate::{counted_array, dist};
 use log::Level::Trace;
 use std::collections::HashMap;
 use std::ffi::OsString;

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -25,5 +25,7 @@ mod msvc;
 mod nvcc;
 mod rust;
 mod tasking_vx;
+#[macro_use]
+mod counted_array;
 
 pub use crate::compiler::compiler::*;

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -19,9 +19,9 @@ use crate::compiler::c::{
 use crate::compiler::{
     clang, gcc, write_temp_file, Cacheable, ColorMode, CompileCommand, CompilerArguments,
 };
-use crate::dist;
 use crate::mock_command::{CommandCreatorSync, RunCommand};
 use crate::util::run_input_output;
+use crate::{counted_array, dist};
 use local_encoding::{Encoder, Encoding};
 use log::Level::Debug;
 use std::collections::{HashMap, HashSet};

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -20,9 +20,9 @@ use crate::compiler::c::{
 };
 use crate::compiler::gcc::ArgData::*;
 use crate::compiler::{gcc, write_temp_file, Cacheable, CompileCommand, CompilerArguments};
-use crate::dist;
 use crate::mock_command::{CommandCreator, CommandCreatorSync, RunCommand};
 use crate::util::{run_input_output, OsStrExt};
+use crate::{counted_array, dist};
 use log::Level::Trace;
 use std::ffi::OsString;
 use std::fs::File;

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -20,7 +20,6 @@ use crate::compiler::{
 };
 #[cfg(feature = "dist-client")]
 use crate::compiler::{DistPackagers, OutputsRewriter};
-use crate::dist;
 #[cfg(feature = "dist-client")]
 use crate::dist::pkg;
 #[cfg(feature = "dist-client")]
@@ -28,6 +27,7 @@ use crate::lru_disk_cache::{LruCache, Meter};
 use crate::mock_command::{CommandCreatorSync, RunCommand};
 use crate::util::{fmt_duration_as_secs, hash_all, hash_all_archives, run_input_output, Digest};
 use crate::util::{ref_env, HashToDigest, OsStrExt};
+use crate::{counted_array, dist};
 use filetime::FileTime;
 use log::Level::Trace;
 #[cfg(feature = "dist-client")]

--- a/src/compiler/tasking_vx.rs
+++ b/src/compiler/tasking_vx.rs
@@ -22,7 +22,7 @@ use crate::{
         c::{ArtifactDescriptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments},
         Cacheable, ColorMode, CompileCommand, CompilerArguments,
     },
-    dist,
+    counted_array, dist,
     errors::*,
     mock_command::{CommandCreatorSync, RunCommand},
     util::run_input_output,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,6 @@
 extern crate async_trait;
 #[macro_use]
 extern crate clap;
-#[macro_use]
-extern crate counted_array;
 #[cfg(feature = "jsonwebtoken")]
 use jsonwebtoken as jwt;
 #[macro_use]


### PR DESCRIPTION
Remove uses of `counted_array` dependency in favor of placing that code (with edits to remove dead code) in the source tree.

Resolves #1243