### PR TITLE
Replace atty with is-terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,17 +125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,21 +922,18 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -1132,14 +1118,14 @@ checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "io-lifetimes 1.0.3",
  "rustix 0.36.4",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2215,7 +2201,6 @@ dependencies = [
  "ar",
  "assert_cmd",
  "async-trait",
- "atty",
  "base64 0.21.0",
  "bincode",
  "blake3",
@@ -2236,6 +2221,7 @@ dependencies = [
  "gzp",
  "http",
  "hyper",
+ "is-terminal",
  "itertools",
  "jobserver",
  "jsonwebtoken",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ strip = true
 anyhow = "1.0"
 ar = "0.9"
 async-trait = "0.1"
-atty = "0.2.6"
 base64 = "0.21"
 bincode = "1"
 blake3 = "1"
@@ -45,6 +44,7 @@ futures = "0.3"
 gzp = { version = "0.11.3", default-features = false, features = ["deflate_rust"]  }
 http = "0.2"
 hyper = { version = "0.14.24", optional = true, features = ["server"] }
+is-terminal = "0.4.5"
 jobserver = "0.1"
 jsonwebtoken = { version = "8", optional = true }
 lazy_static = "1.0.0"


### PR DESCRIPTION
Replaces atty with is-terminal. As atty is unmaintained, the ecosystems have been using is-terminal instead of atty.