### PR TITLE
Remove unused sha-1 from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2491,7 +2491,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serial_test",
- "sha-1",
  "sha2",
  "strip-ansi-escapes",
  "syslog",
@@ -2675,17 +2674,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ retry = "2"
 ring = { version = "0.16", optional = true, features = ["std"] }
 rredis = { package = "redis", version = "0.21", optional = true, default-features = false, features = ["aio", "tokio-comp", "tokio-native-tls-comp"] }
 semver = "1.0"
-sha-1 = { version = "0.10.1", optional = true }
 sha2 = { version = "0.10.6", optional = true }
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
Removes `sha-1` crate from dependencies as it seems not to be used.