### PR TITLE
enable gha actions storage for the default feature set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ features = [
 
 [features]
 default = ["all"]
-all = ["dist-client", "redis", "s3", "memcached", "gcs", "azure"]
+all = ["dist-client", "redis", "s3", "memcached", "gcs", "azure", "gha"]
 azure = ["chrono", "hyper", "hyperx", "reqwest", "url", "hmac", "md-5", "sha2"]
 s3 = ["aws-config", "aws-sdk-s3", "aws-smithy-client", "aws-sig-auth"]
 gcs = ["chrono", "hyper", "hyperx", "percent-encoding", "reqwest", "ring", "url"]


### PR DESCRIPTION
Enabling by default is mandated by popularity and being able to integrate into gha workflows