### PR TITLE
Add support for clang '-fuse-ctor-homing' flag

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -184,6 +184,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     // Note: this overrides the -fprofile-use option in gcc.rs.
     take_arg!("-fprofile-use", PathBuf, Concatenated('='), ClangProfileUse),
     take_arg!("-fsanitize-blacklist", PathBuf, Concatenated('='), ExtraHashFile),
+    flag!("-fuse-ctor-homing", PassThroughFlag),
     take_arg!("-gcc-toolchain", OsString, Separated, PassThrough),
     flag!("-gcodeview", PassThroughFlag),
     take_arg!("-include-pch", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
@@ -548,6 +549,12 @@ mod test {
             "-no-opaque-pointers"
         );
         assert_eq!(ovec!["-Xclang", "-no-opaque-pointers"], a.preprocessor_args);
+    }
+
+    #[test]
+    fn test_parse_xclang_use_ctor_homing() {
+        let a = parses!("-c", "foo.c", "-o", "foo.o", "-Xclang", "-fuse-ctor-homing");
+        assert_eq!(ovec!["-Xclang", "-fuse-ctor-homing"], a.common_args);
     }
 
     #[test]


### PR DESCRIPTION
references:
- https://clang.llvm.org/docs/UsersManual.html#cmdoption-fuse-ctor-homing
- https://blog.llvm.org/posts/2021-04-05-constructor-homing-for-debug-info/

closes #1266

Signed-off-by: Robert Günzler <r@gnzler.io>