### PR TITLE
fix: clippy warnings

### DIFF
--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -553,7 +553,7 @@ pub fn storage_from_config(
 
     let (dir, size) = (&config.fallback_cache.dir, config.fallback_cache.size);
     debug!("Init disk cache with dir {:?}, size {}", dir, size);
-    Ok(Arc::new(DiskCache::new(&dir, size, pool)))
+    Ok(Arc::new(DiskCache::new(dir, size, pool)))
 }
 
 #[cfg(test)]

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -143,7 +143,7 @@ fn get_clap_command() -> clap::Command {
                 .help("package toolchain for distributed compilation")
                 .value_parser(clap::value_parser!(PathBuf))
                 .num_args(2)
-                .value_names(&["EXE", "OUT"]),
+                .value_names(["EXE", "OUT"]),
             flag_infer_long("stats-format")
                 .help("set output format of statistics")
                 .value_name("FMT")
@@ -156,7 +156,7 @@ fn get_clap_command() -> clap::Command {
         ])
         .group(
             ArgGroup::new("one_and_only_one")
-                .args(&[
+                .args([
                     "dist-auth",
                     "dist-status",
                     "show-stats",

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -567,8 +567,8 @@ where
     T: CommandCreatorSync,
 {
     trace!("do_compile");
-    let exe_path = which_in(exe, path, &cwd)?;
-    let res = request_compile(&mut conn, &exe_path, &cmdline, &cwd, env_vars)?;
+    let exe_path = which_in(exe, path, cwd)?;
+    let res = request_compile(&mut conn, &exe_path, &cmdline, cwd, env_vars)?;
     handle_compile_response(
         creator, runtime, &mut conn, res, &exe_path, cmdline, cwd, stdout, stderr,
     )

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -599,7 +599,7 @@ where
             // Do this first so cleanup works correctly
             let local_path = output_paths.last().expect("nothing in vec after push");
 
-            let mut file = try_or_cleanup!(File::create(&local_path)
+            let mut file = try_or_cleanup!(File::create(local_path)
                 .with_context(|| format!("Failed to create output file {}", local_path.display())));
             let count = try_or_cleanup!(io::copy(&mut output_data.into_reader(), &mut file)
                 .with_context(|| format!("Failed to write output to {}", local_path.display())));
@@ -1285,7 +1285,7 @@ mod test {
         // showincludes prefix detection output
         next_command(
             &creator,
-            Ok(MockChild::new(exit_status(0), &stdout, &String::new())),
+            Ok(MockChild::new(exit_status(0), stdout, String::new())),
         );
         let c = detect_compiler(creator, &f.bins[0], f.tempdir.path(), &[], &[], pool, None)
             .wait()
@@ -1364,9 +1364,9 @@ LLVM version: 6.0",
         );
         // rustc --print=sysroot
         let sysroot = f.tempdir.path().to_str().unwrap();
-        next_command(creator, Ok(MockChild::new(exit_status(0), &sysroot, "")));
-        next_command(creator, Ok(MockChild::new(exit_status(0), &sysroot, "")));
-        next_command(creator, Ok(MockChild::new(exit_status(0), &sysroot, "")));
+        next_command(creator, Ok(MockChild::new(exit_status(0), sysroot, "")));
+        next_command(creator, Ok(MockChild::new(exit_status(0), sysroot, "")));
+        next_command(creator, Ok(MockChild::new(exit_status(0), sysroot, "")));
     }
 
     #[test]
@@ -1496,7 +1496,7 @@ LLVM version: 6.0",
             .iter()
             .map(|version| {
                 let output = format!("clang\n\"{}.0.0\"", version);
-                next_command(&creator, Ok(MockChild::new(exit_status(0), &output, "")));
+                next_command(&creator, Ok(MockChild::new(exit_status(0), output, "")));
                 let c = detect_compiler(
                     creator.clone(),
                     &f.bins[0],
@@ -1550,7 +1550,7 @@ LLVM version: 6.0",
         let f = TestFixture::new();
         let runtime = Runtime::new().unwrap();
         let pool = runtime.handle().clone();
-        let storage = DiskCache::new(&f.tempdir.path().join("cache"), u64::MAX, &pool);
+        let storage = DiskCache::new(f.tempdir.path().join("cache"), u64::MAX, &pool);
         let storage = Arc::new(storage);
         // Pretend to be GCC.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "gcc", "")));
@@ -1661,7 +1661,7 @@ LLVM version: 6.0",
         let f = TestFixture::new();
         let runtime = Runtime::new().unwrap();
         let pool = runtime.handle().clone();
-        let storage = DiskCache::new(&f.tempdir.path().join("cache"), u64::MAX, &pool);
+        let storage = DiskCache::new(f.tempdir.path().join("cache"), u64::MAX, &pool);
         let storage = Arc::new(storage);
         // Pretend to be GCC.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "gcc", "")));
@@ -1846,7 +1846,7 @@ LLVM version: 6.0",
         let f = TestFixture::new();
         let runtime = single_threaded_runtime();
         let pool = runtime.handle().clone();
-        let storage = DiskCache::new(&f.tempdir.path().join("cache"), u64::MAX, &pool);
+        let storage = DiskCache::new(f.tempdir.path().join("cache"), u64::MAX, &pool);
         let storage = Arc::new(storage);
         // Pretend to be GCC.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "gcc", "")));
@@ -1957,7 +1957,7 @@ LLVM version: 6.0",
         let f = TestFixture::new();
         let runtime = single_threaded_runtime();
         let pool = runtime.handle().clone();
-        let storage = DiskCache::new(&f.tempdir.path().join("cache"), u64::MAX, &pool);
+        let storage = DiskCache::new(f.tempdir.path().join("cache"), u64::MAX, &pool);
         let storage = Arc::new(storage);
         // Pretend to be GCC.  Also inject a fake object file that the subsequent
         // preprocessor failure should remove.
@@ -2037,7 +2037,7 @@ LLVM version: 6.0",
             test_dist::ErrorSubmitToolchainClient::new(),
             test_dist::ErrorRunJobClient::new(),
         ];
-        let storage = DiskCache::new(&f.tempdir.path().join("cache"), u64::MAX, &pool);
+        let storage = DiskCache::new(f.tempdir.path().join("cache"), u64::MAX, &pool);
         let storage = Arc::new(storage);
         // Pretend to be GCC.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "gcc", "")));

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -312,7 +312,7 @@ pub async fn preprocess<T>(
 where
     T: CommandCreatorSync,
 {
-    let mut cmd = creator.clone().new_command_sync(&executable);
+    let mut cmd = creator.clone().new_command_sync(executable);
     cmd.arg("-E")
         .arg(&parsed_args.input)
         .args(&parsed_args.dependency_args)
@@ -415,7 +415,7 @@ impl<'a> Iterator for ExpandAtArgs<'a> {
 
             let mut contents = String::new();
             let file = self.cwd.join(&value);
-            let res = File::open(&file).and_then(|mut f| f.read_to_string(&mut contents));
+            let res = File::open(file).and_then(|mut f| f.read_to_string(&mut contents));
             if res.is_err() {
                 // Failed to read the file, so return the argument as it is.
                 // This will result in a CannotCache.

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -816,7 +816,7 @@ impl<'a> Iterator for ExpandIncludeFile<'a> {
                 None => return None,
             };
             let file = match arg.split_prefix("@") {
-                Some(arg) => self.cwd.join(&arg),
+                Some(arg) => self.cwd.join(arg),
                 None => return Some(arg),
             };
 

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -187,7 +187,7 @@ where
     }
     cmd.args(&["-nologo", "-showIncludes", "-c", "-Fonul", "-I."])
         .arg(&input)
-        .current_dir(&tempdir.path())
+        .current_dir(tempdir.path())
         // The MSDN docs say the -showIncludes output goes to stderr,
         // but that's not true unless running with -E.
         .stdout(Stdio::piped())
@@ -901,7 +901,7 @@ where
         .args(&parsed_args.common_args)
         .env_clear()
         .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
-        .current_dir(&cwd);
+        .current_dir(cwd);
     if parsed_args.depfile.is_some() && !parsed_args.msvc_show_includes {
         cmd.arg("-showIncludes");
     }
@@ -1009,7 +1009,7 @@ fn generate_compile_commands(
         });
 
     let mut fo = OsString::from("-Fo");
-    fo.push(&out_file);
+    fo.push(out_file);
 
     let mut arguments: Vec<OsString> = vec![
         parsed_args.compilation_flag.clone(),
@@ -1085,7 +1085,7 @@ mod test {
         let stderr = String::from("some\r\nstderr\r\n");
         next_command(
             &creator,
-            Ok(MockChild::new(exit_status(0), &stdout, &stderr)),
+            Ok(MockChild::new(exit_status(0), stdout, stderr)),
         );
         assert_eq!(
             "blah: ",

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -671,7 +671,7 @@ impl RustupProxy {
         let state = match state {
             Ok(ProxyPath::ToBeDiscovered) => {
                 // still no rustup found, use which crate to find one
-                match which::which(&proxy_name) {
+                match which::which(proxy_name) {
                     Ok(proxy_candidate) => {
                         warn!(
                             "proxy: rustup found, but not where it was expected (next to rustc {})",
@@ -2262,7 +2262,7 @@ impl RlibDepReader {
         env_vars: &[(OsString, OsString)],
         rlib: &Path,
     ) -> Result<Vec<String>> {
-        let rlib_mtime = fs::metadata(&rlib)
+        let rlib_mtime = fs::metadata(rlib)
             .and_then(|m| m.modified())
             .context("Unable to get rlib modified time")?;
 
@@ -2278,8 +2278,8 @@ impl RlibDepReader {
         trace!("Discovering dependencies of {}", rlib.display());
 
         let mut cmd = process::Command::new(&self.executable);
-        cmd.args(&["-Z", "ls"])
-            .arg(&rlib)
+        cmd.args(["-Z", "ls"])
+            .arg(rlib)
             .env_clear()
             .envs(ref_env(env_vars))
             .env("RUSTC_BOOTSTRAP", "1"); // TODO: this is fairly naughty
@@ -3264,7 +3264,7 @@ proc_macro false
                     "b=b.rlib"
                 ],
                 &[],
-                &mk_files
+                mk_files
             ),
             hash_key(
                 &f,
@@ -3284,7 +3284,7 @@ proc_macro false
                     "lib"
                 ],
                 &[],
-                &mk_files
+                mk_files
             )
         );
     }

--- a/src/compiler/tasking_vx.rs
+++ b/src/compiler/tasking_vx.rs
@@ -293,7 +293,7 @@ async fn preprocess<T>(
 where
     T: CommandCreatorSync,
 {
-    let mut preprocess = creator.clone().new_command_sync(&executable);
+    let mut preprocess = creator.clone().new_command_sync(executable);
     preprocess
         .arg("-E")
         .arg(&parsed_args.input)
@@ -321,7 +321,7 @@ where
     // you can specify a target name which overrules the default target name.
 
     if let Some(ref depfile) = parsed_args.depfile {
-        let mut generate_depfile = creator.clone().new_command_sync(&executable);
+        let mut generate_depfile = creator.clone().new_command_sync(executable);
         generate_depfile
             .arg("-Em")
             .arg("-o")

--- a/src/dist/client_auth.rs
+++ b/src/dist/client_auth.rs
@@ -150,7 +150,7 @@ mod code_grant_pkce {
         let code_verifier = base64::encode_engine(&code_verifier_bytes, &BASE64_URL_SAFE_ENGINE);
         let mut hasher = Sha256::new();
         hasher.update(&code_verifier);
-        let code_challenge = base64::encode_engine(&hasher.finalize(), &BASE64_URL_SAFE_ENGINE);
+        let code_challenge = base64::encode_engine(hasher.finalize(), &BASE64_URL_SAFE_ENGINE);
         Ok((code_verifier, code_challenge))
     }
 

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -91,7 +91,7 @@ mod common {
                 anyhow::bail!(errmsg);
             }
         } else {
-            Ok(bincode::deserialize(&*bytes)?)
+            Ok(bincode::deserialize(&bytes)?)
         }
     }
 

--- a/src/dist/pkg.rs
+++ b/src/dist/pkg.rs
@@ -362,7 +362,7 @@ mod toolchain_imp {
 }
 
 pub fn make_tar_header(src: &Path, dest: &str) -> io::Result<tar::Header> {
-    let metadata_res = fs::metadata(&src);
+    let metadata_res = fs::metadata(src);
 
     let mut file_header = tar::Header::new_ustar();
     // TODO: test this works
@@ -396,7 +396,7 @@ pub fn make_tar_header(src: &Path, dest: &str) -> io::Result<tar::Header> {
     // to be like Unix, and the path is (now) relative so there should be no funny results
     // due to Windows
     // TODO: should really use a `set_path_str` or similar
-    file_header.set_path(&dest)?;
+    file_header.set_path(dest)?;
     Ok(file_header)
 }
 

--- a/src/lru_disk_cache/mod.rs
+++ b/src/lru_disk_cache/mod.rs
@@ -181,7 +181,7 @@ impl LruDiskCache {
 
     /// Returns `true` if the disk cache can store a file of `size` bytes.
     pub fn can_store(&self, size: u64) -> bool {
-        size <= self.lru.capacity() as u64
+        size <= self.lru.capacity()
     }
 
     /// Add the file at `path` of size `size` to the cache.
@@ -194,7 +194,7 @@ impl LruDiskCache {
             AddFile::RelPath(p) => p,
         };
         //TODO: ideally LRUCache::insert would give us back the entries it had to remove.
-        while self.lru.size() as u64 + size > self.lru.capacity() as u64 {
+        while self.lru.size() + size > self.lru.capacity() {
             let (rel_path, _) = self.lru.remove_lru().expect("Unexpectedly empty cache!");
             let remove_path = self.rel_to_abs_path(rel_path);
             //TODO: check that files are removable during `init`, so that this is only
@@ -233,7 +233,7 @@ impl LruDiskCache {
                     rel_path.to_string_lossy(),
                     e
                 );
-                fs::remove_file(&self.rel_to_abs_path(rel_path))
+                fs::remove_file(self.rel_to_abs_path(rel_path))
                     .expect("Failed to remove file we just created!");
                 e
             })
@@ -245,13 +245,13 @@ impl LruDiskCache {
         key: K,
         with: F,
     ) -> Result<()> {
-        self.insert_by(key, None, |path| with(File::create(&path)?))
+        self.insert_by(key, None, |path| with(File::create(path)?))
     }
 
     /// Add a file with `bytes` as its contents to the cache at path `key`.
     pub fn insert_bytes<K: AsRef<OsStr>>(&mut self, key: K, bytes: &[u8]) -> Result<()> {
         self.insert_by(key, Some(bytes.len() as u64), |path| {
-            let mut f = File::create(&path)?;
+            let mut f = File::create(path)?;
             f.write_all(bytes)?;
             Ok(())
         })

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -134,7 +134,7 @@ where
 {
     let b = dir.join(path);
     let parent = b.parent().unwrap();
-    fs::create_dir_all(&parent)?;
+    fs::create_dir_all(parent)?;
     let f = fs::File::create(&b)?;
     fill_contents(f)?;
     b.canonicalize()
@@ -153,7 +153,7 @@ pub fn mk_bin_contents<F: FnOnce(File) -> io::Result<()>>(
     use std::os::unix::fs::OpenOptionsExt;
     let bin = dir.join(path);
     let parent = bin.parent().unwrap();
-    fs::create_dir_all(&parent)?;
+    fs::create_dir_all(parent)?;
     let f = fs::OpenOptions::new()
         .write(true)
         .create(true)

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -74,7 +74,7 @@ pub fn stop_local_daemon() {
 
 pub fn get_stats<F: 'static + Fn(ServerInfo)>(f: F) {
     sccache_command()
-        .args(&["--show-stats", "--stats-format=json"])
+        .args(["--show-stats", "--stats-format=json"])
         .assert()
         .success()
         .stdout(predicate::function(move |output: &[u8]| {
@@ -98,13 +98,13 @@ pub fn zero_stats() {
 
 pub fn write_json_cfg<T: Serialize>(path: &Path, filename: &str, contents: &T) {
     let p = path.join(filename);
-    let mut f = fs::File::create(&p).unwrap();
+    let mut f = fs::File::create(p).unwrap();
     f.write_all(&serde_json::to_vec(contents).unwrap()).unwrap();
 }
 
 pub fn write_source(path: &Path, filename: &str, contents: &str) {
     let p = path.join(filename);
-    let mut f = fs::File::create(&p).unwrap();
+    let mut f = fs::File::create(p).unwrap();
     f.write_all(contents.as_bytes()).unwrap();
 }
 

--- a/tests/oauth.rs
+++ b/tests/oauth.rs
@@ -168,11 +168,11 @@ impl SeleniumContainer {
 impl Drop for SeleniumContainer {
     fn drop(&mut self) {
         let Output { stdout, stderr, .. } = Command::new("docker")
-            .args(&["logs", &self.cid])
+            .args(["logs", &self.cid])
             .output()
             .unwrap();
         let output = Command::new("docker")
-            .args(&["kill", &self.cid])
+            .args(["kill", &self.cid])
             .output()
             .unwrap();
 

--- a/tests/sccache_cargo.rs
+++ b/tests/sccache_cargo.rs
@@ -101,7 +101,7 @@ impl SccacheTest<'_> {
     fn show_stats(&self) -> assert_cmd::assert::AssertResult {
         trace!("sccache --show-stats");
         Command::new(SCCACHE_BIN.as_os_str())
-            .args(&["--show-stats", "--stats-format=json"])
+            .args(["--show-stats", "--stats-format=json"])
             .assert()
             .try_success()
     }
@@ -205,7 +205,7 @@ fn test_rust_cargo_build_nightly() -> Result<()> {
 
 fn cargo_clean(test_info: &SccacheTest) -> Result<()> {
     Command::new(CARGO.as_os_str())
-        .args(&["clean"])
+        .args(["clean"])
         .envs(test_info.env.iter().cloned())
         .current_dir(CRATE_DIR.as_os_str())
         .assert()
@@ -222,7 +222,7 @@ fn test_rust_cargo_cmd(cmd: &str, test_info: SccacheTest) -> Result<()> {
 
     // Now build the crate with cargo.
     Command::new(CARGO.as_os_str())
-        .args(&[cmd, "--color=never"])
+        .args([cmd, "--color=never"])
         .envs(test_info.env.iter().cloned())
         .current_dir(CRATE_DIR.as_os_str())
         .assert()
@@ -231,7 +231,7 @@ fn test_rust_cargo_cmd(cmd: &str, test_info: SccacheTest) -> Result<()> {
     // Clean it so we can build it again.
     cargo_clean(&test_info)?;
     Command::new(CARGO.as_os_str())
-        .args(&[cmd, "--color=always"])
+        .args([cmd, "--color=always"])
         .envs(test_info.env.iter().cloned())
         .current_dir(CRATE_DIR.as_os_str())
         .assert()
@@ -250,7 +250,7 @@ fn test_rust_cargo_env_dep(test_info: SccacheTest) -> Result<()> {
     cargo_clean(&test_info)?;
     // Now build the crate with cargo.
     Command::new(CARGO.as_os_str())
-        .args(&["run", "--color=never"])
+        .args(["run", "--color=never"])
         .envs(test_info.env.iter().cloned())
         .current_dir(CRATE_DIR.as_os_str())
         .assert()
@@ -261,7 +261,7 @@ fn test_rust_cargo_env_dep(test_info: SccacheTest) -> Result<()> {
     cargo_clean(&test_info)?;
 
     Command::new(CARGO.as_os_str())
-        .args(&["run", "--color=always"])
+        .args(["run", "--color=always"])
         .envs(test_info.env.iter().cloned())
         .env("TEST_ENV_VAR", "OTHER_VALUE")
         .current_dir(CRATE_DIR.as_os_str())

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -184,7 +184,7 @@ fn test_msvc_deps(compiler: Compiler, tempdir: &Path) {
     } = compiler;
     // Check that -deps works.
     trace!("compile with -deps");
-    let mut args = compile_cmdline(name, &exe, INPUT, OUTPUT, Vec::new());
+    let mut args = compile_cmdline(name, exe, INPUT, OUTPUT, Vec::new());
     args.push("-depstest.d".into());
     sccache_command()
         .args(&args)
@@ -215,7 +215,7 @@ fn test_gcc_mp_werror(compiler: Compiler, tempdir: &Path) {
         env_vars,
     } = compiler;
     trace!("test -MP with -Werror");
-    let mut args = compile_cmdline(name, &exe, INPUT_ERR, OUTPUT, Vec::new());
+    let mut args = compile_cmdline(name, exe, INPUT_ERR, OUTPUT, Vec::new());
     args.extend(vec_from!(
         OsString, "-MD", "-MP", "-MF", "foo.pp", "-Werror"
     ));
@@ -255,7 +255,7 @@ int main(int argc, char** argv) {
 }
 ",
     );
-    let mut args = compile_cmdline(name, &exe, SRC, OUTPUT, Vec::new());
+    let mut args = compile_cmdline(name, exe, SRC, OUTPUT, Vec::new());
     args.extend(vec_from!(OsString, "-fprofile-generate"));
     trace!("compile source.c (1)");
     sccache_command()
@@ -329,7 +329,7 @@ fn test_gcc_clang_no_warnings_from_macro_expansion(compiler: Compiler, tempdir: 
     sccache_command()
         .args(
             [
-                &compile_cmdline(name, &exe, INPUT_MACRO_EXPANSION, OUTPUT, Vec::new())[..],
+                &compile_cmdline(name, exe, INPUT_MACRO_EXPANSION, OUTPUT, Vec::new())[..],
                 &vec_from!(OsString, "-Wunreachable-code")[..],
             ]
             .concat(),
@@ -355,7 +355,7 @@ fn test_compile_with_define(compiler: Compiler, tempdir: &Path) {
     sccache_command()
         .args(
             [
-                &compile_cmdline(name, &exe, INPUT_WITH_DEFINE, OUTPUT, Vec::new())[..],
+                &compile_cmdline(name, exe, INPUT_WITH_DEFINE, OUTPUT, Vec::new())[..],
                 &vec_from!(OsString, "-DSCCACHE_TEST_DEFINE")[..],
             ]
             .concat(),
@@ -404,7 +404,7 @@ fn run_sccache_command_tests(compiler: Compiler, tempdir: &Path) {
         let (major, is_appleclang) = match re.captures(version_output) {
             Some(c) => (
                 c.name("major").unwrap().as_str().parse::<usize>().unwrap(),
-                c.name("apple") == None,
+                c.name("apple").is_none(),
             ),
             None => panic!(
                 "Version info not found in --version output: {}",
@@ -431,7 +431,7 @@ fn test_clang_multicall(compiler: Compiler, tempdir: &Path) {
     sccache_command()
         .args(compile_cmdline(
             name,
-            &exe,
+            exe,
             INPUT_CLANG_MULTICALL,
             OUTPUT,
             Vec::new(),
@@ -515,7 +515,7 @@ fn find_compilers() -> Vec<Compiler> {
             which_in(c, env::var_os("PATH"), &cwd)
                 .ok()
                 .map(|full_path| Compiler {
-                    name: *c,
+                    name: c,
                     exe: full_path.into(),
                     env_vars: vec![],
                 })


### PR DESCRIPTION
An automatically fix by running `cargo clippy --fix`. Not sure whether worth doing it seems no one running it before.