### PR TITLE
Allow flags as plugin args with -Xclang (#1603)

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -687,6 +687,37 @@ mod test {
     }
 
     #[test]
+    fn test_parse_xclang_plugin_arg_unknown_flag() {
+        let a = parses!(
+            "-c",
+            "foo.c",
+            "-o",
+            "foo.o",
+            "-Xclang",
+            "-add-plugin",
+            "-Xclang",
+            "some-plugin",
+            "-Xclang",
+            "-plugin-arg-some-plugin",
+            "-Xclang",
+            "-fsome-unknown-flag"
+        );
+        assert_eq!(
+            ovec![
+                "-Xclang",
+                "-add-plugin",
+                "-Xclang",
+                "some-plugin",
+                "-Xclang",
+                "-plugin-arg-some-plugin",
+                "-Xclang",
+                "-fsome-unknown-flag"
+            ],
+            a.common_args
+        );
+    }
+
+    #[test]
     fn test_parse_xclang_verify() {
         let a = parses!("-c", "foo.c", "-o", "foo.o", "-Xclang", "-verify");
         assert_eq!(ovec!["-Xclang", "-verify"], a.preprocessor_args);

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -485,7 +485,7 @@ where
                 .flag_str()
                 .unwrap_or("Can't handle complex arguments through clang",)),
             None => match arg {
-                Argument::Raw(_) if follows_plugin_arg => &mut common_args,
+                _ if follows_plugin_arg => &mut common_args,
                 Argument::Raw(flag) => cannot_cache!(
                     "Can't handle Raw arguments with -Xclang",
                     flag.to_str().unwrap_or("").to_string()


### PR DESCRIPTION
Allows passing flags after `-plugin-arg-PLUGIN` (with `-Xclang`).

Ref #1603 