### PR TITLE
feat: Print sccache version for Server stats

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -889,12 +889,14 @@ where
     async fn get_info(&self) -> Result<ServerInfo> {
         let stats = self.stats.lock().await.clone();
         let cache_location = self.storage.location();
+        let version = env!("CARGO_PKG_VERSION").to_string();
         futures::try_join!(self.storage.current_size(), self.storage.max_size()).map(
             move |(cache_size, max_cache_size)| ServerInfo {
                 stats,
                 cache_location,
                 cache_size,
                 max_cache_size,
+                version,
             },
         )
     }
@@ -1423,6 +1425,7 @@ pub struct ServerInfo {
     pub cache_location: String,
     pub cache_size: Option<u64>,
     pub max_cache_size: Option<u64>,
+    pub version: String,
 }
 
 /// Status of the dist client.
@@ -1617,6 +1620,12 @@ impl ServerInfo {
             "{:<name_width$} {}",
             "Cache location",
             self.cache_location,
+            name_width = name_width
+        );
+        println!(
+            "{:<name_width$} {}",
+            "Version (client)",
+            self.version,
             name_width = name_width
         );
         for &(name, val) in &[

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -155,7 +155,7 @@ fn test_server_stats() {
     // Ask it for stats.
     let info = request_stats(conn).unwrap();
     assert_eq!(0, info.stats.compile_requests);
-    // Include sccache ver (cli) to validate. 
+    // Include sccache ver (cli) to validate.
     assert_eq!(env!("CARGO_PKG_VERSION"), info.version);
     // Now signal it to shut down.
     sender.send(ServerMessage::Shutdown).ok().unwrap();

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -155,6 +155,8 @@ fn test_server_stats() {
     // Ask it for stats.
     let info = request_stats(conn).unwrap();
     assert_eq!(0, info.stats.compile_requests);
+    // Include sccache ver (cli) to validate. 
+    assert_eq!(env!("CARGO_PKG_VERSION"), info.version);
     // Now signal it to shut down.
     sender.send(ServerMessage::Shutdown).ok().unwrap();
     // Ensure that it shuts down.


### PR DESCRIPTION
Hi.

Coming from this [discussion ](https://github.com/mozilla/sccache/issues/1548) started by @Xuanwo , it's has been considered a good idea to include the version info when running the _sccache --show-stats_ command.

I have included a basic solution, directly included & calling the env! macro to get the  _CARGO_PKG_VERSION_. 
One of the pending confirmations should be the _display_ info of this new version field, as it has been mentioned that it should be explicit regarding it's the _client_ version.

It's not a big thing, but hope to help a bit with this cool project besides my ongoing learning of Rust.
Sorry in advance for any mistake.

Thanks.
