### PR TITLE
Reduce depandabot PR frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: monthly
+      interval: weekly 
     open-pull-requests-limit: 8
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,5 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: monthly
+      interval: weekly
     open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: monthly
     open-pull-requests-limit: 8
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,5 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 5


### PR DESCRIPTION
Mental overhead is still too high due to the number of deps, many times the patch updates are edge cases being fixed that are not relevant to us, and effectively slowing down actual development. 

A dependabot PR review still requires to verify that MSRV is still ok, it compiles, check compile output, check changelog and/or commit history. That's a lot for a miniscule benefit, of a project that's almost always private infra.

Ref #1277 which assumed weekly would be ok, which it is not.