### PR TITLE
Use println instead of warn to avoid missing deprecated message

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -537,8 +537,8 @@ fn config_from_env() -> Result<EnvConfig> {
 
 
         if env::var("SCCACHE_GCS_OAUTH_URL").is_ok() {
-            warn!("SCCACHE_GCS_OAUTH_URL has been deprecated");
-            warn!("if you intend to use vm metadata for auth, please set correct service account intead");
+            eprintln!("SCCACHE_GCS_OAUTH_URL has been deprecated");
+            eprintln!("if you intend to use vm metadata for auth, please set correct service account intead");
         }
 
         let credential_url = env::var("SCCACHE_GCS_CREDENTIALS_URL").ok();


### PR DESCRIPTION
Signed-off-by: b1tg <b1tg@protonmail.ch>

Fix https://github.com/mozilla/sccache/issues/1484