### PR TITLE
Support for Type Library Headers for MSVC

### DIFF
--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -807,6 +807,39 @@ pub fn parse_arguments(
             }
         }
     }
+    if language == Language::Cxx {
+        if let Some(obj) = outputs.get("obj") {
+            // MSVC can produce "type library headers"[1], with the extensions "tlh" and "tli".
+            // These files can be used in later compilation steps to interact with COM interfaces.
+            //
+            // These files are only created when the `#import` directive is used.
+            // Figuring out if an import directive is used would require parsing C++, which would be a lot of work.
+            // To avoid that problem, we just optionally cache these headers if they happen to be produced.
+            // This isn't perfect, but it is easy!
+            //
+            // [1]: https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170#_predir_the_23import_directive_header_files_created_by_import
+            let tlh = obj.path.with_extension("tlh");
+            let tli = obj.path.with_extension("tli");
+
+            // Primary type library header
+            outputs.insert(
+                "tlh",
+                ArtifactDescriptor {
+                    path: tlh,
+                    optional: true,
+                },
+            );
+
+            // Secondary type library header
+            outputs.insert(
+                "tli",
+                ArtifactDescriptor {
+                    path: tli,
+                    optional: true,
+                },
+            );
+        }
+    }
     // -Fd is not taken into account unless -Zi or -ZI are given
     // Clang is currently unable to generate PDB files
     if debug_info && !is_clang {
@@ -1391,6 +1424,72 @@ mod test {
         assert!(preprocessor_args.is_empty());
         assert!(common_args.is_empty());
         assert!(!msvc_show_includes);
+    }
+
+    #[test]
+    fn test_cpp_parse_arguments_collects_type_library_headers() {
+        let args = ovec!["-c", "foo.cpp", "-Fofoo.obj"];
+        let ParsedArguments {
+            input,
+            language,
+            outputs,
+            ..
+        } = match parse_arguments(args) {
+            CompilerArguments::Ok(args) => args,
+            o => panic!("Got unexpected parse result: {:?}", o),
+        };
+        assert_eq!(Some("foo.cpp"), input.to_str());
+        assert_eq!(Language::Cxx, language);
+        assert_map_contains!(
+            outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: PathBuf::from("foo.obj"),
+                    optional: false
+                }
+            ),
+            (
+                "tlh",
+                ArtifactDescriptor {
+                    path: PathBuf::from("foo.tlh"),
+                    optional: true
+                }
+            ),
+            (
+                "tli",
+                ArtifactDescriptor {
+                    path: PathBuf::from("foo.tli"),
+                    optional: true
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_c_parse_arguments_does_not_collect_type_library_headers() {
+        let args = ovec!["-c", "foo.c", "-Fofoo.obj"];
+        let ParsedArguments {
+            input,
+            language,
+            outputs,
+            ..
+        } = match parse_arguments(args) {
+            CompilerArguments::Ok(args) => args,
+            o => panic!("Got unexpected parse result: {:?}", o),
+        };
+        assert_eq!(Some("foo.c"), input.to_str());
+        assert_eq!(Language::C, language);
+        assert_map_contains!(
+            outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: PathBuf::from("foo.obj"),
+                    optional: false
+                }
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
Introduce caching support for MSVC type library headers.
Type library headers are optional extra outputs that appear when the `#import` statement is used.
This fix takes the easy route of just caching these files if they happen to be produced.

The hard (but more correct way) would be to parse the preprocessed C++ and determine if `#import` is ever used, which would enable us to include that information in the cache key and invalidate any previous cache entries that don't contain type library headers but should.
However, parsing C++ is pretty complex and clearing your cache if you get a missing tlh prior to this change is pretty easy.

This fixes #1769 