### PR TITLE
fix: Sccache dist tests broken after bump to tokio 1.21 and later

### DIFF
--- a/.github/actions/artifact_failure/action.yml
+++ b/.github/actions/artifact_failure/action.yml
@@ -1,0 +1,25 @@
+name: "Upload failure Artifacts"
+description: "Upload failure Artifacts"
+inputs:
+  name:
+    description: ""
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: pack failure artifacts
+      shell: bash
+      run: |
+        killall sccache || true
+        killall sccache-dist || true
+
+        tar --exclude='target' \
+            --exclude='docs' \
+            --exclude='bins' \
+            --exclude='.git' \
+            --exclude='failure-*' \
+            -zcf failure-${{ inputs.name }}.tar.gz .
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.name }}
+        path: failure-${{ inputs.name }}.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         include:
           - os: ubuntu-20.04
             rustc: 1.60.0 # Oldest supported version, keep in sync with README.md
-          - os: ubuntu-18.04
+          - os: ubuntu-22.04
             rustc: 1.60.0
             extra_desc: dist-server
             extra_args: --no-default-features --features=dist-tests test_dist_ -- --test-threads 1
@@ -86,6 +86,12 @@ jobs:
 
       - name: Run tests
         run: cargo test --locked --all-targets --verbose ${{ matrix.extra_args }}
+
+      - name: Upload failure
+        if: failure()
+        uses: ./.github/actions/artifact_failure
+        with:
+          name: test-${{ matrix.os }}-${{ matrix.rustc || 'stable' }}-${{ matrix.extra_desc }}
 
   build:
     name: build ${{ matrix.binary || 'sccache' }} ${{ matrix.target }}
@@ -182,10 +188,10 @@ jobs:
             extra_args: --features=unstable
           - os: macOS-11
             rustc: nightly
-# Disable on Windows for now as it fails with:
-# found invalid metadata files for crate `vte_generate_state_changes`
-#          - os: windows-2019
-#            rustc: nightly
+    # Disable on Windows for now as it fails with:
+    # found invalid metadata files for crate `vte_generate_state_changes`
+    #          - os: windows-2019
+    #            rustc: nightly
     env:
       RUST_BACKTRACE: 1
     steps:
@@ -207,9 +213,9 @@ jobs:
       - name: Execute tests
         run: cargo test --no-fail-fast --locked --all-targets --verbose ${{ matrix.extra_args }}
         env:
-          CARGO_INCREMENTAL: '0'
-          RUSTC_WRAPPER: ''
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off'
+          CARGO_INCREMENTAL: "0"
+          RUSTC_WRAPPER: ""
+          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
 
       - name: Generate coverage data (via `grcov`)
         id: coverage
@@ -245,53 +251,58 @@ jobs:
       matrix:
         job:
           - { os: macos-12 }
-        release: [ "13.1" ]
+        release: ["13.1"]
     steps:
-    - uses: actions/checkout@v3
-    - name: Prepare, build and test
-      uses: vmactions/freebsd-vm@v0
-      with:
-        mem: 8192
-        usesh: true
-        copyback: false
-        prepare: pkg install -y ca_root_nss curl gmake gtar pot sudo
-        run: |
-          #####################################################################################
-          ###  Prepare, build, and test
-          #####################################################################################
-          ###  based on ref: <https://github.com/rust-lang/rustup/pull/2783>
-          ###  and on ref: <https://github.com/uutils/coreutils/commit/86c610a84b8b6c>
-          ###  * NOTE: All steps need to be run in this block, otherwise, we are operating back
-          ###    on the mac host.
-          set -exo pipefail
-          #
-          ### Basic user setup ################################################################
-          TEST_USER=tester
-          TEST_USER_HOME="/opt/$TEST_USER"
-          REPO_NAME=${GITHUB_WORKSPACE##*/}
-          WORKSPACE_PARENT="/Users/runner/work/${REPO_NAME}"
-          WORKSPACE="${WORKSPACE_PARENT}/${REPO_NAME}"
-          export WORKSPACE
-          #
-          mkdir -p "$TEST_USER_HOME"
-          pw adduser -n "$TEST_USER" -d "$TEST_USER_HOME" -c "Tester" -h -
-          chown -R "$TEST_USER":"$TEST_USER" "$TEST_USER_HOME"
-          chown -R "$TEST_USER":"$TEST_USER" "/$WORKSPACE_PARENT"/
-          cat > /usr/local/etc/sudoers.d/wheel<<EOF
-          $TEST_USER ALL=(ALL) NOPASSWD: ALL
-          EOF
-          #
-          ### Install rust stable from rustup  ################################################
-          su "$TEST_USER" -c "/bin/sh -exo pipefail" <<"EOH"
-          whoami
-          echo "$HOME"
-          fetch -o /tmp/rustup.sh https://sh.rustup.rs
-          sh /tmp/rustup.sh -y --profile=minimal
-          ### Run tests #######################################################################
-          . "$HOME/.cargo/env"
-          "$WORKSPACE/scripts/freebsd-ci-test.sh"
-          EOH
-          # end
+      - uses: actions/checkout@v3
+      - name: Prepare, build and test
+        uses: vmactions/freebsd-vm@v0
+        with:
+          mem: 8192
+          usesh: true
+          copyback: false
+          prepare: pkg install -y ca_root_nss curl gmake gtar pot sudo
+          run: |
+            #####################################################################################
+            ###  Prepare, build, and test
+            #####################################################################################
+            ###  based on ref: <https://github.com/rust-lang/rustup/pull/2783>
+            ###  and on ref: <https://github.com/uutils/coreutils/commit/86c610a84b8b6c>
+            ###  * NOTE: All steps need to be run in this block, otherwise, we are operating back
+            ###    on the mac host.
+            set -exo pipefail
+            #
+            ### Basic user setup ################################################################
+            TEST_USER=tester
+            TEST_USER_HOME="/opt/$TEST_USER"
+            REPO_NAME=${GITHUB_WORKSPACE##*/}
+            WORKSPACE_PARENT="/Users/runner/work/${REPO_NAME}"
+            WORKSPACE="${WORKSPACE_PARENT}/${REPO_NAME}"
+            export WORKSPACE
+            #
+            mkdir -p "$TEST_USER_HOME"
+            pw adduser -n "$TEST_USER" -d "$TEST_USER_HOME" -c "Tester" -h -
+            chown -R "$TEST_USER":"$TEST_USER" "$TEST_USER_HOME"
+            chown -R "$TEST_USER":"$TEST_USER" "/$WORKSPACE_PARENT"/
+            cat > /usr/local/etc/sudoers.d/wheel<<EOF
+            $TEST_USER ALL=(ALL) NOPASSWD: ALL
+            EOF
+            #
+            ### Install rust stable from rustup  ################################################
+            su "$TEST_USER" -c "/bin/sh -exo pipefail" <<"EOH"
+            whoami
+            echo "$HOME"
+            fetch -o /tmp/rustup.sh https://sh.rustup.rs
+            sh /tmp/rustup.sh -y --profile=minimal
+            ### Run tests #######################################################################
+            . "$HOME/.cargo/env"
+            "$WORKSPACE/scripts/freebsd-ci-test.sh"
+            EOH
+            # end
+      - name: Upload failure
+        if: failure()
+        uses: ./.github/actions/artifact_failure
+        with:
+          name: test-freebsd-13.1-stable
 
   release:
     name: release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,17 +810,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-locks"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
-dependencies = [
- "futures-channel",
- "futures-task",
- "tokio",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,7 +2202,6 @@ dependencies = [
  "filetime",
  "flate2",
  "futures",
- "futures-locks",
  "gzp",
  "http",
  "hyper",
@@ -2750,9 +2738,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2760,13 +2748,12 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2815,9 +2802,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ env_logger = "0.10"
 filetime = "0.2"
 flate2 = { version = "1.0", optional = true, default-features = false, features = ["rust_backend"] }
 futures = "0.3"
-futures-locks = "0.7"
 gzp = { version = "0.11.1", default-features = false, features = ["deflate_rust"]  }
 http = "0.2"
 hyper = { version = "0.14.10", optional = true, features = ["server"] }

--- a/scripts/freebsd-ci-test.sh
+++ b/scripts/freebsd-ci-test.sh
@@ -247,6 +247,7 @@ test_sccache_dist_01()
 	# one failed remote build.
 	if [ "$FAILED_DIST" -gt 1 ]; then
 		2>&1 echo "More than one distributed compilations failed"
+		cat "$TEST_TMPDIR"/sccache_log.txt
 		return 1
 	fi
 	if [ "$SUCCEEDED_DIST" -eq 0 ]; then

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -556,7 +556,10 @@ mod server {
 
         rouille::Response {
             status_code: 200,
-            headers: vec![("Content-Type".into(), "application/octet-stream".into())],
+            headers: vec![
+                ("Content-Type".into(), "application/octet-stream".into()),
+                ("Content-Length".into(), data.len().to_string().into()),
+            ],
             data: rouille::ResponseBody::from_data(data),
             upgrade: None,
         }
@@ -744,6 +747,9 @@ mod server {
                 }
                 // Finish the client
                 let new_client = client_builder
+                    // Disable connection pool to avoid broken connection
+                    // between runtime
+                    .pool_max_idle_per_host(0)
                     .build()
                     .context("failed to create a HTTP client")?;
                 // Use the updated certificates
@@ -783,12 +789,16 @@ mod server {
                         prepare_response(request, &res)
                     },
                     (GET) (/api/v1/scheduler/server_certificate/{server_id: ServerId}) => {
-                        let certs = server_certificates.lock().unwrap();
-                        let (cert_digest, cert_pem) = try_or_500_log!(req_id, certs.get(&server_id)
+                        let certs = {
+                            let guard = server_certificates.lock().unwrap();
+                            guard.get(&server_id).map(|v|v.to_owned())
+                        };
+
+                        let (cert_digest, cert_pem) = try_or_500_log!(req_id, certs
                             .context("server cert not available"));
                         let res = ServerCertificateHttpResponse {
-                            cert_digest: cert_digest.clone(),
-                            cert_pem: cert_pem.clone(),
+                            cert_digest,
+                            cert_pem,
                         };
                         prepare_response(request, &res)
                     },
@@ -1100,6 +1110,9 @@ mod client {
             let client = reqwest::ClientBuilder::new()
                 .timeout(timeout)
                 .connect_timeout(connect_timeout)
+                // Disable connection pool to avoid broken connection
+                // between runtime
+                .pool_max_idle_per_host(0)
                 .build()
                 .context("failed to create an async HTTP client")?;
             let client_toolchains =

--- a/src/server.rs
+++ b/src/server.rs
@@ -32,7 +32,6 @@ use filetime::FileTime;
 use futures::channel::mpsc;
 use futures::future::FutureExt;
 use futures::{future, stream, Sink, SinkExt, Stream, StreamExt, TryFutureExt};
-use futures_locks::RwLock;
 use number_prefix::NumberPrefix;
 use std::collections::HashMap;
 use std::env;
@@ -48,12 +47,13 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::process::{ExitStatus, Output};
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::task::{Context, Poll, Waker};
 use std::time::Duration;
 #[cfg(feature = "dist-client")]
 use std::time::Instant;
 use std::u64;
+use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::TcpListener,
@@ -683,7 +683,7 @@ where
     C: Send,
 {
     /// Server statistics.
-    stats: Arc<RwLock<ServerStats>>,
+    stats: Arc<Mutex<ServerStats>>,
 
     /// Distributed sccache client
     dist_client: Arc<DistClientContainer>,
@@ -760,7 +760,7 @@ where
             match req.into_inner() {
                 Request::Compile(compile) => {
                     debug!("handle_client: compile");
-                    me.stats.write().await.compile_requests += 1;
+                    me.stats.lock().await.compile_requests += 1;
                     me.handle_compile(compile).await
                 }
                 Request::GetStats => {
@@ -825,11 +825,11 @@ where
         info: ActiveInfo,
     ) -> SccacheService<C> {
         SccacheService {
-            stats: Arc::new(RwLock::new(ServerStats::default())),
+            stats: Arc::default(),
             dist_client: Arc::new(dist_client),
             storage,
-            compilers: Arc::new(RwLock::new(HashMap::new())),
-            compiler_proxies: Arc::new(RwLock::new(HashMap::new())),
+            compilers: Arc::default(),
+            compiler_proxies: Arc::default(),
             rt,
             creator: C::new(client),
             tx,
@@ -887,7 +887,7 @@ where
 
     /// Get info and stats about the cache.
     async fn get_info(&self) -> Result<ServerInfo> {
-        let stats = self.stats.read().await.clone();
+        let stats = self.stats.lock().await.clone();
         let cache_location = self.storage.location();
         futures::try_join!(self.storage.current_size(), self.storage.max_size()).map(
             move |(cache_size, max_cache_size)| ServerInfo {
@@ -901,7 +901,7 @@ where
 
     /// Zero stats about the cache.
     async fn zero_stats(&self) {
-        *self.stats.write().await = ServerStats::default();
+        *self.stats.lock().await = ServerStats::default();
     }
 
     /// Handle a compile request from a client.
@@ -1090,11 +1090,10 @@ where
         cwd: PathBuf,
         env_vars: Vec<(OsString, OsString)>,
     ) -> SccacheResponse {
-        let mut stats = self.stats.write().await;
         match compiler {
             Err(e) => {
                 debug!("check_compiler: Unsupported compiler: {}", e.to_string());
-                stats.requests_unsupported_compiler += 1;
+                self.stats.lock().await.requests_unsupported_compiler += 1;
                 return Message::WithoutBody(Response::Compile(
                     CompileResponse::UnsupportedCompiler(OsString::from(e.to_string())),
                 ));
@@ -1106,7 +1105,7 @@ where
                 match c.parse_arguments(&cmd, &cwd, &env_vars) {
                     CompilerArguments::Ok(hasher) => {
                         debug!("parse_arguments: Ok: {:?}", cmd);
-                        stats.requests_executed += 1;
+                        self.stats.lock().await.requests_executed += 1;
                         let (tx, rx) = Body::pair();
                         self.start_compile_task(c, hasher, cmd, cwd, env_vars, tx);
                         let res = CompileResponse::CompileStarted;
@@ -1121,12 +1120,13 @@ where
                         } else {
                             debug!("parse_arguments: CannotCache({}): {:?}", why, cmd)
                         }
+                        let mut stats = self.stats.lock().await;
                         stats.requests_not_cacheable += 1;
                         *stats.not_cached.entry(why.to_string()).or_insert(0) += 1;
                     }
                     CompilerArguments::NotCompilation => {
                         debug!("parse_arguments: NotCompilation: {:?}", cmd);
-                        stats.requests_not_compile += 1;
+                        self.stats.lock().await.requests_not_compile += 1;
                     }
                 }
             }
@@ -1190,16 +1190,22 @@ where
             };
             match result {
                 Ok((compiled, out)) => {
-                    let mut stats = me.stats.write().await;
+                    let mut stats = me.stats.lock().await;
                     match compiled {
                         CompileResult::Error => {
+                            debug!("compile result: cache error");
+
                             stats.cache_errors.increment(&kind);
                         }
                         CompileResult::CacheHit(duration) => {
+                            debug!("compile result: cache hit");
+
                             stats.cache_hits.increment(&kind);
                             stats.cache_read_hit_duration += duration;
                         }
                         CompileResult::CacheMiss(miss_type, dist_type, duration, future) => {
+                            debug!("compile result: cache miss");
+
                             match dist_type {
                                 DistType::NoDist => {}
                                 DistType::Ok(id) => {
@@ -1224,16 +1230,24 @@ where
                             }
                             stats.cache_misses.increment(&kind);
                             stats.compiler_write_duration += duration;
+                            debug!("stats after compile result: {stats:?}");
                             cache_write = Some(future);
                         }
                         CompileResult::NotCacheable => {
+                            debug!("compile result: not cacheable");
+
                             stats.cache_misses.increment(&kind);
                             stats.non_cacheable_compilations += 1;
                         }
                         CompileResult::CompileFailed => {
+                            debug!("compile result: compile failed");
+
                             stats.compile_fails += 1;
                         }
                     };
+                    // Make sure the write guard has been dropped ASAP.
+                    drop(stats);
+
                     let Output {
                         status,
                         stdout,
@@ -1248,7 +1262,7 @@ where
                     res.stderr = stderr;
                 }
                 Err(err) => {
-                    let mut stats = me.stats.write().await;
+                    let mut stats = me.stats.lock().await;
                     match err.downcast::<ProcessError>() {
                         Ok(ProcessError(output)) => {
                             debug!("Compilation failed: {:?}", output);
@@ -1299,7 +1313,7 @@ where
                     match cache_write.await {
                         Err(e) => {
                             debug!("Error executing cache write: {}", e);
-                            me.stats.write().await.cache_write_errors += 1;
+                            me.stats.lock().await.cache_write_errors += 1;
                         }
                         //TODO: save cache stats!
                         Ok(info) => {
@@ -1308,7 +1322,7 @@ where
                                 info.object_file_pretty,
                                 util::fmt_duration_as_secs(&info.duration)
                             );
-                            let mut stats = me.stats.write().await;
+                            let mut stats = me.stats.lock().await;
                             stats.cache_writes += 1;
                             stats.cache_write_duration += info.duration;
                         }
@@ -1794,13 +1808,13 @@ impl Future for ShutdownOrInactive {
 /// Helper future which tracks the `ActiveInfo` below. This future will resolve
 /// once all instances of `ActiveInfo` have been dropped.
 struct WaitUntilZero {
-    info: std::sync::Weak<Mutex<Info>>,
+    info: std::sync::Weak<std::sync::Mutex<Info>>,
 }
 
 #[derive(Clone)]
 #[allow(dead_code)]
 struct ActiveInfo {
-    info: Arc<Mutex<Info>>,
+    info: Arc<std::sync::Mutex<Info>>,
 }
 
 struct Info {
@@ -1818,7 +1832,7 @@ impl Drop for Info {
 impl WaitUntilZero {
     #[rustfmt::skip]
     fn new() -> (WaitUntilZero, ActiveInfo) {
-        let info = Arc::new(Mutex::new(Info { waker: None }));
+        let info = Arc::new(std::sync::Mutex::new(Info { waker: None }));
 
         (WaitUntilZero { info: Arc::downgrade(&info) }, ActiveInfo { info })
     }

--- a/src/test/mock_storage.rs
+++ b/src/test/mock_storage.rs
@@ -15,9 +15,9 @@
 use crate::cache::{Cache, CacheWrite, Storage};
 use crate::errors::*;
 use futures::channel::mpsc;
-use futures_locks::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Mutex;
 
 /// A mock `Storage` implementation.
 pub struct MockStorage {

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -25,7 +25,7 @@ mod harness;
 fn basic_compile(tmpdir: &Path, sccache_cfg_path: &Path, sccache_cached_cfg_path: &Path) {
     let envs: Vec<(_, &OsStr)> = vec![
         ("RUST_BACKTRACE", "1".as_ref()),
-        ("SCCACHE_LOG", "sccache=trace".as_ref()),
+        ("SCCACHE_LOG", "trace".as_ref()),
         ("SCCACHE_CONF", sccache_cfg_path.as_ref()),
         ("SCCACHE_CACHED_CONF", sccache_cached_cfg_path.as_ref()),
     ];

--- a/tests/harness/Dockerfile.sccache-dist
+++ b/tests/harness/Dockerfile.sccache-dist
@@ -1,15 +1,4 @@
-FROM ubuntu:18.04 as bwrap-build
+FROM ubuntu:22.04
 RUN apt-get update && \
-    apt-get install -y wget xz-utils gcc libcap-dev make && \
+    apt-get install -y libcap2 bubblewrap && \
     apt-get clean
-RUN wget -q -O - https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz | \
-    tar -xJ
-RUN cd /bubblewrap-0.3.1 && \
-    ./configure --disable-man && \
-    make
-
-FROM aidanhs/ubuntu-docker:18.04-17.03.2-ce
-RUN apt-get update && \
-    apt-get install libcap2 libssl1.1 && \
-    apt-get clean
-COPY --from=bwrap-build /bubblewrap-0.3.1/bwrap /bwrap

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -8,7 +8,7 @@ use std::io::Write;
 use std::net::{self, IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
-use std::str;
+use std::str::{self, FromStr};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -25,20 +25,10 @@ use predicates::prelude::*;
 use serde::Serialize;
 use uuid::Uuid;
 
-#[cfg(feature = "dist-server")]
-macro_rules! matches {
-    ($expression:expr, $($pattern:tt)+) => {
-        match $expression {
-            $($pattern)+ => true,
-            _ => false
-        }
-    }
-}
-
 const CONTAINER_NAME_PREFIX: &str = "sccache_dist_test";
 const DIST_IMAGE: &str = "sccache_dist_test_image";
 const DIST_DOCKERFILE: &str = include_str!("Dockerfile.sccache-dist");
-const DIST_IMAGE_BWRAP_PATH: &str = "/bwrap";
+const DIST_IMAGE_BWRAP_PATH: &str = "/usr/bin/bwrap";
 const MAX_STARTUP_WAIT: Duration = Duration::from_secs(5);
 
 const DIST_SERVER_TOKEN: &str = "THIS IS THE TEST TOKEN";
@@ -55,6 +45,9 @@ pub fn start_local_daemon(cfg_path: &Path, cached_cfg_path: &Path) {
     // will hang because the internal server process is not detached.
     let _ = sccache_command()
         .arg("--start-server")
+        // Uncomment following lines to debug locally.
+        // .env("SCCACHE_LOG", "debug")
+        // .env("SCCACHE_ERROR_LOG", "/tmp/sccache_log.txt")
         .env("SCCACHE_CONF", cfg_path)
         .env("SCCACHE_CACHED_CONF", cached_cfg_path)
         .status()
@@ -79,7 +72,9 @@ pub fn get_stats<F: 'static + Fn(ServerInfo)>(f: F) {
         .success()
         .stdout(predicate::function(move |output: &[u8]| {
             let s = str::from_utf8(output).expect("Output not UTF-8");
-            f(serde_json::from_str(s).expect("Failed to parse JSON stats"));
+            let stats = serde_json::from_str(s).expect("Failed to parse JSON stats");
+            eprintln!("get server stats: {stats:?}");
+            f(stats);
             true
         }));
 }
@@ -271,6 +266,8 @@ impl DistSystem {
                 "SCCACHE_LOG=sccache=trace",
                 "-e",
                 "RUST_BACKTRACE=1",
+                "--network",
+                "host",
                 "-v",
                 &format!("{}:/sccache-dist", self.sccache_dist.to_str().unwrap()),
                 "-v",
@@ -337,6 +334,8 @@ impl DistSystem {
                 "SCCACHE_LOG=sccache=trace",
                 "-e",
                 "RUST_BACKTRACE=1",
+                "--network",
+                "host",
                 "-v",
                 &format!("{}:/sccache-dist", self.sccache_dist.to_str().unwrap()),
                 "-v",
@@ -364,7 +363,7 @@ impl DistSystem {
 
         check_output(&output);
 
-        let server_ip = self.container_ip(&server_name);
+        let server_ip = IpAddr::from_str("127.0.0.1").unwrap();
         let server_cfg = sccache_server_cfg(&self.tmpdir, self.scheduler_url(), server_ip);
         fs::File::create(&server_cfg_path)
             .unwrap()
@@ -388,7 +387,7 @@ impl DistSystem {
         handler: S,
     ) -> ServerHandle {
         let server_addr = {
-            let ip = self.host_interface_ip();
+            let ip = IpAddr::from_str("127.0.0.1").unwrap();
             let listener = net::TcpListener::bind(SocketAddr::from((ip, 0))).unwrap();
             listener.local_addr().unwrap()
         };
@@ -461,8 +460,7 @@ impl DistSystem {
     }
 
     pub fn scheduler_url(&self) -> HTTPUrl {
-        let ip = self.container_ip(self.scheduler_name.as_ref().unwrap());
-        let url = format!("http://{}:{}", ip, SCHEDULER_PORT);
+        let url = format!("http://127.0.0.1:{}", SCHEDULER_PORT);
         HTTPUrl::from_url(reqwest::Url::parse(&url).unwrap())
     }
 
@@ -473,37 +471,6 @@ impl DistSystem {
         .unwrap();
         assert!(res.status().is_success());
         bincode::deserialize_from(res).unwrap()
-    }
-
-    fn container_ip(&self, name: &str) -> IpAddr {
-        let output = Command::new("docker")
-            .args(&[
-                "inspect",
-                "--format",
-                "{{ .NetworkSettings.IPAddress }}",
-                name,
-            ])
-            .output()
-            .unwrap();
-        check_output(&output);
-        let stdout = String::from_utf8(output.stdout).unwrap();
-        stdout.trim().to_owned().parse().unwrap()
-    }
-
-    // The interface that the host sees on the docker network (typically 'docker0')
-    fn host_interface_ip(&self) -> IpAddr {
-        let output = Command::new("docker")
-            .args(&[
-                "inspect",
-                "--format",
-                "{{ .NetworkSettings.Gateway }}",
-                self.scheduler_name.as_ref().unwrap(),
-            ])
-            .output()
-            .unwrap();
-        check_output(&output);
-        let stdout = String::from_utf8(output.stdout).unwrap();
-        stdout.trim().to_owned().parse().unwrap()
     }
 }
 


### PR DESCRIPTION
It's a long-term problem that sccache dist tests failed after bumping tokio.

After a bisect of all commits between tokio 1.20.1 to 1.21.0, I confirmed that this problem was introduced in https://github.com/tokio-rs/tokio/pull/4840. The PR itself is simple and correct, but it can lead to problems in `hyper` (`reqwest` affected too).

After this PR, hyper can't reuse connections between different runtimes. To address this problem, we should ensure all requests sent by hyper are from the same runtime. But it's a huge change based on our current design. So in this PR, I disabled the keep-alive of reqwest to make sure everything just works as before.

Changes that are included in this PR:

- Disable keep-alive in hyper side
  - NOTE: we always set `keep-alive: Close` by hand, so this change won't affect of dist server's perf.
- Use the new image for testing (ubuntu 22.04)
  - Use openssl 3.0 and a new version of glibc, which makes it possible to test locally on modern systems.
- Use `localhost` with network `host` instead of `docker` container IP
  - Make it possible to test with complex and different docker setups. For example, use `podman-docker` without the `docker0` network bridge.
- Bump the version of `tokio` and `tokio-utils`
- Smaller our lock scope

Future Plan:

- Should we migrate to an async web framework instead?
- Maybe we need to init the async runtime first and always stick to the same one?
- We should not spawn a new thread to use `reqwest::blocking::Client`.


Close https://github.com/mozilla/sccache/pull/1541
Close https://github.com/mozilla/sccache/pull/1543