### PR TITLE
feat: Enable logging for opendal operations

### DIFF
--- a/src/cache/azure.rs
+++ b/src/cache/azure.rs
@@ -15,6 +15,7 @@
 
 use opendal::Operator;
 
+use opendal::layers::LoggingLayer;
 use opendal::services::azblob;
 
 use crate::errors::*;
@@ -27,6 +28,7 @@ impl AzureBlobCache {
         builder.container(container);
         builder.root(key_prefix);
 
-        Ok(builder.build()?.into())
+        let op: Operator = builder.build()?.into();
+        Ok(op.layer(LoggingLayer::default()))
     }
 }

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -335,8 +335,9 @@ impl Storage for opendal::Operator {
                 let hit = CacheRead::from(io::Cursor::new(res))?;
                 Ok(Cache::Hit(hit))
             }
+            Err(e) if e.kind() == opendal::ErrorKind::ObjectNotFound => Ok(Cache::Miss),
             Err(e) => {
-                warn!("Got error: {:?}", e);
+                warn!("Got unexpected error: {:?}", e);
                 Ok(Cache::Miss)
             }
         }

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 use crate::errors::*;
-use opendal::services::gcs;
 use opendal::Operator;
+use opendal::{layers::LoggingLayer, services::gcs};
 use reqsign::{GoogleBuilder, GoogleToken, GoogleTokenLoad};
 
 #[derive(Copy, Clone)]
@@ -67,7 +67,8 @@ impl GCSCache {
         }
         builder.signer(signer_builder.build()?);
 
-        Ok(builder.build()?.into())
+        let op: Operator = builder.build()?.into();
+        Ok(op.layer(LoggingLayer::default()))
     }
 }
 

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use opendal::layers::LoggingLayer;
 use opendal::services::s3;
 use opendal::Operator;
 
@@ -41,7 +42,8 @@ impl S3Cache {
             builder.endpoint(&endpoint_resolver(endpoint, use_ssl)?);
         }
 
-        Ok(builder.build()?.into())
+        let op: Operator = builder.build()?.into();
+        Ok(op.layer(LoggingLayer::default()))
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

This PR introduces two changes:

- Enable logging for opendal operations for better debugging
- Omit error print while meeting object not found (cache miss)