### PR TITLE
Make `SCCACHE_S3_NO_CREDENTIALS` require a value of `true`

### DIFF
--- a/docs/S3.md
+++ b/docs/S3.md
@@ -26,4 +26,4 @@ Sccache is able to load credentials from various sources. Including:
 - AssumeRole: assume role with the role specified by `AWS_ROLE_ARN`.
 - AssumeRoleWithWebIdentity: assume role with web webIdentity specified by `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`.
 
-Alternatively, the `SCCACHE_S3_NO_CREDENTIALS` environment variable can be set to use public readonly access to the S3 bucket, without the need for credentials. This can be useful for implementing a readonly cache for pull requests, which typically cannot be given access to credentials for security reasons.
+Alternatively, the `SCCACHE_S3_NO_CREDENTIALS=true` environment variable can be set to use public readonly access to the S3 bucket, without the need for credentials. This can be useful for implementing a readonly cache for pull requests, which typically cannot be given access to credentials for security reasons.

--- a/docs/S3.md
+++ b/docs/S3.md
@@ -26,4 +26,4 @@ Sccache is able to load credentials from various sources. Including:
 - AssumeRole: assume role with the role specified by `AWS_ROLE_ARN`.
 - AssumeRoleWithWebIdentity: assume role with web webIdentity specified by `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`.
 
-Alternatively, the `SCCACHE_S3_NO_CREDENTIALS` environment variable can be set to use public readonly access to the S3 bucket, without the need for credentials. Valid values for this environment variable are `true` and `false`. This can be useful for implementing a readonly cache for pull requests, which typically cannot be given access to credentials for security reasons.
+Alternatively, the `SCCACHE_S3_NO_CREDENTIALS` environment variable can be set to use public readonly access to the S3 bucket, without the need for credentials. Valid values for this environment variable are `true`, `1`, `false`, and `0`. This can be useful for implementing a readonly cache for pull requests, which typically cannot be given access to credentials for security reasons.

--- a/docs/S3.md
+++ b/docs/S3.md
@@ -26,4 +26,4 @@ Sccache is able to load credentials from various sources. Including:
 - AssumeRole: assume role with the role specified by `AWS_ROLE_ARN`.
 - AssumeRoleWithWebIdentity: assume role with web webIdentity specified by `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`.
 
-Alternatively, the `SCCACHE_S3_NO_CREDENTIALS=true` environment variable can be set to use public readonly access to the S3 bucket, without the need for credentials. This can be useful for implementing a readonly cache for pull requests, which typically cannot be given access to credentials for security reasons.
+Alternatively, the `SCCACHE_S3_NO_CREDENTIALS` environment variable can be set to use public readonly access to the S3 bucket, without the need for credentials. Valid values for this environment variable are `true` and `false`. This can be useful for implementing a readonly cache for pull requests, which typically cannot be given access to credentials for security reasons.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1136,7 +1136,7 @@ fn test_s3_no_credentials_valid_true() {
             ..
         }) => {
             assert_eq!(bucket, "my-bucket");
-            assert_eq!(no_credentials, true);
+            assert!(no_credentials);
         }
         None => unreachable!(),
     };
@@ -1159,7 +1159,7 @@ fn test_s3_no_credentials_valid_false() {
             ..
         }) => {
             assert_eq!(bucket, "my-bucket");
-            assert_eq!(no_credentials, false);
+            assert!(!no_credentials);
         }
         None => unreachable!(),
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -512,7 +512,10 @@ fn config_from_env() -> Result<EnvConfig> {
     // ======= AWS =======
     let s3 = env::var("SCCACHE_BUCKET").ok().map(|bucket| {
         let region = env::var("SCCACHE_REGION").ok();
-        let no_credentials = env::var("SCCACHE_S3_NO_CREDENTIALS").ok().is_some();
+        let no_credentials = env::var("SCCACHE_S3_NO_CREDENTIALS")
+            .ok()
+            .map(|value| value == "true")
+            .unwrap_or_default();
         let use_ssl = env::var("SCCACHE_S3_USE_SSL")
             .ok()
             .map(|value| value != "off");

--- a/src/config.rs
+++ b/src/config.rs
@@ -1084,7 +1084,7 @@ fn config_overrides() {
 #[test]
 #[serial]
 fn test_s3_no_credentials() {
-    env::set_var("SCCACHE_S3_NO_CREDENTIALS", "1");
+    env::set_var("SCCACHE_S3_NO_CREDENTIALS", "true");
     env::set_var("SCCACHE_BUCKET", "my-bucket");
     env::set_var("AWS_ACCESS_KEY_ID", "aws-access-key-id");
     env::set_var("AWS_SECRET_ACCESS_KEY", "aws-secret-access-key");

--- a/src/config.rs
+++ b/src/config.rs
@@ -514,9 +514,9 @@ fn config_from_env() -> Result<EnvConfig> {
         let region = env::var("SCCACHE_REGION").ok();
         let no_credentials =
             env::var("SCCACHE_S3_NO_CREDENTIALS").map_or(Ok(false), |val| match val.as_str() {
-                "true" => Ok(true),
-                "false" => Ok(false),
-                _ => bail!("SCCACHE_S3_NO_CREDENTIALS must be 'true' or 'false'."),
+                "true" | "1" => Ok(true),
+                "false" | "0" => Ok(false),
+                _ => bail!("SCCACHE_S3_NO_CREDENTIALS must be 'true', '1', 'false', or '0'."),
             })?;
         let use_ssl = env::var("SCCACHE_S3_USE_SSL")
             .ok()
@@ -1109,12 +1109,12 @@ fn test_s3_no_credentials_conflict() {
 #[test]
 #[serial]
 fn test_s3_no_credentials_invalid() {
-    env::set_var("SCCACHE_S3_NO_CREDENTIALS", "1");
+    env::set_var("SCCACHE_S3_NO_CREDENTIALS", "yes");
     env::set_var("SCCACHE_BUCKET", "my-bucket");
 
     let error = config_from_env().unwrap_err();
     assert_eq!(
-        "SCCACHE_S3_NO_CREDENTIALS must be 'true' or 'false'.",
+        "SCCACHE_S3_NO_CREDENTIALS must be 'true', '1', 'false', or '0'.",
         error.to_string()
     );
 


### PR DESCRIPTION
Closes #1723.

This PR updates the `SCCACHE_S3_NO_CREDENTIALS` environment variable to require a value of `true` in order to enable this feature.

**Note:** This is a breaking change and should probably be called out loudly in any future release notes.