### PR TITLE
Replace lazy_static with once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,7 +2293,6 @@ dependencies = [
  "itertools",
  "jobserver",
  "jsonwebtoken",
- "lazy_static",
  "libc",
  "libmount",
  "linked-hash-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ hyper = { version = "0.14.24", optional = true, features = ["server"] }
 is-terminal = "0.4.5"
 jobserver = "0.1"
 jwt = { package = "jsonwebtoken", version = "8", optional = true }
-lazy_static = "1.0.0"
+once_cell = "1.17"
 libc = "0.2.140"
 linked-hash-map = "0.5"
 log = "0.4"
@@ -95,7 +95,6 @@ chrono = "0.4.24"
 itertools = "0.10"
 predicates = "=3.0.2"
 thirtyfour_sync = "0.27"
-once_cell = "1.17"
 serial_test = "2.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -26,7 +26,7 @@ use crate::mock_command::CommandCreatorSync;
 use crate::util::{hash_all, Digest, HashToDigest};
 use async_trait::async_trait;
 use fs_err as fs;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
@@ -687,9 +687,9 @@ impl pkg::ToolchainPackager for CToolchainPackager {
 /// The cache is versioned by the inputs to `hash_key`.
 pub const CACHE_VERSION: &[u8] = b"11";
 
-lazy_static! {
-    /// Environment variables that are factored into the cache key.
-    static ref CACHED_ENV_VARS: HashSet<&'static OsStr> = [
+/// Environment variables that are factored into the cache key.
+static CACHED_ENV_VARS: Lazy<HashSet<&'static OsStr>> = Lazy::new(|| {
+    [
         // SCCACHE_C_CUSTOM_CACHE_BUSTER has no particular meaning behind it,
         // serving as a way for the user to factor custom data into the hash.
         // One can set it to different values for different invocations
@@ -701,8 +701,11 @@ lazy_static! {
         "WATCHOS_DEPLOYMENT_TARGET",
         "SDKROOT",
         "CCC_OVERRIDE_OPTIONS",
-    ].iter().map(OsStr::new).collect();
-}
+    ]
+    .iter()
+    .map(OsStr::new)
+    .collect()
+});
 
 /// Compute the hash key of `compiler` compiling `preprocessor_output` with `args`.
 pub fn hash_key(

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -31,8 +31,8 @@ use crate::{counted_array, dist};
 use async_trait::async_trait;
 use filetime::FileTime;
 use fs_err as fs;
-use lazy_static::lazy_static;
 use log::Level::Trace;
+use once_cell::sync::Lazy;
 #[cfg(feature = "dist-client")]
 #[cfg(feature = "dist-client")]
 use std::borrow::Borrow;
@@ -208,14 +208,9 @@ pub struct CrateTypes {
     staticlib: bool,
 }
 
-lazy_static! {
-    /// Emit types that we will cache.
-    static ref ALLOWED_EMIT: HashSet<&'static str> = [
-        "link",
-        "metadata",
-        "dep-info",
-    ].iter().copied().collect();
-}
+/// Emit types that we will cache.
+static ALLOWED_EMIT: Lazy<HashSet<&'static str>> =
+    Lazy::new(|| ["link", "metadata", "dep-info"].iter().copied().collect());
 
 /// Version number for cache key.
 const CACHE_VERSION: &[u8] = b"6";

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@
 use directories::ProjectDirs;
 use fs::File;
 use fs_err as fs;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 #[cfg(any(feature = "dist-client", feature = "dist-server"))]
 use serde::ser::Serializer;
@@ -35,10 +35,8 @@ use std::sync::Mutex;
 
 use crate::errors::*;
 
-lazy_static! {
-    static ref CACHED_CONFIG_PATH: PathBuf = CachedConfig::file_config_path();
-    static ref CACHED_CONFIG: Mutex<Option<CachedFileConfig>> = Mutex::new(None);
-}
+static CACHED_CONFIG_PATH: Lazy<PathBuf> = Lazy::new(CachedConfig::file_config_path);
+static CACHED_CONFIG: Lazy<Mutex<Option<CachedFileConfig>>> = Lazy::new(|| Mutex::new(None));
 
 const ORGANIZATION: &str = "Mozilla";
 const APP_NAME: &str = "sccache";

--- a/src/dist/client_auth.rs
+++ b/src/dist/client_auth.rs
@@ -89,7 +89,7 @@ mod code_grant_pkce {
     use base64::Engine;
     use futures::channel::oneshot;
     use hyper::{Body, Method, Request, Response, StatusCode};
-    use lazy_static::lazy_static;
+    use once_cell::sync::Lazy;
     use rand::{rngs::OsRng, RngCore};
     use serde::{Deserialize, Serialize};
     use sha2::{Digest, Sha256};
@@ -142,9 +142,7 @@ mod code_grant_pkce {
         pub shutdown_tx: Option<oneshot::Sender<()>>,
     }
 
-    lazy_static! {
-        pub static ref STATE: Mutex<Option<State>> = Mutex::new(None);
-    }
+    pub static STATE: Lazy<Mutex<Option<State>>> = Lazy::new(|| Mutex::new(None));
 
     pub fn generate_verifier_and_challenge() -> Result<(String, String)> {
         let mut code_verifier_bytes = vec![0; NUM_CODE_VERIFIER_BYTES];
@@ -281,7 +279,7 @@ mod implicit {
     };
     use futures::channel::oneshot;
     use hyper::{Body, Method, Request, Response, StatusCode};
-    use lazy_static::lazy_static;
+    use once_cell::sync::Lazy;
     use std::collections::HashMap;
     use std::sync::mpsc;
     use std::sync::Mutex;
@@ -310,9 +308,7 @@ mod implicit {
         pub shutdown_tx: Option<oneshot::Sender<()>>,
     }
 
-    lazy_static! {
-        pub static ref STATE: Mutex<Option<State>> = Mutex::new(None);
-    }
+    pub static STATE: Lazy<Mutex<Option<State>>> = Lazy::new(|| Mutex::new(None));
 
     pub fn finish_url(client_id: &str, url: &mut Url, redirect_uri: &str, state: &str) {
         url.query_pairs_mut()

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -253,7 +253,7 @@ mod server {
     use crate::util::new_reqwest_blocking_client;
     use byteorder::{BigEndian, ReadBytesExt};
     use flate2::read::ZlibDecoder as ZlibReadDecoder;
-    use lazy_static::lazy_static;
+    use once_cell::sync::Lazy;
     use rand::{rngs::OsRng, RngCore};
     use rouille::accept;
     use serde::Serialize;
@@ -400,16 +400,14 @@ mod server {
     pub type ServerAuthCheck = Box<dyn Fn(&str) -> Option<ServerId> + Send + Sync>;
 
     const JWT_KEY_LENGTH: usize = 256 / 8;
-    lazy_static! {
-        static ref JWT_HEADER: jwt::Header = jwt::Header::new(jwt::Algorithm::HS256);
-        static ref JWT_VALIDATION: jwt::Validation = {
-            let mut validation = jwt::Validation::new(jwt::Algorithm::HS256);
-            validation.leeway = 0;
-            validation.validate_exp = false;
-            validation.validate_nbf = false;
-            validation
-        };
-    }
+    static JWT_HEADER: Lazy<jwt::Header> = Lazy::new(|| jwt::Header::new(jwt::Algorithm::HS256));
+    static JWT_VALIDATION: Lazy<jwt::Validation> = Lazy::new(|| {
+        let mut validation = jwt::Validation::new(jwt::Algorithm::HS256);
+        validation.leeway = 0;
+        validation.validate_exp = false;
+        validation.validate_nbf = false;
+        validation
+    });
 
     // Based on rouille::input::json::json_input
     #[derive(Debug)]


### PR DESCRIPTION
Replaces `lazy_static` with `once_cell` as `once_cell` is without macros and it will go to standard library.