### PR TITLE
Use Infallible instead of void

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,6 @@ dependencies = [
  "url",
  "uuid",
  "version-compare",
- "void",
  "walkdir",
  "which",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,6 @@ zstd = "0.12"
 nix = { version = "0.26.2", optional = true }
 rouille = { version = "3.5", optional = true, default-features = false, features = ["ssl"] }
 syslog = { version = "6", optional = true }
-void = { version = "1", optional = true }
 version-compare = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
@@ -133,7 +132,7 @@ unstable = []
 # Enables distributed support in the sccache client
 dist-client = ["flate2", "hyper", "reqwest", "url", "sha2"]
 # Enables the sccache-dist binary
-dist-server = ["jwt", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "void", "version-compare"]
+dist-server = ["jwt", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "version-compare"]
 # Enables dist tests with external requirements
 dist-tests = ["dist-client", "dist-server"]
 

--- a/src/bin/sccache-dist/main.rs
+++ b/src/bin/sccache-dist/main.rs
@@ -206,7 +206,8 @@ fn run(command: Command) -> Result<i32> {
                 check_client_auth,
                 check_server_auth,
             );
-            void::unreachable(http_scheduler.start()?);
+            http_scheduler.start()?;
+            unreachable!();
         }
 
         Command::Server(server_config::Config {
@@ -282,7 +283,8 @@ fn run(command: Command) -> Result<i32> {
                 server,
             )
             .context("Failed to create sccache HTTP server instance")?;
-            void::unreachable(http_server.start()?)
+            http_server.start()?;
+            unreachable!();
         }
     }
 }

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -258,6 +258,7 @@ mod server {
     use rouille::accept;
     use serde::Serialize;
     use std::collections::HashMap;
+    use std::convert::Infallible;
     use std::io::Read;
     use std::net::SocketAddr;
     use std::result::Result as StdResult;
@@ -265,7 +266,6 @@ mod server {
     use std::sync::Mutex;
     use std::thread;
     use std::time::Duration;
-    use void::Void;
 
     use super::common::{
         AllocJobHttpResponse, HeartbeatServerHttpRequest, JobJwt, ReqwestRequestBuilderExt,
@@ -678,7 +678,7 @@ mod server {
             }
         }
 
-        pub fn start(self) -> Result<Void> {
+        pub fn start(self) -> Result<Infallible> {
             let Self {
                 public_addr,
                 handler,
@@ -918,7 +918,7 @@ mod server {
             })
         }
 
-        pub fn start(self) -> Result<Void> {
+        pub fn start(self) -> Result<Infallible> {
             let Self {
                 public_addr,
                 scheduler_url,

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -405,7 +405,8 @@ impl DistSystem {
             ForkResult::Child => {
                 env::set_var("SCCACHE_LOG", "sccache=trace");
                 env_logger::try_init().unwrap();
-                void::unreachable(server.start().unwrap())
+                server.start().unwrap();
+                unreachable!();
             }
         };
 


### PR DESCRIPTION
We might be able to use standard `Infallible` instead of `void` to describe the type that never happens.