### PR TITLE
Add ZIP archives to Windows Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,14 +243,23 @@ jobs:
       - name: Create release assets
         run: |
           for d in sccache-*; do
-            cp README.md LICENSE $d/
-            tar -zcvf $d.tar.gz $d
-            echo -n $(shasum -ba 256 $d.tar.gz | cut -d " " -f 1) > $d.tar.gz.sha256
+            cp README.md LICENSE "$d/"
+            tar -zcvf "$d.tar.gz" "$d"
+            echo -n "$(shasum -ba 256 "$d.tar.gz" | cut -d " " -f 1)" > "$d.tar.gz.sha256"
+            if [[ $d =~ (sccache-)(.*)?(x86_64-pc-windows)(.*)? ]]; then
+              zip -r "$d.zip" "$d"
+              echo -n "$(shasum -ba 256 "$d.zip" | cut -d " " -f 1)" > "$d.zip.sha256"
+            fi
           done
 
       - name: Create release
         run: |
           tag_name=${GITHUB_REF#refs/tags/}
-          hub release create -m $tag_name $tag_name $(for f in sccache-*.tar.gz*; do echo "-a $f"; done)
+          for f in sccache-*.tar.gz* sccache-*.zip*; do 
+              if [[ -f "$f" ]]; then
+                files="$files -a $f";
+              fi
+          done
+          hub release create -m $tag_name $tag_name $files
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Modify Github Actions config to also create ZIP archives on Windows only
Improve file handling in Github Actions releases so that we don't break on filenames containing whitespace

This new archive type is being introduced so that the next time we bump release version, we will also generate a ZIP archive for the windows build. This will allow us to easily package for `winget` by simply listing the release url containing the ZIP archive, which totally works around any need for a full-on installer.  See #1251 for more information
