### PR TITLE
feat: Add assembler support (.S, .s, .sx)

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -62,6 +62,7 @@ where
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Language {
+    Assembler,
     C,
     Cxx,
     ObjectiveC,
@@ -125,6 +126,7 @@ impl ParsedArguments {
 impl Language {
     pub fn from_file_name(file: &Path) -> Option<Self> {
         match file.extension().and_then(|e| e.to_str()) {
+            Some("S") | Some("s") | Some("sx") => Some(Language::Assembler),
             // gcc: https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html
             Some("c") => Some(Language::C),
             // TODO i
@@ -147,6 +149,7 @@ impl Language {
 
     pub fn as_str(self) -> &'static str {
         match self {
+            Language::Assembler => "assembler",
             Language::C => "c",
             Language::Cxx => "c++",
             Language::ObjectiveC => "objc",

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -593,6 +593,7 @@ fn preprocess_cmd<T>(
     T: RunCommand,
 {
     let language = match parsed_args.language {
+        Language::Assembler => "assembler",
         Language::C => "c",
         Language::Cxx => "c++",
         Language::ObjectiveC => "objective-c",
@@ -710,6 +711,7 @@ pub fn generate_compile_commands(
     // Pass the language explicitly as we might have gotten it from the
     // command line.
     let language = match parsed_args.language {
+        Language::Assembler => "assembler",
         Language::C => "c",
         Language::Cxx => "c++",
         Language::ObjectiveC => "objective-c",
@@ -740,6 +742,7 @@ pub fn generate_compile_commands(
     let dist_command = (|| {
         // https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Overall-Options.html
         let mut language: String = match parsed_args.language {
+            Language::Assembler => "assembler",
             Language::C => "c",
             Language::Cxx => "c++",
             Language::ObjectiveC => "objective-c",

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -79,6 +79,7 @@ impl CCompilerImpl for Nvcc {
         T: CommandCreatorSync,
     {
         let language = match parsed_args.language {
+            Language::Assembler => "assembler",
             Language::C => "c",
             Language::Cxx => "c++",
             Language::ObjectiveC => "objective-c",

--- a/src/server.rs
+++ b/src/server.rs
@@ -1099,7 +1099,7 @@ where
                 ));
             }
             Ok(c) => {
-                debug!("check_compiler: Supported compiler");
+                debug!("check_compiler: Supported compiler: {:?}", c.kind());
                 // Now check that we can handle this compiler with
                 // the provided commandline.
                 match c.parse_arguments(&cmd, &cwd, &env_vars) {

--- a/tests/test.s
+++ b/tests/test.s
@@ -1,0 +1,28 @@
+	.file	"test.c"
+	.text
+	.section	.rodata
+.LC0:
+	.string	"hello world"
+	.text
+	.globl	foo
+	.type	foo, @function
+foo:
+.LFB0:
+	.cfi_startproc
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register 6
+	leaq	.LC0(%rip), %rax
+	movq	%rax, %rdi
+	call	puts@PLT
+	nop
+	popq	%rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE0:
+	.size	foo, .-foo
+	.ident	"GCC: (GNU) 12.2.1 20230111"
+	.section	.note.GNU-stack,"",@progbits


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

This PR will add `.S`, `.s` and `.sx` support. By this PR, we can cache projects that have pregenerated assembler files now! For example: `ring` in rust.