### PR TITLE
feat: Enable backtrace for anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +46,9 @@ name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "ar"
@@ -129,6 +141,21 @@ dependencies = [
  "pin-project",
  "rand",
  "tokio",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -890,6 +917,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
 name = "gzp"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,6 +1575,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,6 +2170,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "ordered-multimap",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,21 +31,17 @@ bincode = "1"
 blake3 = "1"
 byteorder = "1.0"
 bytes = "1"
-opendal = { version = "0.34.0", optional = true }
-reqsign = { version = "0.10.1", optional = true }
+opendal = { version= "0.34.0", optional = true }
+reqsign = {version="0.10.1", optional = true}
 clap = { version = "4.1.11", features = ["derive", "env", "wrap_help"] }
 directories = "5.0.0"
 encoding = "0.2"
 env_logger = "0.10"
 filetime = "0.2"
-flate2 = { version = "1.0", optional = true, default-features = false, features = [
-  "rust_backend",
-] }
+flate2 = { version = "1.0", optional = true, default-features = false, features = ["rust_backend"] }
 fs-err = "2.9"
 futures = "0.3"
-gzp = { version = "0.11.3", default-features = false, features = [
-  "deflate_rust",
-] }
+gzp = { version = "0.11.3", default-features = false, features = ["deflate_rust"]  }
 http = "0.2"
 hyper = { version = "0.14.24", optional = true, features = ["server"] }
 is-terminal = "0.4.5"
@@ -60,13 +56,7 @@ number_prefix = "0.4"
 openssl = { version = "0.10.48", optional = true }
 rand = "0.8.4"
 regex = "1.7.3"
-reqwest = { version = "0.11", features = [
-  "json",
-  "blocking",
-  "stream",
-  "rustls-tls",
-  "trust-dns",
-], optional = true }
+reqwest = { version = "0.11", features = ["json", "blocking", "stream", "rustls-tls", "trust-dns"], optional = true }
 retry = "2"
 semver = "1.0"
 sha2 = { version = "0.10.6", optional = true }
@@ -76,20 +66,9 @@ strip-ansi-escapes = "0.1"
 tar = "0.4.36"
 tempfile = "3"
 # trust-dns-resolver must be kept in sync with the version reqwest uses
-trust-dns-resolver = { version = "0.22.0", features = [
-  "dnssec-ring",
-  "dns-over-rustls",
-  "dns-over-https-rustls",
-] }
+trust-dns-resolver = { version = "0.22.0", features = ["dnssec-ring", "dns-over-rustls", "dns-over-https-rustls"] }
 mime = "0.3"
-tokio = { version = "1", features = [
-  "rt-multi-thread",
-  "io-util",
-  "time",
-  "net",
-  "process",
-  "macros",
-] }
+tokio = { version = "1", features = ["rt-multi-thread", "io-util", "time", "net", "process", "macros"] }
 tokio-serde = "0.8"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
 tower = "0.4"
@@ -104,9 +83,7 @@ zstd = "0.12"
 
 # dist-server only
 nix = { version = "0.26.2", optional = true }
-rouille = { version = "3.5", optional = true, default-features = false, features = [
-  "ssl",
-] }
+rouille = { version = "3.5", optional = true, default-features = false, features = ["ssl"] }
 syslog = { version = "6", optional = true }
 version-compare = { version = "0.1.1", optional = true }
 
@@ -128,23 +105,19 @@ version = "0.1.10"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"
-features = ["fileapi", "handleapi", "stringapiset", "winnls"]
+features = [
+    "fileapi",
+    "handleapi",
+    "stringapiset",
+    "winnls",
+]
 
 [features]
 default = ["all"]
-all = [
-  "dist-client",
-  "redis",
-  "s3",
-  "memcached",
-  "gcs",
-  "azure",
-  "gha",
-  "webdav",
-]
-azure = ["opendal", "reqsign"]
-s3 = ["opendal", "reqsign"]
-gcs = ["opendal", "reqsign", "url", "reqwest/blocking"]
+all = ["dist-client", "redis", "s3", "memcached", "gcs", "azure", "gha", "webdav"]
+azure = ["opendal","reqsign"]
+s3 = ["opendal","reqsign"]
+gcs = ["opendal","reqsign", "url", "reqwest/blocking"]
 gha = ["opendal"]
 webdav = ["opendal"]
 memcached = ["opendal/services-memcached"]
@@ -159,17 +132,7 @@ unstable = []
 # Enables distributed support in the sccache client
 dist-client = ["flate2", "hyper", "reqwest", "url", "sha2"]
 # Enables the sccache-dist binary
-dist-server = [
-  "jwt",
-  "flate2",
-  "libmount",
-  "nix",
-  "openssl",
-  "reqwest",
-  "rouille",
-  "syslog",
-  "version-compare",
-]
+dist-server = ["jwt", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "version-compare"]
 # Enables dist tests with external requirements
 dist-tests = ["dist-client", "dist-server"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = true
 strip = true
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { version = "1.0", features = ["backtrace"] }
 ar = "0.9"
 async-trait = "0.1"
 base64 = "0.21"
@@ -31,17 +31,21 @@ bincode = "1"
 blake3 = "1"
 byteorder = "1.0"
 bytes = "1"
-opendal = { version= "0.34.0", optional = true }
-reqsign = {version="0.10.1", optional = true}
+opendal = { version = "0.34.0", optional = true }
+reqsign = { version = "0.10.1", optional = true }
 clap = { version = "4.1.11", features = ["derive", "env", "wrap_help"] }
 directories = "5.0.0"
 encoding = "0.2"
 env_logger = "0.10"
 filetime = "0.2"
-flate2 = { version = "1.0", optional = true, default-features = false, features = ["rust_backend"] }
+flate2 = { version = "1.0", optional = true, default-features = false, features = [
+  "rust_backend",
+] }
 fs-err = "2.9"
 futures = "0.3"
-gzp = { version = "0.11.3", default-features = false, features = ["deflate_rust"]  }
+gzp = { version = "0.11.3", default-features = false, features = [
+  "deflate_rust",
+] }
 http = "0.2"
 hyper = { version = "0.14.24", optional = true, features = ["server"] }
 is-terminal = "0.4.5"
@@ -56,7 +60,13 @@ number_prefix = "0.4"
 openssl = { version = "0.10.48", optional = true }
 rand = "0.8.4"
 regex = "1.7.3"
-reqwest = { version = "0.11", features = ["json", "blocking", "stream", "rustls-tls", "trust-dns"], optional = true }
+reqwest = { version = "0.11", features = [
+  "json",
+  "blocking",
+  "stream",
+  "rustls-tls",
+  "trust-dns",
+], optional = true }
 retry = "2"
 semver = "1.0"
 sha2 = { version = "0.10.6", optional = true }
@@ -66,9 +76,20 @@ strip-ansi-escapes = "0.1"
 tar = "0.4.36"
 tempfile = "3"
 # trust-dns-resolver must be kept in sync with the version reqwest uses
-trust-dns-resolver = { version = "0.22.0", features = ["dnssec-ring", "dns-over-rustls", "dns-over-https-rustls"] }
+trust-dns-resolver = { version = "0.22.0", features = [
+  "dnssec-ring",
+  "dns-over-rustls",
+  "dns-over-https-rustls",
+] }
 mime = "0.3"
-tokio = { version = "1", features = ["rt-multi-thread", "io-util", "time", "net", "process", "macros"] }
+tokio = { version = "1", features = [
+  "rt-multi-thread",
+  "io-util",
+  "time",
+  "net",
+  "process",
+  "macros",
+] }
 tokio-serde = "0.8"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
 tower = "0.4"
@@ -83,7 +104,9 @@ zstd = "0.12"
 
 # dist-server only
 nix = { version = "0.26.2", optional = true }
-rouille = { version = "3.5", optional = true, default-features = false, features = ["ssl"] }
+rouille = { version = "3.5", optional = true, default-features = false, features = [
+  "ssl",
+] }
 syslog = { version = "6", optional = true }
 version-compare = { version = "0.1.1", optional = true }
 
@@ -105,19 +128,23 @@ version = "0.1.10"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"
-features = [
-    "fileapi",
-    "handleapi",
-    "stringapiset",
-    "winnls",
-]
+features = ["fileapi", "handleapi", "stringapiset", "winnls"]
 
 [features]
 default = ["all"]
-all = ["dist-client", "redis", "s3", "memcached", "gcs", "azure", "gha", "webdav"]
-azure = ["opendal","reqsign"]
-s3 = ["opendal","reqsign"]
-gcs = ["opendal","reqsign", "url", "reqwest/blocking"]
+all = [
+  "dist-client",
+  "redis",
+  "s3",
+  "memcached",
+  "gcs",
+  "azure",
+  "gha",
+  "webdav",
+]
+azure = ["opendal", "reqsign"]
+s3 = ["opendal", "reqsign"]
+gcs = ["opendal", "reqsign", "url", "reqwest/blocking"]
 gha = ["opendal"]
 webdav = ["opendal"]
 memcached = ["opendal/services-memcached"]
@@ -132,7 +159,17 @@ unstable = []
 # Enables distributed support in the sccache client
 dist-client = ["flate2", "hyper", "reqwest", "url", "sha2"]
 # Enables the sccache-dist binary
-dist-server = ["jwt", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "version-compare"]
+dist-server = [
+  "jwt",
+  "flate2",
+  "libmount",
+  "nix",
+  "openssl",
+  "reqwest",
+  "rouille",
+  "syslog",
+  "version-compare",
+]
 # Enables dist tests with external requirements
 dist-tests = ["dist-client", "dist-server"]
 


### PR DESCRIPTION
This PR enable `backtrace` feature for anyhow which helps a lot for debugging.

For example, after `backtrace` enabled, the output of error changed:

from

```shell
[2023-05-24T20:41:14Z ERROR sccache::server] ["openssl_sys"] fatal error: Not an archive file (invalid global header)
```

to

```shell
[2023-05-24T20:41:14Z ERROR sccache::server] ["openssl_sys"] fatal error: Not an archive file (invalid global header)
    
    Stack backtrace:
       0: <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual
                 at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/result.rs:2065:27
       1: sccache::util::hash_all_archives::{{closure}}::{{closure}}::{{closure}}
                 at /home/xuanwo/Code/mozilla/sccache/src/util.rs:153:29
       2: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
```

In which we know where this error come from.