### PR TITLE
Support nvcc's `--threads` flag

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -100,6 +100,8 @@ pub struct ParsedArguments {
     pub common_args: Vec<OsString>,
     /// Commandline arguments for the compiler that specify the architecture given
     pub arch_args: Vec<OsString>,
+    /// Commandline arguments for the preprocessor or the compiler that don't affect the computed hash.
+    pub unhashed_args: Vec<OsString>,
     /// Extra files that need to have their contents hashed.
     pub extra_hash_files: Vec<PathBuf>,
     /// Whether or not the `-showIncludes` argument is passed on MSVC
@@ -400,6 +402,7 @@ where
                 compiler.plusplus(),
             )
         };
+
         // A compiler binary may be a symlink to another and so has the same digest, but that means
         // the toolchain will not contain the correct path to invoke the compiler! Add the compiler
         // executable path to try and prevent this

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -292,6 +292,7 @@ where
         preprocessor_args,
         common_args,
         arch_args: vec![],
+        unhashed_args: vec![],
         extra_hash_files: vec![],
         msvc_show_includes: false,
         profile_generate: false,
@@ -349,6 +350,7 @@ pub fn generate_compile_commands(
         out_file.into(),
     ];
     arguments.extend(parsed_args.preprocessor_args.clone());
+    arguments.extend(parsed_args.unhashed_args.clone());
     arguments.extend(parsed_args.common_args.clone());
     let command = CompileCommand {
         executable: executable.to_owned(),
@@ -755,6 +757,7 @@ mod test {
             preprocessor_args: vec![],
             common_args: vec![],
             arch_args: vec![],
+            unhashed_args: vec![],
             extra_hash_files: vec![],
             msvc_show_includes: false,
             profile_generate: false,

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -548,6 +548,7 @@ pub fn parse_arguments(
     let mut output_arg = None;
     let mut input_arg = None;
     let mut common_args = vec![];
+    let mut unhashed_args = vec![];
     let mut preprocessor_args = vec![];
     let mut dependency_args = vec![];
     let mut extra_hash_files = vec![];
@@ -705,6 +706,7 @@ pub fn parse_arguments(
                 | Some(PassThroughPath(_))
                 | Some(PedanticFlag)
                 | Some(Standard(_)) => &mut common_args,
+                Some(Unhashed(_)) => &mut unhashed_args,
 
                 Some(ProfileGenerate) => {
                     profile_generate = true;
@@ -821,6 +823,7 @@ pub fn parse_arguments(
         preprocessor_args,
         common_args,
         arch_args: vec![],
+        unhashed_args,
         extra_hash_files,
         msvc_show_includes: show_includes,
         profile_generate,
@@ -1018,6 +1021,7 @@ fn generate_compile_commands(
     ];
     arguments.extend(parsed_args.preprocessor_args.clone());
     arguments.extend(parsed_args.dependency_args.clone());
+    arguments.extend(parsed_args.unhashed_args.clone());
     arguments.extend(parsed_args.common_args.clone());
 
     let command = CompileCommand {
@@ -1626,6 +1630,7 @@ mod test {
             preprocessor_args: vec![],
             common_args: vec![],
             arch_args: vec![],
+            unhashed_args: vec![],
             extra_hash_files: vec![],
             msvc_show_includes: false,
             profile_generate: false,
@@ -1686,6 +1691,7 @@ mod test {
             preprocessor_args: vec![],
             common_args: vec![],
             arch_args: vec![],
+            unhashed_args: vec![],
             extra_hash_files: vec![],
             msvc_show_includes: false,
             profile_generate: false,

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -197,7 +197,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("--ptxas-options", OsString, CanBeSeparated('='), PassThrough),
     take_arg!("--relocatable-device-code", OsString, CanBeSeparated('='), PreprocessorArgument),
     take_arg!("--system-include", PathBuf, CanBeSeparated('='), PreprocessorArgumentPath),
-    take_arg!("--threads", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("--threads", OsString, CanBeSeparated('='), Unhashed),
 
     take_arg!("-Xarchive", OsString, CanBeSeparated('='), PassThrough),
     take_arg!("-Xcompiler", OsString, CanBeSeparated('='), PreprocessorArgument),
@@ -217,7 +217,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     flag!("-nohdinitlist", PreprocessorArgumentFlag),
     flag!("-ptx", DoCompilation),
     take_arg!("-rdc", OsString, CanBeSeparated('='), PreprocessorArgument),
-    take_arg!("-t", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-t", OsString, CanBeSeparated('='), Unhashed),
     take_arg!("-x", OsString, CanBeSeparated('='), Language),
 ]);
 
@@ -311,7 +311,7 @@ mod test {
         assert!(a.preprocessor_args.is_empty());
         assert_eq!(
             ovec!["-t=1", "-t=2", "--threads", "1", "--threads", "2"],
-            a.common_args
+            a.unhashed_args
         );
     }
 

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -285,7 +285,17 @@ mod test {
 
     #[test]
     fn test_parse_threads_argument_simple_cu() {
-        let a = parses!("-t=1", "-t", "2", "--threads=1", "--threads=2", "-c", "foo.cu", "-o", "foo.o");
+        let a = parses!(
+            "-t=1",
+            "-t",
+            "2",
+            "--threads=1",
+            "--threads=2",
+            "-c",
+            "foo.cu",
+            "-o",
+            "foo.o"
+        );
         assert_eq!(Some("foo.cu"), a.input.to_str());
         assert_eq!(Language::Cuda, a.language);
         assert_map_contains!(
@@ -299,12 +309,10 @@ mod test {
             )
         );
         assert!(a.preprocessor_args.is_empty());
-        assert_eq!(ovec![
-            "-t=1",
-            "-t=2",
-            "--threads", "1",
-            "--threads", "2"
-        ], a.common_args);
+        assert_eq!(
+            ovec!["-t=1", "-t=2", "--threads", "1", "--threads", "2"],
+            a.common_args
+        );
     }
 
     #[test]

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -197,6 +197,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("--ptxas-options", OsString, CanBeSeparated('='), PassThrough),
     take_arg!("--relocatable-device-code", OsString, CanBeSeparated('='), PreprocessorArgument),
     take_arg!("--system-include", PathBuf, CanBeSeparated('='), PreprocessorArgumentPath),
+    take_arg!("--threads", OsString, CanBeSeparated('='), PassThrough),
 
     take_arg!("-Xarchive", OsString, CanBeSeparated('='), PassThrough),
     take_arg!("-Xcompiler", OsString, CanBeSeparated('='), PreprocessorArgument),
@@ -216,6 +217,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     flag!("-nohdinitlist", PreprocessorArgumentFlag),
     flag!("-ptx", DoCompilation),
     take_arg!("-rdc", OsString, CanBeSeparated('='), PreprocessorArgument),
+    take_arg!("-t", OsString, CanBeSeparated('='), PassThrough),
     take_arg!("-x", OsString, CanBeSeparated('='), Language),
 ]);
 
@@ -279,6 +281,30 @@ mod test {
         );
         assert!(a.preprocessor_args.is_empty());
         assert!(a.common_args.is_empty());
+    }
+
+    #[test]
+    fn test_parse_threads_argument_simple_cu() {
+        let a = parses!("-t=1", "-t", "2", "--threads=1", "--threads=2", "-c", "foo.cu", "-o", "foo.o");
+        assert_eq!(Some("foo.cu"), a.input.to_str());
+        assert_eq!(Language::Cuda, a.language);
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
+        assert!(a.preprocessor_args.is_empty());
+        assert_eq!(ovec![
+            "-t=1",
+            "-t=2",
+            "--threads", "1",
+            "--threads", "2"
+        ], a.common_args);
     }
 
     #[test]

--- a/src/compiler/tasking_vx.rs
+++ b/src/compiler/tasking_vx.rs
@@ -273,6 +273,7 @@ where
         preprocessor_args,
         common_args,
         arch_args: vec![],
+        unhashed_args: vec![],
         extra_hash_files: vec![],
         msvc_show_includes: false,
         profile_generate: false,
@@ -364,6 +365,7 @@ fn generate_compile_commands(
         out_file.path.as_os_str().into(),
     ];
     arguments.extend(parsed_args.preprocessor_args.clone());
+    arguments.extend(parsed_args.unhashed_args.clone());
     arguments.extend(parsed_args.common_args.clone());
     let command = CompileCommand {
         executable: executable.to_owned(),
@@ -695,6 +697,7 @@ mod test {
             preprocessor_args: vec![],
             common_args: vec![],
             arch_args: vec![],
+            unhashed_args: vec![],
             extra_hash_files: vec![],
             msvc_show_includes: false,
             profile_generate: false,

--- a/src/compiler/tasking_vx.rs
+++ b/src/compiler/tasking_vx.rs
@@ -721,4 +721,55 @@ mod test {
         // Ensure that we ran all processes.
         assert_eq!(0, creator.lock().unwrap().children.len());
     }
+
+    #[test]
+    fn test_cuda_threads_included_in_compile_command() {
+        let creator = new_creator();
+        let f = TestFixture::new();
+        let parsed_args = ParsedArguments {
+            input: "foo.cu".into(),
+            language: Language::Cuda,
+            compilation_flag: "-c".into(),
+            depfile: None,
+            outputs: vec![(
+                "obj",
+                ArtifactDescriptor {
+                    path: "foo.o".into(),
+                    optional: false,
+                },
+            )]
+            .into_iter()
+            .collect(),
+            dependency_args: vec![],
+            preprocessor_args: vec![],
+            common_args: vec![],
+            arch_args: vec![],
+            unhashed_args: ovec!["--threads", "2"],
+            extra_hash_files: vec![],
+            msvc_show_includes: false,
+            profile_generate: false,
+            color_mode: ColorMode::Auto,
+            suppress_rewrite_includes_only: false,
+        };
+        let compiler = &f.bins[0];
+        // Compiler invocation.
+        next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));
+        let mut path_transformer = dist::PathTransformer::default();
+        let (command, _, cacheable) = generate_compile_commands(
+            &mut path_transformer,
+            compiler,
+            &parsed_args,
+            f.tempdir.path(),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(
+            ovec!["-c", "foo.cu", "-o", "foo.o", "--threads", "2"],
+            command.arguments
+        );
+        let _ = command.execute(&creator).wait();
+        assert_eq!(Cacheable::Yes, cacheable);
+        // Ensure that we ran all processes.
+        assert_eq!(0, creator.lock().unwrap().children.len());
+    }
 }


### PR DESCRIPTION
This PR adds support for nvcc's [`--threads`](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/#threads-number-t) flag.