### PR TITLE
feat: Introduce the default gha version

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -195,7 +195,7 @@ jobs:
     needs: build
 
     env:
-      SCCACHE_GHA_VERSION: "sccache_integration_tests"
+      SCCACHE_GHA_ENABLED: "on"
       RUSTC_WRAPPER: /home/runner/.cargo/bin/sccache
 
     steps:

--- a/docs/GHA.md
+++ b/docs/GHA.md
@@ -1,6 +1,8 @@
 # GitHub Actions
 
-To use the [GitHub Actions cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows), you need to set the `SCCACHE_GHA_VERSION` which is a namespace for the whole cache set.
+To use the [GitHub Actions cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows), you need to set `SCCACHE_GHA` to `on` to enable it.
+
+By changing `SCCACHE_GHA_VERSION`, we can purge all the cache.
 
 This cache type will needs token like `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` to work. You can set these environmental variables using the following step in a GitHub Actions workflow.
 

--- a/docs/GHA.md
+++ b/docs/GHA.md
@@ -1,6 +1,6 @@
 # GitHub Actions
 
-To use the [GitHub Actions cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows), you need to set `SCCACHE_GHA` to `on` to enable it.
+To use the [GitHub Actions cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows), you need to set `SCCACHE_GHA_ENABLED` to `on` to enable it.
 
 By changing `SCCACHE_GHA_VERSION`, we can purge all the cache.
 

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -490,7 +490,7 @@ pub fn storage_from_config(
                 return Ok(Arc::new(storage));
             }
             #[cfg(feature = "gha")]
-            CacheType::GHA(config::GHACacheConfig { ref version }) => {
+            CacheType::GHA(config::GHACacheConfig { ref version, .. }) => {
                 debug!("Init gha cache with version {version}");
 
                 let storage = GHACache::build(version)

--- a/src/cache/gha.rs
+++ b/src/cache/gha.rs
@@ -32,7 +32,13 @@ pub struct GHACache;
 impl GHACache {
     pub fn build(version: &str) -> Result<Operator> {
         let mut builder = ghac::Builder::default();
+        // This is the prefix of gha cache.
+        // From user side, cache key will be like `sccache/f/c/b/fcbxxx`
+        //
+        // User customization is theoretically supported, but I decided
+        // to see the community feedback first.
         builder.root("/sccache");
+
         if version.is_empty() {
             builder.version(GHA_CACHE_VERSION);
         } else {

--- a/src/cache/gha.rs
+++ b/src/cache/gha.rs
@@ -17,14 +17,7 @@ use opendal::services::ghac;
 use opendal::Operator;
 
 use crate::errors::*;
-
-/// GHA_CACHE_VERSION exists to give sccache maintainers a chance
-/// to purge users' cache enforcedly. Also, this version is the default
-/// value if the user doesn't input one.
-///
-/// Please bump this version if something awful happens. For example,
-/// this is a bug that may lead to path conflict.
-const GHA_CACHE_VERSION: &str = "sccache-v0";
+use crate::VERSION;
 
 /// A cache that stores entries in GHA Cache Services.
 pub struct GHACache;
@@ -40,9 +33,9 @@ impl GHACache {
         builder.root("/sccache");
 
         if version.is_empty() {
-            builder.version(GHA_CACHE_VERSION);
+            builder.version(&format!("sccache-v{VERSION}"));
         } else {
-            builder.version(&format!("{GHA_CACHE_VERSION}-{version}"));
+            builder.version(&format!("sccache-v{VERSION}-{version}"));
         }
 
         let op: Operator = builder.build()?.into();

--- a/src/cache/gha.rs
+++ b/src/cache/gha.rs
@@ -32,6 +32,7 @@ pub struct GHACache;
 impl GHACache {
     pub fn build(version: &str) -> Result<Operator> {
         let mut builder = ghac::Builder::default();
+        builder.root("/sccache");
         if version.is_empty() {
             builder.version(GHA_CACHE_VERSION);
         } else {

--- a/src/cache/gha.rs
+++ b/src/cache/gha.rs
@@ -18,13 +18,25 @@ use opendal::Operator;
 
 use crate::errors::*;
 
+/// GHA_CACHE_VERSION is exist to give sccache maintainers a chance
+/// to purge users cache enforcely. Also this version is the default
+/// value if user doesn't input one.
+///
+/// Please bump this version if something really bad happended. For example,
+/// this is bug that may lead to path conflict.
+const GHA_CACHE_VERSION: &str = "sccache-v0";
+
 /// A cache that stores entries in GHA Cache Services.
 pub struct GHACache;
 
 impl GHACache {
     pub fn build(version: &str) -> Result<Operator> {
         let mut builder = ghac::Builder::default();
-        builder.version(version);
+        if version.is_empty() {
+            builder.version(GHA_CACHE_VERSION);
+        } else {
+            builder.version(&format!("{GHA_CACHE_VERSION}-{version}"));
+        }
 
         let op: Operator = builder.build()?.into();
         Ok(op.layer(LoggingLayer::default()))

--- a/src/cache/gha.rs
+++ b/src/cache/gha.rs
@@ -18,12 +18,12 @@ use opendal::Operator;
 
 use crate::errors::*;
 
-/// GHA_CACHE_VERSION is exist to give sccache maintainers a chance
-/// to purge users cache enforcely. Also this version is the default
-/// value if user doesn't input one.
+/// GHA_CACHE_VERSION exists to give sccache maintainers a chance
+/// to purge users' cache enforcedly. Also, this version is the default
+/// value if the user doesn't input one.
 ///
-/// Please bump this version if something really bad happended. For example,
-/// this is bug that may lead to path conflict.
+/// Please bump this version if something awful happens. For example,
+/// this is a bug that may lead to path conflict.
 const GHA_CACHE_VERSION: &str = "sccache-v0";
 
 /// A cache that stores entries in GHA Cache Services.

--- a/src/config.rs
+++ b/src/config.rs
@@ -192,6 +192,7 @@ pub struct GCSCacheConfig {
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct GHACacheConfig {
+    pub enabled: bool,
     /// Version for gha cache is a namespace. By setting different versions,
     /// we can avoid mixed caches.
     pub version: String,
@@ -573,10 +574,14 @@ fn config_from_env() -> Result<EnvConfig> {
 
     // ======= GHA =======
     let gha = if let Ok(version) = env::var("SCCACHE_GHA_VERSION") {
-        Some(GHACacheConfig { version })
-    } else if env::var("SCCACHE_GHA").is_ok() {
+        Some(GHACacheConfig {
+            enabled: true,
+            version,
+        })
+    } else if env::var("SCCACHE_GHA_ENABLED").is_ok() {
         // If SCCACHE_GHA has been set, enable with default version.
         Some(GHACacheConfig {
+            enabled: true,
             version: "".to_string(),
         })
     } else {
@@ -1111,6 +1116,7 @@ no_credentials = true
                     credential_url: None,
                 }),
                 gha: Some(GHACacheConfig {
+                    enabled: true,
                     version: "sccache".to_string()
                 }),
                 redis: Some(RedisCacheConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -574,6 +574,11 @@ fn config_from_env() -> Result<EnvConfig> {
     // ======= GHA =======
     let gha = if let Ok(version) = env::var("SCCACHE_GHA_VERSION") {
         Some(GHACacheConfig { version })
+    } else if env::var("SCCACHE_GHA").is_ok() {
+        // If SCCACHE_GHA has been set, enable with default version.
+        Some(GHACacheConfig {
+            version: "".to_string(),
+        })
     } else {
         None
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -1087,6 +1087,7 @@ key_prefix = "prefix"
 service_account = "example_service_account"
 
 [cache.gha]
+enabled = true
 version = "sccache"
 
 [cache.memcached]

--- a/src/config.rs
+++ b/src/config.rs
@@ -574,16 +574,23 @@ fn config_from_env() -> Result<EnvConfig> {
 
     // ======= GHA =======
     let gha = if let Ok(version) = env::var("SCCACHE_GHA_VERSION") {
+        // If SCCACHE_GHA_VERSION has been set, we don't need to check
+        // SCCACHE_GHA_ENABLED's value anymore.
         Some(GHACacheConfig {
             enabled: true,
             version,
         })
-    } else if env::var("SCCACHE_GHA_ENABLED").is_ok() {
-        // If SCCACHE_GHA has been set, enable with default version.
-        Some(GHACacheConfig {
-            enabled: true,
-            version: "".to_string(),
-        })
+    } else if let Ok(enabled) = env::var("SCCACHE_GHA_ENABLED") {
+        // If only SCCACHE_GHA_ENABLED has been set, enable with
+        // default version.
+        if enabled == "on" || enabled == "true" {
+            Some(GHACacheConfig {
+                enabled: true,
+                version: "".to_string(),
+            })
+        } else {
+            None
+        }
     } else {
         None
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,12 @@ pub mod util;
 
 use std::env;
 
+/// VERSION is the pkg version of sccache.
+///
+/// This version is safe to be used in cache services to indicate the version
+/// that sccache ie.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// Used to denote the environment variable that controls
 /// logging for sccache, and sccache-dist.
 pub const LOGGING_ENV: &str = "SCCACHE_LOG";


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

This PR will introduce the default gha version.

This change has the following benefits:

- User don't need think and pick version if they don't care or don't wanna purge cache
- Give sccache a chance to purge users cache while needed (serious bug happened)

To support this change, I did following:

- Add `SCCACHE_GHA_ENABLED` as a flag
- make `SCCACHE_GHA_VERSION` an optional version.