### PR TITLE
The "cache read miss" is now the compiler step. Make it more explicit 

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -345,12 +345,12 @@ where
                     out_pretty.clone(),
                 )
                 .await?;
-                let duration = start.elapsed();
+                let duration_compilation = start.elapsed();
                 if !compiler_result.status.success() {
                     debug!(
                         "[{}]: Compiled in {}, but failed, not storing in cache",
                         out_pretty,
-                        fmt_duration_as_secs(&duration)
+                        fmt_duration_as_secs(&duration_compilation)
                     );
                     return Ok((CompileResult::CompileFailed, compiler_result));
                 }
@@ -359,14 +359,14 @@ where
                     debug!(
                         "[{}]: Compiled in {}, but not cacheable",
                         out_pretty,
-                        fmt_duration_as_secs(&duration)
+                        fmt_duration_as_secs(&duration_compilation)
                     );
                     return Ok((CompileResult::NotCacheable, compiler_result));
                 }
                 debug!(
                     "[{}]: Compiled in {}, storing in cache",
                     out_pretty,
-                    fmt_duration_as_secs(&duration)
+                    fmt_duration_as_secs(&duration_compilation)
                 );
                 let start_create_artifact = Instant::now();
                 let mut entry = CacheWrite::from_objects(outputs, &pool)
@@ -398,7 +398,7 @@ where
                 };
                 let future = Box::pin(future);
                 Ok((
-                    CompileResult::CacheMiss(miss_type, dist_type, duration, future),
+                    CompileResult::CacheMiss(miss_type, dist_type, duration_compilation, future),
                     compiler_result,
                 ))
             }
@@ -784,7 +784,7 @@ pub enum CompileResult {
     CacheMiss(
         MissType,
         DistType,
-        Duration,
+        Duration, // Compilation time
         Pin<Box<dyn Future<Output = Result<CacheWriteInfo>> + Send>>,
     ),
     /// Not in cache, but the compilation result was determined to be not cacheable.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1223,7 +1223,7 @@ where
                                 }
                             }
                             stats.cache_misses.increment(&kind);
-                            stats.cache_read_miss_duration += duration;
+                            stats.compiler_write_duration += duration;
                             cache_write = Some(future);
                         }
                         CompileResult::NotCacheable => {
@@ -1390,7 +1390,7 @@ pub struct ServerStats {
     /// The total time spent reading cache hits.
     pub cache_read_hit_duration: Duration,
     /// The total time spent reading cache misses.
-    pub cache_read_miss_duration: Duration,
+    pub compiler_write_duration: Duration,
     /// The count of compilation failures.
     pub compile_fails: u64,
     /// Counts of reasons why compiles were not cached.
@@ -1440,7 +1440,7 @@ impl Default for ServerStats {
             cache_writes: u64::default(),
             cache_write_duration: Duration::new(0, 0),
             cache_read_hit_duration: Duration::new(0, 0),
-            cache_read_miss_duration: Duration::new(0, 0),
+            compiler_write_duration: Duration::new(0, 0),
             compile_fails: u64::default(),
             not_cached: HashMap::new(),
             dist_compiles: HashMap::new(),
@@ -1528,9 +1528,9 @@ impl ServerStats {
         );
         set_duration_stat!(
             stats_vec,
-            self.cache_read_miss_duration,
+            self.compiler_write_duration,
             self.cache_misses.all(),
-            "Average cache read miss"
+            "Average compiler write"
         );
         set_duration_stat!(
             stats_vec,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1530,7 +1530,7 @@ impl ServerStats {
             stats_vec,
             self.compiler_write_duration,
             self.cache_misses.all(),
-            "Average compiler write"
+            "Average compiler"
         );
         set_duration_stat!(
             stats_vec,


### PR DESCRIPTION
We are getting:
```
Average cache write               0.115 s
Average compiler write            5.737 s
Average cache read hit            0.000 s
```
was:
```
Average cache write               0.115 s
Average cache read miss           5.737 s
Average cache read hit            0.000 s
```