### PR TITLE
Produce JSON depsfiles from MSVC

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -370,7 +370,9 @@ jobs:
       - name: Compile MSVC (no cache)
         shell: bash
         working-directory: ./tests/msvc
-        run: cl "@args.rsp"
+        run: |
+          cl "@args.rsp"
+          test -e ./foo.o || { echo "No compiler output found"; exit -1; }
 
       - name: Start Server
         shell: bash
@@ -380,17 +382,23 @@ jobs:
         shell: bash
         working-directory: ./tests/msvc
         run: |
+          rm ./foo.o || true
           $SCCACHE_EXE "$(where cl.exe)" -c "@args.rsp"
           $SCCACHE_EXE --show-stats
           $SCCACHE_EXE --show-stats | grep -e "Cache misses\s*[1-9]"
+          test -e ./foo.o || { echo "No compiler output found"; exit -1; }
+          test -e ./foo.o.json || { echo "No dependency list found"; exit -1; }
 
       - name: Compile - Cache Hit
         shell: bash
         working-directory: ./tests/msvc
         run: |
+          rm ./foo.o || true
           $SCCACHE_EXE "$(where cl.exe)" -c "@args.rsp"
           $SCCACHE_EXE --show-stats
           $SCCACHE_EXE --show-stats | grep -e "Cache hits\s*[1-9]"
+          test -e ./foo.o || { echo "No compiler output found"; exit -1; }
+          test -e ./foo.o.json || { echo "No dependency list found"; exit -1; }
 
       - name: Stop Server
         if: success() || failure()

--- a/tests/msvc/args.rsp
+++ b/tests/msvc/args.rsp
@@ -1,1 +1,1 @@
-foo.cpp -Fofoo.o
+foo.cpp -Fofoo.o /sourceDependencies foo.o.json


### PR DESCRIPTION
MSVC deps files are emitted as JSON, in a format described by the compiler documentation: https://learn.microsoft.com/en-us/cpp/build/reference/sourcedependencies?view=msvc-170

Prior to this commit, sccache will output a clang or gcc style deps file, with dependencies on lines instead of JSON.

After this commit, we remove the code responsible for writing the deps file, and depend on the command we execute on `cl.exe` for preprocessing to write the deps file.

The advantage of this is that we get improved compatibility with tools that use the JSON output deps files from MSVC, such as Unreal Engine's build system.

This fixes #1771 