### PR TITLE
Remove "Storage options" anchor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Table of Contents (ToC)
 * [Build Requirements](#build-requirements)
 * [Build](#build)
 * [Usage](#usage)
-* [Storage Options](#storage-options)
+* Storage Options
   * [Local](docs/Local.md)
   * [S3](docs/S3.md)
   * [Redis](docs/Redis.md)


### PR DESCRIPTION
The anchor no longer exists and the entries underneath link to different pages