### PR TITLE
fix: handle -Xclang args when invoking clang/clang++ on windows cmake

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -185,7 +185,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("-fprofile-use", PathBuf, Concatenated('='), ClangProfileUse),
     take_arg!("-fsanitize-blacklist", PathBuf, Concatenated('='), ExtraHashFile),
     take_arg!("-gcc-toolchain", OsString, Separated, PassThrough),
-    flag!("-gcodeview", PreprocessorArgumentFlag),
+    flag!("-gcodeview", PassThroughFlag),
     take_arg!("-include-pch", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
     take_arg!("-load", PathBuf, Separated, ExtraHashFile),
     take_arg!("-mllvm", OsString, Separated, PassThrough),

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -315,7 +315,6 @@ mod test {
             )
         );
         assert_eq!(ovec!["-Xclang", "--dependent-lib=msvcrt"], a.common_args);
-        // assert!(a.common_args.is_empty());
     }
 
     #[test]
@@ -330,6 +329,11 @@ mod test {
             "foo.o"
         );
         parses!("-c", "foo.c", "-gcc-toolchain", "somewhere", "-o", "foo.o");
+    }
+
+    #[test]
+    fn test_gcodeview() {
+        parses!("-c", "foo.c", "-o", "foo.o", "-Xclang", "-gcodeview");
     }
 
     #[test]

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -301,7 +301,14 @@ mod test {
 
     #[test]
     fn test_dependent_lib() {
-        let a = parses!("-c", "foo.c", "-o", "foo.o", "-Xclang", "--dependent-lib=msvcrt");
+        let a = parses!(
+            "-c",
+            "foo.c",
+            "-o",
+            "foo.o",
+            "-Xclang",
+            "--dependent-lib=msvcrt"
+        );
         assert_eq!(Some("foo.c"), a.input.to_str());
         assert_eq!(Language::C, a.language);
         assert_map_contains!(
@@ -377,7 +384,10 @@ mod test {
             ])
         );
         assert_eq!(
-            CompilerArguments::CannotCache("Can't handle UnknownFlag arguments with -Xclang", Some("-broken".to_string())),
+            CompilerArguments::CannotCache(
+                "Can't handle UnknownFlag arguments with -Xclang",
+                Some("-broken".to_string())
+            ),
             parse_arguments_(stringvec![
                 "-c", "foo.c", "-o", "foo.o", "-Xclang", "-broken"
             ])

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -159,6 +159,7 @@ impl CCompilerImpl for Clang {
 }
 
 counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
+    take_arg!("--dependent-lib", OsString, Concatenated('='), PassThrough),
     take_arg!("--serialize-diagnostics", OsString, Separated, PassThrough),
     take_arg!("--target", OsString, Separated, PassThrough),
     // Note: for clang we must override the dep options from gcc.rs with `CanBeSeparated`.
@@ -184,6 +185,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("-fprofile-use", PathBuf, Concatenated('='), ClangProfileUse),
     take_arg!("-fsanitize-blacklist", PathBuf, Concatenated('='), ExtraHashFile),
     take_arg!("-gcc-toolchain", OsString, Separated, PassThrough),
+    flag!("-gcodeview", PreprocessorArgumentFlag),
     take_arg!("-include-pch", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
     take_arg!("-load", PathBuf, Separated, ExtraHashFile),
     take_arg!("-mllvm", OsString, Separated, PassThrough),
@@ -298,6 +300,25 @@ mod test {
     }
 
     #[test]
+    fn test_dependent_lib() {
+        let a = parses!("-c", "foo.c", "-o", "foo.o", "-Xclang", "--dependent-lib=msvcrt");
+        assert_eq!(Some("foo.c"), a.input.to_str());
+        assert_eq!(Language::C, a.language);
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: PathBuf::from("foo.o"),
+                    optional: false
+                }
+            )
+        );
+        assert_eq!(ovec!["-Xclang", "--dependent-lib=msvcrt"], a.common_args);
+        // assert!(a.common_args.is_empty());
+    }
+
+    #[test]
     fn test_parse_arguments_others() {
         parses!("-c", "foo.c", "-B", "somewhere", "-o", "foo.o");
         parses!(
@@ -352,7 +373,7 @@ mod test {
             ])
         );
         assert_eq!(
-            CompilerArguments::CannotCache("Can't handle UnknownFlag arguments with -Xclang", None),
+            CompilerArguments::CannotCache("Can't handle UnknownFlag arguments with -Xclang", Some("-broken".to_string())),
             parse_arguments_(stringvec![
                 "-c", "foo.c", "-o", "foo.o", "-Xclang", "-broken"
             ])

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -113,6 +113,7 @@ ArgData! { pub
     NoDiagnosticsColorFlag,
     // Should only be necessary for -Xclang flags - unknown flags not hidden behind
     // that are assumed to not affect compilation
+    PassThroughFlag,
     PassThrough(OsString),
     PassThroughPath(PathBuf),
     PreprocessorArgumentFlag,
@@ -342,6 +343,7 @@ where
                 need_explicit_dep_argument_path = DepArgumentRequirePath::Provided
             }
             Some(ExtraHashFile(_))
+            | Some(PassThroughFlag)
             | Some(PreprocessorArgumentFlag)
             | Some(PreprocessorArgument(_))
             | Some(PreprocessorArgumentPath(_))
@@ -382,6 +384,7 @@ where
             | Some(DiagnosticsColor(_))
             | Some(DiagnosticsColorFlag)
             | Some(NoDiagnosticsColorFlag)
+            | Some(PassThroughFlag)
             | Some(PassThrough(_))
             | Some(PassThroughPath(_)) => &mut common_args,
             Some(Arch(_)) => &mut arch_args,
@@ -446,6 +449,7 @@ where
             | Some(NoDiagnosticsColorFlag)
             | Some(Arch(_))
             | Some(PassThrough(_))
+            | Some(PassThroughFlag)
             | Some(PassThroughPath(_)) => &mut common_args,
             Some(ExtraHashFile(path)) => {
                 extra_hash_files.push(cwd.join(path));

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -436,8 +436,8 @@ where
             None => match arg {
                 Argument::Raw(_) if follows_plugin_arg => &mut common_args,
                 Argument::Raw(_) => cannot_cache!("Can't handle Raw arguments with -Xclang"),
-                Argument::UnknownFlag(_) => {
-                    cannot_cache!("Can't handle UnknownFlag arguments with -Xclang")
+                Argument::UnknownFlag(flag) => {
+                    cannot_cache!("Can't handle UnknownFlag arguments with -Xclang", flag.to_str().unwrap_or("").to_string())
                 }
                 _ => unreachable!(),
             },

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -440,7 +440,10 @@ where
                 Argument::Raw(_) if follows_plugin_arg => &mut common_args,
                 Argument::Raw(_) => cannot_cache!("Can't handle Raw arguments with -Xclang"),
                 Argument::UnknownFlag(flag) => {
-                    cannot_cache!("Can't handle UnknownFlag arguments with -Xclang", flag.to_str().unwrap_or("").to_string())
+                    cannot_cache!(
+                        "Can't handle UnknownFlag arguments with -Xclang",
+                        flag.to_str().unwrap_or("").to_string()
+                    )
                 }
                 _ => unreachable!(),
             },

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -701,7 +701,7 @@ pub fn parse_arguments(
                 | Some(NoDiagnosticsColorFlag)
                 | Some(Arch(_))
                 | Some(PassThroughFlag)
-                | Some(PassThrough(_))            
+                | Some(PassThrough(_))
                 | Some(PassThroughPath(_))
                 | Some(PedanticFlag)
                 | Some(Standard(_)) => &mut common_args,

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -700,7 +700,8 @@ pub fn parse_arguments(
                 | Some(DiagnosticsColorFlag)
                 | Some(NoDiagnosticsColorFlag)
                 | Some(Arch(_))
-                | Some(PassThrough(_))
+                | Some(PassThroughFlag)
+                | Some(PassThrough(_))            
                 | Some(PassThroughPath(_))
                 | Some(PedanticFlag)
                 | Some(Standard(_)) => &mut common_args,


### PR DESCRIPTION
Instead of clang-cl.