### PR TITLE
Ignore RPM environment variables

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -278,7 +278,19 @@ pub fn try_parse() -> Result<Command> {
                 //
                 // FIXME: Maybe we should strip out `LD_PRELOAD` always?
                 if env::var_os("RUNNING_UNDER_RR").is_some() {
-                    env_vars.retain(|(k, _v)| k != "LD_PRELOAD" && k != "RUNNING_UNDER_RR");
+                    env_vars.retain(|(k, _v)| {
+                        k != "LD_PRELOAD"
+                            && k != "RUNNING_UNDER_RR"
+                            && k != "HOSTNAME"
+                            && k != "PWD"
+                            && k != "HOST"
+                            && k != "RPM_BUILD_ROOT"
+                            && k != "SOURCE_DATE_EPOCH"
+                            && k != "RPM_PACKAGE_RELEASE"
+                            && k != "MINICOM"
+                            && k != "DESTDIR"
+                            && k != "RPM_PACKAGE_VERSION"
+                    });
                 }
 
                 let cmd = matches


### PR DESCRIPTION
RPM sets a number of environment variables by default that interfere with the sccache's ability to cache artefacts. Some of these variables are also used by other applications.

This extends the default ignore list to allow sccache to be used under different environments for caching.

An alternate idea is a way to configure and define a list of environment variables to ignore.