### PR TITLE
nvcc: Handle compiler detection when gcc isn't on the path

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1044,11 +1044,11 @@ use self::ArgData::PassThrough as Detect_PassThrough;
 // Establish a set of compiler flags that are required for
 // valid execution of the compiler even in preprocessor mode.
 // If the requested compiler invocatiomn has any of these arguments
-// propagate them when doing our compiler vendor detection 
+// propagate them when doing our compiler vendor detection
 //
 // Current known required flags:
 // ccbin/compiler-bindir needed for nvcc
-//  This flag specifies the host compiler to use otherwise 
+//  This flag specifies the host compiler to use otherwise
 //  gcc is expected to exist on the PATH. So if gcc doesn't exist
 //  compiler detection fails if we don't pass along the ccbin arg
 counted_array!(static ARGS: [ArgInfo<ArgData>; _] = [

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1102,7 +1102,7 @@ __VERSION__
     // to propagate `-ccbin` flags so we ensure nvcc has a host
     // compiler, when gcc isn't on the PATH
     for arg in ArgsIter::new(arguments.iter().cloned(), &ARGS[..]) {
-        let arg = arg.unwrap_or(Argument::Raw(OsString::from("")));
+        let arg = arg.unwrap_or_else(|_| Argument::Raw(OsString::from("")));
         if let Some(Detect_PassThrough(_)) = arg.get_data() {
             let required_arg = arg.normalize(NormalizedDisposition::Concatenated);
             cmd.args(&Vec::from_iter(required_arg.iter_os_strings()));

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1036,12 +1036,12 @@ where
     }
 }
 
-ArgData! { pub
+ArgData! {
     PassThrough(OsString),
 }
 use self::ArgData::PassThrough as Detect_PassThrough;
 
-counted_array!(pub static ARGS: [ArgInfo<ArgData>; _] = [
+counted_array!(static ARGS: [ArgInfo<ArgData>; _] = [
     take_arg!("--compiler-bindir", OsString, CanBeSeparated('='), Detect_PassThrough),
     take_arg!("-ccbin", OsString, CanBeSeparated('='), Detect_PassThrough),
 ]);


### PR DESCRIPTION
To properly handle compiler detction sccache invokes the compiler with -E. To generate the preprocessed output `nvcc` invokes the host comiler, which either requires gcc to be on the path or `-ccbin` argument to be provided.

This PR allows `sccache` to be used with `nvcc` when `gcc` isn't on the path but the host compiler to be used is included via `-ccbin`.

This was found when building small build images which only had a compiler with a name like `gcc-aarch64`.