### PR TITLE
Support MSVC flag 'external:anglebrackets'

### DIFF
--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -491,6 +491,7 @@ msvc_args!(static ARGS: [ArgInfo<ArgData>; _] = [
     msvc_flag!("external:W2", PassThrough),
     msvc_flag!("external:W3", PassThrough),
     msvc_flag!("external:W4", PassThrough),
+    msvc_flag!("external:anglebrackets", PassThrough),
     msvc_take_arg!("favor:", OsString, Concatenated, PassThroughWithSuffix),
     msvc_take_arg!("fp:", OsString, Concatenated, PassThroughWithSuffix),
     msvc_take_arg!("fsanitize-blacklist", PathBuf, Concatenated('='), ExtraHashFile),


### PR DESCRIPTION
Add support for the '/external:anglebrackets' flag, as documented here: https://learn.microsoft.com/en-us/cpp/build/reference/external-external-headers-diagnostics?view=msvc-170#arguments