### PR TITLE
Use scoped thread provided by standard library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,7 +2209,6 @@ dependencies = [
  "cc",
  "chrono",
  "clap",
- "crossbeam-utils",
  "daemonize",
  "directories",
  "encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,6 @@ zip = { version = "0.6", default-features = false }
 zstd = "0.12"
 
 # dist-server only
-crossbeam-utils = { version = "0.8", optional = true }
 nix = { version = "0.26.2", optional = true }
 rouille = { version = "3.5", optional = true, default-features = false, features = ["ssl"] }
 syslog = { version = "6", optional = true }
@@ -136,7 +135,7 @@ unstable = []
 # Enables distributed support in the sccache client
 dist-client = ["flate2", "hyper", "reqwest", "url", "sha2"]
 # Enables the sccache-dist binary
-dist-server = ["crossbeam-utils", "jwt", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "void", "version-compare"]
+dist-server = ["jwt", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "void", "version-compare"]
 # Enables dist tests with external requirements
 dist-tests = ["dist-client", "dist-server"]
 

--- a/src/bin/sccache-dist/build.rs
+++ b/src/bin/sccache-dist/build.rs
@@ -413,8 +413,8 @@ impl OverlayBuilder {
                     // Bizarrely there's no way to actually get any information from a thread::Result::Err
                 })
                 .join()
+                .unwrap_or_else(|_e| Err(anyhow!("Build thread exited unsuccessfully")))
         })
-        .unwrap_or_else(|e| Err(anyhow!("Error joining build thread: {:?}", e)))
     }
 
     // Failing during cleanup is pretty unexpected, but we can still return the successful compile

--- a/src/bin/sccache-dist/build.rs
+++ b/src/bin/sccache-dist/build.rs
@@ -265,9 +265,9 @@ impl OverlayBuilder {
             compile_command.arguments
         );
 
-        crossbeam_utils::thread::scope(|scope| {
+        std::thread::scope(|scope| {
             scope
-                .spawn(|_| {
+                .spawn(|| {
                     // Now mounted filesystems will be automatically unmounted when this thread dies
                     // (and tmpfs filesystems will be completely destroyed)
                     nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNS)
@@ -410,11 +410,9 @@ impl OverlayBuilder {
                         output: compile_output,
                         outputs,
                     })
-
                     // Bizarrely there's no way to actually get any information from a thread::Result::Err
                 })
                 .join()
-                .unwrap_or_else(|_e| Err(anyhow!("Build thread exited unsuccessfully")))
         })
         .unwrap_or_else(|e| Err(anyhow!("Error joining build thread: {:?}", e)))
     }


### PR DESCRIPTION
We might be able to use the scoped thread provided by standard library introduced in rust 1.63 instead of crossbeam.