### PR TITLE
Replace dep `jobserver` with `jobslot`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobslot"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b52a1ef21d9c8e2b6ce68167f987a722c01f4d65b1760c495f8cd2b760f609d1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "scopeguard",
+ "tokio",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,7 +1992,7 @@ dependencies = [
  "hyper",
  "hyperx",
  "itertools",
- "jobserver",
+ "jobslot",
  "jsonwebtoken",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ hmac = { version = "0.12.0", optional = true }
 http = "0.2"
 hyper = { version = "0.14", optional = true, features = ["server"] }
 hyperx = { version = "1.0", optional = true }
-jobserver = "0.1"
+jobslot = { version = "0.2.4", features = ["tokio"] }
 jsonwebtoken = { version = "8", optional = true }
 lazy_static = "1.0.0"
 libc = "0.2.132"


### PR DESCRIPTION
Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>

This PR replaces dep `jobserver` with a fork [`jobslot`](https://github.com/cargo-bins/jobslot/blob/main/README.md).

## Advantages over `jobserver`?

 - `jobslot` contains bug fix for [Client::configure is unsafe]
 - `jobslot` removed use of signal handling in the helper thread on unix
 - `jobslot` uses `winapi` on windows instead of manually declaring bindings (some of the bindings seem to be wrong)
 - `jobslot` uses `getrandom` on windows instead of making homebrew one using raw windows api

[Client::configure is unsafe]: https://github.com/alexcrichton/jobserver-rs/issues/25


[PR]: https://github.com/alexcrichton/jobserver-rs/pull/40#issuecomment-1195689752
[`std::os::unix::process::CommandExt::pre_exec`]: https://doc.rust-lang.org/std/os/unix/process/trait.CommandExt.html#tymethod.pre_exec