### PR TITLE
Add the ability to clear a cache

### DIFF
--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -357,6 +357,9 @@ pub trait Storage: Send + Sync {
 
     /// Get the maximum storage size, if applicable.
     async fn max_size(&self) -> Result<Option<u64>>;
+
+    /// Clear the contents of the cache.
+    async fn clear(&self) -> Result<()>;
 }
 
 /// Implement storage for operator.
@@ -445,6 +448,11 @@ impl Storage for opendal::Operator {
 
     async fn max_size(&self) -> Result<Option<u64>> {
         Ok(None)
+    }
+
+    async fn clear(&self) -> Result<()> {
+        let meta = self.metadata();
+        Err(anyhow!("Cannot clear the cache on {}", meta.scheme()))
     }
 }
 

--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -139,4 +139,16 @@ impl Storage for DiskCache {
     async fn max_size(&self) -> Result<Option<u64>> {
         Ok(self.lru.lock().unwrap().get().map(|l| l.capacity()))
     }
+
+    async fn clear(&self) -> Result<()> {
+        trace!("DiskCache::clear");
+        let lru = self.lru.clone();
+
+        self.pool
+            .spawn_blocking(move || {
+                lru.lock().unwrap().get_or_init()?.clear()?;
+                Ok(())
+            })
+            .await?
+    }
 }

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -84,6 +84,8 @@ pub enum Command {
         /// The environment variables to use for execution.
         env_vars: Vec<(OsString, OsString)>,
     },
+    /// Clear the cache of entries.
+    ClearCache,
 }
 
 fn flag_infer_long_and_short(name: &'static str) -> Arg {
@@ -139,6 +141,9 @@ fn get_clap_command() -> clap::Command {
             flag_infer_long("dist-status")
                 .help("show status of the distributed client")
                 .action(ArgAction::SetTrue),
+            flag_infer_long("clear-cache")
+                .help("clear the contents of the on-disk cache")
+                .action(ArgAction::SetTrue),
             flag_infer_long("package-toolchain")
                 .help("package toolchain for distributed compilation")
                 .value_parser(clap::value_parser!(PathBuf))
@@ -163,6 +168,7 @@ fn get_clap_command() -> clap::Command {
                     "start-server",
                     "stop-server",
                     "zero-stats",
+                    "clear-cache",
                     "package-toolchain",
                     "CMD",
                 ])
@@ -257,6 +263,8 @@ pub fn try_parse() -> Result<Command> {
                 Ok(Command::DistAuth)
             } else if matches.get_flag("dist-status") {
                 Ok(Command::DistStatus)
+            } else if matches.get_flag("clear-cache") {
+                Ok(Command::ClearCache)
             } else if matches.contains_id("package-toolchain") {
                 let mut toolchain_values = matches
                     .get_many("package-toolchain")

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -545,6 +545,13 @@ where
     }))
 }
 
+pub fn request_clear_cache(mut conn: ServerConnection) -> Result<()> {
+    debug!("clear_cache");
+    conn.request(Request::ClearCache)
+        .context("Failed to send data to or receive data from server")?;
+    Ok(())
+}
+
 /// Send a `Compile` request to the sccache server `conn`, and handle the response.
 ///
 /// The first entry in `cmdline` will be looked up in `path` if it is not
@@ -744,6 +751,11 @@ pub fn run_command(cmd: Command) -> Result<i32> {
                 &mut io::stderr(),
             );
             return res.context("failed to execute compile");
+        }
+        Command::ClearCache => {
+            trace!("Command::ClearCache");
+            let conn = connect_or_start_server(get_port(), startup_timeout)?;
+            request_clear_cache(conn).context("couldn't clear cache on server")?;
         }
     }
 

--- a/src/lru_disk_cache/mod.rs
+++ b/src/lru_disk_cache/mod.rs
@@ -311,6 +311,23 @@ impl LruDiskCache {
             None => Ok(()),
         }
     }
+
+    /// Clear the contents of the cache and reset the datastructures. This will
+    /// iterate of all files and directories in the root path of the cache and
+    /// remove each one. The root directory will be preserved.
+    pub fn clear(&mut self) -> Result<()> {
+        let capacity = self.lru.capacity();
+        for entry in fs::read_dir(self.path())? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                fs::remove_dir_all(entry.path())?;
+            } else {
+                fs::remove_file(entry.path())?;
+            }
+        }
+        self.lru = LruCache::with_meter(capacity, FileSize);
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -566,5 +583,31 @@ mod tests {
         assert!(!c.contains_key("file2"));
         assert!(!f.tmp().join("cache").join("file2").exists());
         assert!(!p4.exists());
+    }
+
+    #[test]
+    fn test_clear() {
+        let f = TestFixture::new();
+
+        let p1 = f.create_file("file1", 10);
+        let p2 = f.create_file("file2", 10);
+        let p3 = f.create_file("file3", 10);
+        let p4 = f.create_file("dir1/dir2/file4", 10);
+
+        let cache_dir = f.tmp().join("cache-dir");
+        let mut cache = LruDiskCache::new(&cache_dir, 45).unwrap();
+
+        cache.insert_file("file1", &p1).unwrap();
+        cache.insert_file("file2", &p2).unwrap();
+        cache.insert_file("file3", &p3).unwrap();
+        cache.insert_file("dir1/dir2/file4", &p4).unwrap();
+        assert_eq!(cache.len(), 4);
+
+        cache.clear().unwrap();
+        // Make sure the metadata is gone.
+        assert_eq!(cache.len(), 0);
+
+        // Make sure the cache directory is actually cleared.
+        assert_eq!(fs::read_dir(&cache_dir).unwrap().into_iter().count(), 0)
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -32,7 +32,7 @@ pub enum Response {
     /// Second response for `Request::Compile`, containing the results of the compilation.
     CompileFinished(CompileFinished),
     /// Response for `Request::ClearCache`.
-    ClearCacheComplete,
+    ClearCacheComplete(ClearCacheComplete),
 }
 
 /// Possible responses from the server for a `Compile` request.
@@ -59,6 +59,15 @@ pub struct CompileFinished {
     pub stderr: Vec<u8>,
     /// The state of any compiler options passed to control color output.
     pub color_mode: ColorMode,
+}
+
+/// Possible responses from the server for a `ClearCache` request.
+#[derive(Serialize, Deserialize, Debug)]
+pub enum ClearCacheComplete {
+    /// The cache was cleared.
+    Ok,
+    /// The cache was not cleared.
+    Err(String),
 }
 
 /// The contents of a compile request from a client.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -15,6 +15,7 @@ pub enum Request {
     Shutdown,
     /// Execute a compile or fetch a cached compilation result.
     Compile(Compile),
+    ClearCache,
 }
 
 /// A server response.
@@ -30,6 +31,8 @@ pub enum Response {
     ShuttingDown(Box<ServerInfo>),
     /// Second response for `Request::Compile`, containing the results of the compilation.
     CompileFinished(CompileFinished),
+    /// Response for `Request::ClearCache`.
+    ClearCacheComplete,
 }
 
 /// Possible responses from the server for a `Compile` request.

--- a/src/server.rs
+++ b/src/server.rs
@@ -800,6 +800,13 @@ where
                         Message::WithoutBody(Response::ShuttingDown(Box::new(info)))
                     })
                 }
+                Request::ClearCache => {
+                    debug!("handle_client: clear_cache");
+                    me.clear_cache()
+                        .await
+                        .map(|_| Response::ClearCacheComplete)
+                        .map(Message::WithoutBody)
+                }
             }
         })
     }
@@ -902,6 +909,10 @@ where
     /// Zero stats about the cache.
     async fn zero_stats(&self) {
         *self.stats.lock().await = ServerStats::default();
+    }
+
+    async fn clear_cache(&self) -> Result<()> {
+        self.storage.clear().await
     }
 
     /// Handle a compile request from a client.

--- a/src/test/mock_storage.rs
+++ b/src/test/mock_storage.rs
@@ -60,4 +60,7 @@ impl Storage for MockStorage {
     async fn max_size(&self) -> Result<Option<u64>> {
         Ok(None)
     }
+    async fn clear(&self) -> Result<()> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
replace #858 resolve #835

This adds the --clear-cache argument that will remove the contents of
the cache.

This is implemented as `clear()` on the `Storage` trait - however it
is only implemented for the `DiskCache` (and `LruDiskCache`)
implementations. Any invocation on the other implementations will
return an `Err`.

A test for the `LruDiskCache` has also been included in this commit.