### PR TITLE
feat: Allow sccache keep running after hitting rate limit during check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,15 +1556,15 @@ checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opendal"
-version = "0.24.2"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97541724cf371973b28f5a873404f2a2a4f7bb1efe7ca36a27836c13958781c2"
+checksum = "3a657010a255640ce4b5e06b3bf275e3debe013208998cb22fa315eb40395919"
 dependencies = [
  "anyhow",
  "async-compat",
  "async-trait",
  "backon",
- "base64 0.20.0",
+ "base64 0.21.0",
  "bincode 2.0.0-rc.2",
  "bytes",
  "flagset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bincode = "1"
 blake3 = "1"
 byteorder = "1.0"
 bytes = "1"
-opendal = { version= "0.24", optional=true }
+opendal = { version= "0.24.6", optional=true }
 reqsign = {version="0.7.3", optional=true}
 chrono = { version = "0.4.23", optional = true }
 clap = { version = "4.0.32", features = ["derive", "env", "wrap_help"] }

--- a/docs/GHA.md
+++ b/docs/GHA.md
@@ -12,3 +12,7 @@ This cache type will needs token like `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_T
       core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
       core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 ```
+
+## Behavior
+
+If case sccache reaches the rate limit of the service, the build will continue but the storage might not be performed.

--- a/docs/GHA.md
+++ b/docs/GHA.md
@@ -15,4 +15,4 @@ This cache type will needs token like `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_T
 
 ## Behavior
 
-If case sccache reaches the rate limit of the service, the build will continue but the storage might not be performed.
+In case sccache reaches the rate limit of the service, the build will continue but the storage might not be performed.


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

This PR will allow sccache to keep running after hitting the rate limit error.

We introduce this change because we could have services that have very strict limit on our requests. During storage check, it's better to tolerate them and keep running because there are few things either we or our users can do on this.