### PR TITLE
feat: Add SCCACHE_GCS_CREDENTIALS_URL feature back for gcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,9 +1582,9 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opendal"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d1ff77f4919836ec2002b7b42366722b2856c2b718102d3d1cd58db5e56e3e"
+checksum = "c32203b1d5644a1cbd7b918a36269f59a055ff8c6c29f021a34b612a68234f07"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -2010,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab669a353d7993188029580a6297c09de9b3b82d26f9c7a6906e984db5074b"
+checksum = "70bdb7e4031af194baaf4422662b753ae625400ed8d562b3b3530935e1a52a83"
 dependencies = [
  "anyhow",
  "backon",
@@ -2350,6 +2350,7 @@ dependencies = [
  "rand 0.8.5",
  "redis",
  "regex",
+ "reqsign",
  "reqwest",
  "retry",
  "rouille",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ bincode = "1"
 blake3 = "1"
 byteorder = "1.0"
 bytes = "1"
-opendal = { version= "0.22.5", optional=true }
+opendal = { version= "0.22.6", optional=true }
+reqsign = {version="0.7.3", optional=true}
 chrono = { version = "0.4.23", optional = true }
 clap = { version = "4.0.29", features = ["derive", "env", "wrap_help"] }
 directories = "4.0.1"
@@ -120,9 +121,9 @@ features = [
 [features]
 default = ["all"]
 all = ["dist-client", "redis", "s3", "memcached", "gcs", "azure", "gha"]
-azure = ["opendal"]
-s3 = ["opendal"]
-gcs = ["opendal"]
+azure = ["opendal","reqsign"]
+s3 = ["opendal","reqsign"]
+gcs = ["opendal","reqsign"]
 gha = ["gha-toolkit"]
 memcached = ["memcached-rs"]
 native-zlib = []

--- a/docs/Gcs.md
+++ b/docs/Gcs.md
@@ -25,6 +25,7 @@ Cache location                  GCS, bucket: Bucket(name=<bucket name in GCP>), 
 Sccache is able to load credentials from various sources. Including:
 
 - User Input: If `SCCACHE_GCS_KEY_PATH` has been set, we will load from key path first.
+- [Task Cluster](https://taskcluster.net/): If `SCCACHE_GCS_CREDENTIALS_URL` has been set, we will load token from this url first.
 - Static: `GOOGLE_APPLICATION_CREDENTIALS`
 - Well-known locations:
   - Windows: `%APPDATA%\gcloud\application_default_credentials.json`
@@ -35,4 +36,4 @@ Sccache is able to load credentials from various sources. Including:
 
 ## Deprecation
 
-`SCCACHE_GCS_CREDENTIALS_URL` and `SCCACHE_GCS_OAUTH_URL` have been deprecated and not supported, please use `SCCACHE_GCS_SERVICE_ACCOUNT` instead.
+`SCCACHE_GCS_OAUTH_URL` have been deprecated and not supported, please use `SCCACHE_GCS_SERVICE_ACCOUNT` instead.

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -402,6 +402,7 @@ pub fn storage_from_config(config: &Config, pool: &tokio::runtime::Handle) -> Ar
                 ref cred_path,
                 rw_mode,
                 ref service_account,
+                ref credential_url,
             }) => {
                 debug!(
                     "Trying GCS bucket({}, {}, {:?})",
@@ -420,6 +421,7 @@ pub fn storage_from_config(config: &Config, pool: &tokio::runtime::Handle) -> Ar
                         cred_path.as_deref(),
                         service_account.as_deref(),
                         gcs_read_write_mode,
+                        credential_url.as_deref(),
                     ) {
                         Ok(s) => {
                             trace!("Using GCSCache");

--- a/src/config.rs
+++ b/src/config.rs
@@ -186,6 +186,7 @@ pub struct GCSCacheConfig {
     pub cred_path: Option<String>,
     pub service_account: Option<String>,
     pub rw_mode: GCSCacheRWMode,
+    pub credential_url: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -535,14 +536,14 @@ fn config_from_env() -> Result<EnvConfig> {
             .unwrap_or_default()
             .to_owned();
 
-        if env::var("SCCACHE_GCS_CREDENTIALS_URL").is_ok() {
-            warn!("gcs deprecated_url has been deprecated");
-        }
+
 
         if env::var("SCCACHE_GCS_OAUTH_URL").is_ok() {
             warn!("SCCACHE_GCS_OAUTH_URL has been deprecated");
             warn!("if you intend to use vm metadata for auth, please set correct service account intead");
         }
+
+        let credential_url = env::var("SCCACHE_GCS_CREDENTIALS_URL").ok();
 
         let cred_path = env::var("SCCACHE_GCS_KEY_PATH").ok();
         let service_account = env::var("SCCACHE_GCS_SERVICE_ACCOUNT").ok();
@@ -568,6 +569,7 @@ fn config_from_env() -> Result<EnvConfig> {
             cred_path,
             service_account,
             rw_mode,
+            credential_url,
         }
     });
 
@@ -879,7 +881,7 @@ pub mod server {
 
     fn default_pot_clone_args() -> Vec<String> {
         DEFAULT_POT_CLONE_ARGS
-            .into_iter()
+            .iter()
             .map(|s| s.to_string())
             .collect()
     }
@@ -1128,6 +1130,7 @@ no_credentials = true
                     service_account: Some("example_service_account".to_string()),
                     rw_mode: GCSCacheRWMode::ReadOnly,
                     key_prefix: "prefix".into(),
+                    credential_url: None,
                 }),
                 gha: Some(GHACacheConfig {
                     url: "http://localhost".to_owned(),


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

This PR will add `SCCACHE_GCS_CREDENTIALS_URL` feature back so that Mozilla can use sccache in CI without changing existing config.