### PR TITLE
Support authentication in WebDAV storage (#1608)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -300,6 +300,8 @@ jobs:
 
     env:
       SCCACHE_WEBDAV_ENDPOINT: "http://127.0.0.1:8080"
+      SCCACHE_WEBDAV_USERNAME: "bar"
+      SCCACHE_WEBDAV_PASSWORD: "baz"
       RUSTC_WRAPPER: /home/runner/.cargo/bin/sccache
 
     steps:
@@ -309,6 +311,7 @@ jobs:
         shell: bash
         run: |
           mkdir /tmp/static
+          cp `pwd`/tests/htpasswd /tmp/htpasswd
           nginx -c `pwd`/tests/nginx_http_cache.conf
 
       - name: Install rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,9 +1490,9 @@ checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opendal"
-version = "0.27.1"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f2018ea448841041cf00a01f6c145b5017753958dbb563c2bf8921ce4b3e49"
+checksum = "c0ae5735ee4517b68e4fe034c12790e0ac694a8977d1e2aea1b128926c8e8737"
 dependencies = [
  "anyhow",
  "async-compat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ bincode = "1"
 blake3 = "1"
 byteorder = "1.0"
 bytes = "1"
-opendal = { version= "0.27.1", optional=true }
+opendal = { version= "0.29.1", optional=true }
 reqsign = {version="0.8.5", optional=true}
 clap = { version = "4.1.11", features = ["derive", "env", "wrap_help"] }
 directories = "4.0.1"

--- a/docs/Webdav.md
+++ b/docs/Webdav.md
@@ -1,6 +1,6 @@
 # WebDAV
 
-Set `SCCACHE_WEBDAV_ENDPOINT` to a wevdav service endpoint to store cache in a webdav service. Set `SCCACHE_WEBDAV_KEY_PREFIX` to specify the key prefix of cache.
+Set `SCCACHE_WEBDAV_ENDPOINT` to a webdav service endpoint to store cache in a webdav service. Set `SCCACHE_WEBDAV_KEY_PREFIX` to specify the key prefix of cache.
 
 The webdav cache is compatible with:
 
@@ -9,3 +9,9 @@ The webdav cache is compatible with:
 - [Gradle Build Cache](https://docs.gradle.org/current/userguide/build_cache.html)
 
 Users can set `SCCACHE_WEBDAV_ENDPOINT` to those services directly.
+
+## Credentials
+
+Sccache is able to load credentials from the following sources:
+- Set `SCCACHE_WEBDAV_USERNAME`/`SCCACHE_WEBDAV_PASSWORD` to specify the username/password pair for basic authentication.
+- Set `SCCACHE_WEBDAV_TOKEN` to specify the token value for bearer token authentication.

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -557,8 +557,16 @@ pub fn storage_from_config(
             #[cfg(feature = "webdav")]
             CacheType::Webdav(ref c) => {
                 debug!("Init webdav cache with endpoint {}", c.endpoint);
-                let storage = WebdavCache::build(&c.endpoint, &c.key_prefix)
-                    .map_err(|err| anyhow!("create webdav cache failed: {err:?}"))?;
+
+                let storage = WebdavCache::build(
+                    &c.endpoint,
+                    &c.key_prefix,
+                    c.username.as_deref(),
+                    c.password.as_deref(),
+                    c.token.as_deref(),
+                )
+                .map_err(|err| anyhow!("create webdav cache failed: {err:?}"))?;
+
                 return Ok(Arc::new(storage));
             }
             #[allow(unreachable_patterns)]

--- a/src/cache/webdav.rs
+++ b/src/cache/webdav.rs
@@ -20,10 +20,25 @@ pub struct WebdavCache;
 
 impl WebdavCache {
     /// Create a new `WebdavCache`.
-    pub fn build(endpoint: &str, key_prefix: &str) -> Result<Operator> {
+    pub fn build(
+        endpoint: &str,
+        key_prefix: &str,
+        username: Option<&str>,
+        password: Option<&str>,
+        token: Option<&str>,
+    ) -> Result<Operator> {
         let mut builder = Webdav::default();
         builder.endpoint(endpoint);
         builder.root(key_prefix);
+        if let Some(username) = username {
+            builder.username(username);
+        }
+        if let Some(password) = password {
+            builder.password(password);
+        }
+        if let Some(token) = token {
+            builder.token(token);
+        }
 
         let op = Operator::create(builder)?
             .layer(LoggingLayer::default())

--- a/src/config.rs
+++ b/src/config.rs
@@ -233,6 +233,9 @@ pub struct RedisCacheConfig {
 pub struct WebdavCacheConfig {
     pub endpoint: String,
     pub key_prefix: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub token: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -665,10 +668,16 @@ fn config_from_env() -> Result<EnvConfig> {
             .filter(|s| !s.is_empty())
             .unwrap_or_default()
             .to_owned();
+        let username = env::var("SCCACHE_WEBDAV_USERNAME").ok();
+        let password = env::var("SCCACHE_WEBDAV_PASSWORD").ok();
+        let token = env::var("SCCACHE_WEBDAV_TOKEN").ok();
 
         Some(WebdavCacheConfig {
             endpoint,
             key_prefix,
+            username,
+            password,
+            token,
         })
     } else {
         None
@@ -1171,6 +1180,9 @@ no_credentials = true
 [cache.webdav]
 endpoint = "http://127.0.0.1:8080"
 key_prefix = "webdavprefix"
+username = "webdavusername"
+password = "webdavpassword"
+token = "webdavtoken"
 "#;
 
     let file_config: FileConfig = toml::from_str(CONFIG_STR).expect("Is valid toml.");
@@ -1213,6 +1225,9 @@ key_prefix = "webdavprefix"
                 webdav: Some(WebdavCacheConfig {
                     endpoint: "http://127.0.0.1:8080".to_string(),
                     key_prefix: "webdavprefix".into(),
+                    username: Some("webdavusername".to_string()),
+                    password: Some("webdavpassword".to_string()),
+                    token: Some("webdavtoken".to_string()),
                 })
             },
             dist: DistConfig {

--- a/tests/htpasswd
+++ b/tests/htpasswd
@@ -1,0 +1,1 @@
+bar:{PLAIN}baz

--- a/tests/nginx_http_cache.conf
+++ b/tests/nginx_http_cache.conf
@@ -18,6 +18,8 @@ http {
       dav_methods PUT DELETE;
       create_full_put_path on;
       client_max_body_size 1024M;
+      auth_basic           "Authentication required";
+      auth_basic_user_file /tmp/htpasswd;
     }
   }
 }


### PR DESCRIPTION
It's complementary story for WebDAV storage support https://github.com/mozilla/sccache/pull/1597.

The major missing part was ability to provide credentials. OpenDAL 0.27.2+ supports the following options:

* [username/password](https://github.com/datafuselabs/opendal/pull/1323)
* [token](https://github.com/datafuselabs/opendal/pull/1349)

This change allows bypassing them in sccache WebDAV configuration.