### PR TITLE
fix: Ignore C4668 when preprocessing via MSVC

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -400,6 +400,13 @@ jobs:
           test -e ./foo.o || { echo "No compiler output found"; exit -1; }
           test -e ./foo.o.json || { echo "No dependency list found"; exit -1; }
 
+      - name: Compile - Preprocessing Compiler Bug
+        shell: bash
+        working-directory: ./tests/msvc-preprocessing
+        run: |
+          $SCCACHE_EXE "$(where cl.exe)" -c "@args.rsp"
+          $SCCACHE_EXE --show-stats
+
       - name: Stop Server
         if: success() || failure()
         shell: bash

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -950,9 +950,8 @@ where
         .args(&parsed_args.dependency_args)
         .args(&parsed_args.common_args)
         // Windows SDK generates C4668 during preprocessing, but compiles fine.
-        // Making sure that 4668 is a level 4 warning prevents failing preprocessing on it.
         // Read for more info: https://github.com/mozilla/sccache/issues/1725
-        .arg("/w44668")
+        .arg("/wd4668")
         .env_clear()
         .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
         .current_dir(cwd);

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -949,6 +949,10 @@ where
         .args(&parsed_args.preprocessor_args)
         .args(&parsed_args.dependency_args)
         .args(&parsed_args.common_args)
+        // Windows SDK generates C4668 during preprocessing, but compiles fine.
+        // Making sure that 4668 is a level 4 warning prevents failing preprocessing on it.
+        // Read for more info: https://github.com/mozilla/sccache/issues/1725
+        .arg("/w44668")
         .env_clear()
         .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
         .current_dir(cwd);

--- a/tests/msvc-preprocessing/args.rsp
+++ b/tests/msvc-preprocessing/args.rsp
@@ -1,0 +1,1 @@
+foo.cpp -Fofoo.o -W4 -WX -Wall

--- a/tests/msvc-preprocessing/foo.cpp
+++ b/tests/msvc-preprocessing/foo.cpp
@@ -1,0 +1,15 @@
+// This tests sccache's ability to handle a known bug in cl.exe
+// More information: https://github.com/mozilla/sccache/issues/1725
+__pragma(warning(push))
+__pragma(warning(disable: 4668))
+// cl.exe during compilation will correctly ignore 4668 here (undefined define)
+// during preprocessing, it will not ignore 4668
+// sccache must explicitly ignore this warning when preprocessing (to figure out the cache key)
+#if UNDEFINED_MACRO_TRIGGERING_C4668
+#error "This error should be unreachable"
+#endif
+__pragma(warning(pop))
+
+int main() {
+  return 0;
+}


### PR DESCRIPTION
This fixes #1725.