### PR TITLE
Add support for -Xclang -fno-pch-timestamp

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -178,6 +178,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("-fdebug-compilation-dir", OsString, Separated, PassThrough),
     flag!("-fmodules", TooHardFlag),
     flag!("-fno-color-diagnostics", NoDiagnosticsColorFlag),
+    flag!("-fno-pch-timestamp", PassThroughFlag),
     flag!("-fno-profile-instr-generate", TooHardFlag),
     flag!("-fno-profile-instr-use", TooHardFlag),
     take_arg!("-fplugin", PathBuf, CanBeConcatenated('='), ExtraHashFile),
@@ -591,6 +592,19 @@ mod test {
             "-no-opaque-pointers"
         );
         assert_eq!(ovec!["-Xclang", "-no-opaque-pointers"], a.preprocessor_args);
+    }
+
+    #[test]
+    fn test_parse_xclang_fno_pch_timestamp() {
+        let a = parses!(
+            "-c",
+            "foo.c",
+            "-o",
+            "foo.o",
+            "-Xclang",
+            "-fno-pch-timestamp"
+        );
+        assert_eq!(ovec!["-Xclang", "-fno-pch-timestamp"], a.common_args);
     }
 
     #[test]


### PR DESCRIPTION
This is modelled after an analogous change in #1547.

Fixes: #1720