### PR TITLE
freebsd: create /opt/pot earlier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
         mem: 8192
         usesh: true
         copyback: false
-        prepare: pkg install -y curl gmake gtar pot sudo
+        prepare: pkg install -y curl gmake gtar pot sudo ca_root_nss
         run: |
           #####################################################################################
           ###  Prepare, build, and test

--- a/scripts/freebsd-ci-test.sh
+++ b/scripts/freebsd-ci-test.sh
@@ -38,6 +38,7 @@ set -eo pipefail
 
 init()
 {
+	echo "## init()"
 	base=$(realpath "$(dirname "$0")"/..)
 	OS_VERSION="$(freebsd-version | awk -F- '{print $1}')"
 	PUB_INTF="$(netstat -4rn | grep default | awk '{ print $4}')"
@@ -45,6 +46,7 @@ init()
 	export XDG_CONFIG_HOME="$TEST_TMPDIR/.config"
 	mkdir -p "$XDG_CONFIG_HOME"
 	export SCCACHE_DIR="$TEST_TMPDIR/.cache"
+	sudo mkdir -p /opt/pot/
 	killall sccache 2>/dev/null || true
 	killall sccache-dist 2>/dev/null || true
 	export RUST_LOG_STYLE=never


### PR DESCRIPTION
Maybe fix issue #1529 ?

Fails later on:
  
```
  ---- test_s3_invalid_args stdout ----
  thread 'test_s3_invalid_args' panicked at 'Unexpected stderr, failed var.contains(cache storage failed to read)
  ├── var: [2023-01-08T14:17:18Z DEBUG sccache::config] Attempting to read config file at "/tmp/sccache_freebsd.IlySuoe/.config/sccache/config"
  │   [2023-01-08T14:17:18Z DEBUG sccache::config] Couldn't open config file: No such file or directory (os error 2)
  │   [2023-01-08T14:17:18Z DEBUG sccache::config] Attempting to read config file at "/tmp/sccache_freebsd.IlySuoe/.config/sccache/config"
  │   [2023-01-08T14:17:18Z DEBUG sccache::config] Couldn't open config file: No such file or directory (os error 2)
  │   sccache: error: Server startup failed: create s3 cache failed: Unexpected (temporary) at http_util::Client::send => send blocking request, source: https://s3.amazonaws.com/test: Connection Failed: tls connection init failed: invalid peer certificate contents: invalid peer certificate: UnknownIssuer
  │   
  │   Caused by:
  │       0: https://s3.amazonaws.com/test: Connection Failed: tls connection init failed: invalid peer certificate contents: invalid peer certificate: UnknownIssuer
  │       1: invalid peer certificate contents: invalid peer certificate: UnknownIssuer
  └── var as str: [2023-01-08T14:17:18Z DEBUG sccache::config] Attempting to read config file at "/tmp/sccache_freebsd.IlySuoe/.config/sccache/config"
      [2023-01-08T14:17:18Z DEBUG sccache::config] Couldn't open config file: No such file or directory (os error 2)
      [2023-01-08T14:17:18Z DEBUG sccache::config] Attempting to read config file at "/tmp/sccache_freebsd.IlySuoe/.config/sccache/config"
      [2023-01-08T14:17:18Z DEBUG sccache::config] Couldn't open config file: No such file or directory (os error 2)
      sccache: error: Server startup failed: create s3 cache failed: Unexpected (temporary) at http_util::Client::send => send blocking request, source: https://s3.amazonaws.com/test: Connection Failed: tls connection init failed: invalid peer certificate contents: invalid peer certificate: UnknownIssuer
      
      Caused by:
          0: https://s3.amazonaws.com/test: Connection Failed: tls connection init failed: invalid peer certificate contents: invalid peer certificate: UnknownIssuer
          1: invalid peer certificate contents: invalid peer certificate: UnknownIssuer
  
  command=`"/Users/runner/work/sccache/sccache/target/debug/sccache" "--start-server"`
  code=2
  stdout="sccache: Starting the server...\n"
  stderr="[2023-01-08T14:17:18Z DEBUG sccache::config] Attempting to read config file at \"/tmp/sccache_freebsd.IlySuoe/.config/sccache/config\"\n[2023-01-08T14:17:18Z DEBUG sccache::config] Couldn\'t open config file: No such file or directory (os error 2)\n[2023-01-08T14:17:18Z DEBUG sccache::config] Attempting to read config file at \"/tmp/sccache_freebsd.IlySuoe/.config/sccache/config\"\n[2023-01-08T14:17:18Z DEBUG sccache::config] Couldn\'t open config file: No such file or directory (os error 2)\nsccache: error: Server startup failed: create s3 cache failed: Unexpected (temporary) at http_util::Client::send => send blocking request, source: https://s3.amazonaws.com/test: Connection Failed: tls connection init failed: invalid peer certificate contents: invalid peer certificate: UnknownIssuer\n\nCaused by:\n    0: https://s3.amazonaws.com/test: Connection Failed: tls connection init failed: invalid peer certificate contents: invalid peer certificate: UnknownIssuer\n    1: invalid peer certificate contents: invalid peer certificate: UnknownIssuer\n"
  ', /rustc/69f9c33d71c871fc16ac445211281c6e7a340943/library/core/src/ops/function.rs:251:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  
```

which is probably more @Xuanwo ;)