### PR TITLE
Remove Redis TTL

### DIFF
--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -33,8 +33,6 @@ impl RedisCache {
         builder.endpoint(parsed.as_str());
         builder.username(parsed.username());
         builder.password(parsed.password().unwrap_or_default());
-        // Set default ttl to 24 hours.
-        builder.default_ttl(Duration::from_secs(24 * 3600));
 
         let options: HashMap<_, _> = parsed
             .query_pairs()

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -18,7 +18,6 @@ use opendal::layers::LoggingLayer;
 use opendal::services::Redis;
 use opendal::Operator;
 use std::collections::HashMap;
-use std::time::Duration;
 use url::Url;
 
 /// A cache that stores entries in a Redis.


### PR DESCRIPTION
Prior to sccache 0.4.x there was no per key TTL applied to Redis. Long term we probably want to make this configurable, but for now restoring the initial behavior of letting Redis control when the keys expire.