### PR TITLE
Re-enable `aarch64-unknown-linux-musl`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,8 @@ jobs:
             binary: sccache-dist
             extra_args: --no-default-features --features="dist-server"
             target: x86_64-unknown-linux-musl
-#          - os: ubuntu-20.04
-#            target: aarch64-unknown-linux-musl
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-musl
           - os: macOS-11
             target: x86_64-apple-darwin
             macosx_deployment_target: 10.13


### PR DESCRIPTION
This PR uncomments the `ubuntu-20.04`/`aarch64-unknown-linux-musl` matrix combination to verify if the issues described in #1458 are resolved.