### PR TITLE
Introduce SCCACHE_RUST_CUSTOM_CACHE_BUSTER

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,10 @@ Separating caches between invocations
 
 In situations where several different compilation invocations
 should not reuse the cached results from each other,
-one can set `SCCACHE_C_CUSTOM_CACHE_BUSTER` to a unique value
+one can set `SCCACHE_C_CUSTOM_CACHE_BUSTER` or `SCCACHE_RUST_CUSTOM_CACHE_BUSTER` to a unique value
 that'll be mixed into the hash.
 `MACOSX_DEPLOYMENT_TARGET` and `IPHONEOS_DEPLOYMENT_TARGET` variables
-already exhibit such reuse-suppression behaviour.
-There are currently no such variables for compiling Rust.
+already exhibit such reuse-suppression behaviour when compiling C/C++.
 
 ---
 

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1438,7 +1438,9 @@ where
         env_vars.sort();
         for &(ref var, ref val) in env_vars.iter() {
             // CARGO_MAKEFLAGS will have jobserver info which is extremely non-cacheable.
-            if var.starts_with("CARGO_") && var != "CARGO_MAKEFLAGS" {
+            if (var.starts_with("CARGO_") && var != "CARGO_MAKEFLAGS")
+                || var == "SCCACHE_RUST_CUSTOM_CACHE_BUSTER"
+            {
                 var.hash(&mut HashToDigest { digest: &mut m });
                 m.update(b"=");
                 val.hash(&mut HashToDigest { digest: &mut m });


### PR DESCRIPTION
I know usual usecase haven't warranted Rust's equivalent to `SCCACHE_C_CUSTOM_CACHE_BUSTER`, thanks to pretty modernized state of affairs with `cargo` compared to the c land.
But, our CI environments are mixed with upstream and *custom-built toolchain*.

This change is small and shouldn't affect existing functionality at all.