### PR TITLE
Added env var to disable multi arch caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,6 +2316,7 @@ dependencies = [
  "strip-ansi-escapes",
  "syslog",
  "tar",
+ "temp-env",
  "tempfile",
  "thirtyfour_sync",
  "tokio",
@@ -2667,6 +2668,15 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9547444bfe52cbd79515c6c8087d8ae6ca8d64d2d31a27746320f5cb81d1a15c"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ itertools = "0.10"
 predicates = "=3.0.2"
 thirtyfour_sync = "0.27"
 serial_test = "2.0"
+temp-env = "0.3.4"
 
 [target.'cfg(unix)'.dependencies]
 daemonize = "0.5"

--- a/docs/Caching.md
+++ b/docs/Caching.md
@@ -26,8 +26,9 @@ For C/C++, the hash is generated with a blake3 digest of the preprocessed
 file (-E with gcc/clang). For compilations that specify multiple `-arch` flags,
 these flags are rewritten to their corresponding preprocessor defines to allow 
 pre-processing the file (e.g `-arch x86_64` is rewritten to `-D__X86_64__=1`),
-this can be disabled by setting the environment variable
-`SCCACHE_NOCACHE_MULTIARCH` as it may not work in all cases.
+this can be enabled by setting the environment variable
+`SCCACHE_CACHE_MULTIARCH` but is disabled by default as it may not work in all
+cases.
 
 We also take into account in the hash:
 * Hash of the compiler binary

--- a/docs/Caching.md
+++ b/docs/Caching.md
@@ -25,7 +25,9 @@ In parallel, we also take into account in the hash:
 For C/C++, the hash is generated with a blake3 digest of the preprocessed
 file (-E with gcc/clang). For compilations that specify multiple `-arch` flags,
 these flags are rewritten to their corresponding preprocessor defines to allow 
-pre-processing the file (e.g `-arch x86_64` is rewritten to `-D__X86_64__=1`).
+pre-processing the file (e.g `-arch x86_64` is rewritten to `-D__X86_64__=1`),
+this can be disabled by setting the environment variable
+`SCCACHE_NOCACHE_MULTIARCH` as it may not work in all cases.
 
 We also take into account in the hash:
 * Hash of the compiler binary

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -75,7 +75,7 @@ configuration variables
 * `SCCACHE_STARTUP_NOTIFY` specify a path to a socket which will be used for server completion notification
 * `SCCACHE_MAX_FRAME_LENGTH` how much data can be transferred between client and server
 * `SCCACHE_NO_DAEMON` set to `1` to disable putting the server to the background
-* `SCCACHE_NOCACHE_MULTIARCH` to disable caching of multi architecture builds.
+* `SCCACHE_CACHE_MULTIARCH` to disable caching of multi architecture builds.
 
 ### cache configs
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -75,6 +75,7 @@ configuration variables
 * `SCCACHE_STARTUP_NOTIFY` specify a path to a socket which will be used for server completion notification
 * `SCCACHE_MAX_FRAME_LENGTH` how much data can be transferred between client and server
 * `SCCACHE_NO_DAEMON` set to `1` to disable putting the server to the background
+* `SCCACHE_NOCACHE_MULTIARCH` to disable caching of multi architecture builds.
 
 ### cache configs
 

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -277,7 +277,7 @@ where
     let mut xclangs: Vec<OsString> = vec![];
     let mut color_mode = ColorMode::Auto;
     let mut seen_arch = None;
-    let dont_cache_multiarch = !env::var("SCCACHE_CACHE_MULTIARCH").is_ok();
+    let dont_cache_multiarch = env::var("SCCACHE_CACHE_MULTIARCH").is_err();
 
     // Custom iterator to expand `@` arguments which stand for reading a file
     // and interpreting it as a list of more arguments.
@@ -371,7 +371,9 @@ where
             Some(Arch(arch)) => {
                 match seen_arch {
                     Some(s) if &s != arch && dont_cache_multiarch => {
-                        cannot_cache!("multiple different -arch, and SCCACHE_CACHE_MULTIARCH not set")
+                        cannot_cache!(
+                            "multiple different -arch, and SCCACHE_CACHE_MULTIARCH not set"
+                        )
                     }
                     _ => {}
                 };
@@ -661,7 +663,7 @@ fn preprocess_cmd<T>(
                 .map(|arg_string| format!("-D__{}__=1", arg_string).into())
         })
         .collect::<Vec<OsString>>();
-    
+
     let mut arch_args_to_use = &rewritten_arch_args;
     let mut unique_rewritten = rewritten_arch_args.clone();
     unique_rewritten.sort();
@@ -1766,7 +1768,6 @@ mod test {
         }
 
         with_var("SCCACHE_CACHE_MULTIARCH", Some("1"), || {
-
             match parse_arguments_(
                 stringvec!["-arch", "arm64", "-arch", "arm64", "-o", "foo.o", "-c", "foo.cpp"],
                 false,
@@ -1775,8 +1776,9 @@ mod test {
                 o => panic!("Got unexpected parse result: {:?}", o),
             }
 
-            let args =
-                stringvec!["-fPIC", "-arch", "arm64", "-arch", "i386", "-o", "foo.o", "-c", "foo.cpp"];
+            let args = stringvec![
+                "-fPIC", "-arch", "arm64", "-arch", "i386", "-o", "foo.o", "-c", "foo.cpp"
+            ];
             let ParsedArguments {
                 input,
                 language,

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -277,7 +277,7 @@ where
     let mut xclangs: Vec<OsString> = vec![];
     let mut color_mode = ColorMode::Auto;
     let mut seen_arch = None;
-    let dont_cache_multiarch = env::var("SCCACHE_NOCACHE_MULTIARCH").is_ok();
+    let dont_cache_multiarch = !env::var("SCCACHE_CACHE_MULTIARCH").is_ok();
 
     // Custom iterator to expand `@` arguments which stand for reading a file
     // and interpreting it as a list of more arguments.
@@ -371,7 +371,7 @@ where
             Some(Arch(arch)) => {
                 match seen_arch {
                     Some(s) if &s != arch && dont_cache_multiarch => {
-                        cannot_cache!("multiple different -arch, and SCCACHE_NOCACHE_MULTIARCH set")
+                        cannot_cache!("multiple different -arch, and SCCACHE_CACHE_MULTIARCH not set")
                     }
                     _ => {}
                 };
@@ -661,12 +661,21 @@ fn preprocess_cmd<T>(
                 .map(|arg_string| format!("-D__{}__=1", arg_string).into())
         })
         .collect::<Vec<OsString>>();
+    
+    let mut arch_args_to_use = &rewritten_arch_args;
+    let mut unique_rewritten = rewritten_arch_args.clone();
+    unique_rewritten.sort();
+    unique_rewritten.dedup();
+    if unique_rewritten.len() <= 1 {
+        // don't use rewritten arch args if there is only one arch
+        arch_args_to_use = &parsed_args.arch_args;
+    }
 
     cmd.arg(&parsed_args.input)
         .args(&parsed_args.preprocessor_args)
         .args(&parsed_args.dependency_args)
         .args(&parsed_args.common_args)
-        .args(&rewritten_arch_args)
+        .args(arch_args_to_use)
         .env_clear()
         .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
         .current_dir(cwd);
@@ -1441,7 +1450,43 @@ mod test {
 
     #[test]
     fn test_preprocess_cmd_rewrites_archs() {
-        let args = stringvec!["-arch", "arm64", "-arch", "i386", "-c", "foo.cc"];
+        with_var("SCCACHE_CACHE_MULTIARCH", Some("1"), || {
+            let args = stringvec!["-arch", "arm64", "-arch", "i386", "-c", "foo.cc"];
+            let parsed_args = match parse_arguments_(args, false) {
+                CompilerArguments::Ok(args) => args,
+                o => panic!("Got unexpected parse result: {:?}", o),
+            };
+            let mut cmd = MockCommand {
+                child: None,
+                args: vec![],
+            };
+            preprocess_cmd(
+                &mut cmd,
+                &parsed_args,
+                Path::new(""),
+                &[],
+                true,
+                CCompilerKind::Gcc,
+                true,
+                vec![],
+            );
+            // make sure the architectures were rewritten to prepocessor defines
+            let expected_args = ovec![
+                "-x",
+                "c++",
+                "-E",
+                "-fdirectives-only",
+                "foo.cc",
+                "-D__arm64__=1",
+                "-D__i386__=1"
+            ];
+            assert_eq!(cmd.args, expected_args);
+        });
+    }
+
+    #[test]
+    fn test_preprocess_cmd_doesnt_rewrite_single_arch() {
+        let args = stringvec!["-arch", "arm64", "-c", "foo.cc"];
         let parsed_args = match parse_arguments_(args, false) {
             CompilerArguments::Ok(args) => args,
             o => panic!("Got unexpected parse result: {:?}", o),
@@ -1467,8 +1512,8 @@ mod test {
             "-E",
             "-fdirectives-only",
             "foo.cc",
-            "-D__arm64__=1",
-            "-D__i386__=1"
+            "-arch",
+            "arm64"
         ];
         assert_eq!(cmd.args, expected_args);
     }
@@ -1696,20 +1741,18 @@ mod test {
 
     #[test]
     fn test_parse_arguments_multiarch_cache_disabled() {
-        with_var("SCCACHE_NOCACHE_MULTIARCH", Some("1"), || {
-            assert_eq!(
-                CompilerArguments::CannotCache(
-                    "multiple different -arch, and SCCACHE_NOCACHE_MULTIARCH set",
-                    None
-                ),
-                parse_arguments_(
-                    stringvec![
-                        "-fPIC", "-arch", "arm64", "-arch", "i386", "-o", "foo.o", "-c", "foo.cpp"
-                    ],
-                    false
-                )
+        assert_eq!(
+            CompilerArguments::CannotCache(
+                "multiple different -arch, and SCCACHE_CACHE_MULTIARCH not set",
+                None
+            ),
+            parse_arguments_(
+                stringvec![
+                    "-fPIC", "-arch", "arm64", "-arch", "i386", "-o", "foo.o", "-c", "foo.cpp"
+                ],
+                false
             )
-        });
+        )
     }
 
     #[test]
@@ -1722,47 +1765,50 @@ mod test {
             o => panic!("Got unexpected parse result: {:?}", o),
         }
 
-        match parse_arguments_(
-            stringvec!["-arch", "arm64", "-arch", "arm64", "-o", "foo.o", "-c", "foo.cpp"],
-            false,
-        ) {
-            CompilerArguments::Ok(_) => {}
-            o => panic!("Got unexpected parse result: {:?}", o),
-        }
+        with_var("SCCACHE_CACHE_MULTIARCH", Some("1"), || {
 
-        let args =
-            stringvec!["-fPIC", "-arch", "arm64", "-arch", "i386", "-o", "foo.o", "-c", "foo.cpp"];
-        let ParsedArguments {
-            input,
-            language,
-            compilation_flag,
-            outputs,
-            preprocessor_args,
-            msvc_show_includes,
-            common_args,
-            arch_args,
-            ..
-        } = match parse_arguments_(args, false) {
-            CompilerArguments::Ok(args) => args,
-            o => panic!("Got unexpected parse result: {:?}", o),
-        };
-        assert_eq!(Some("foo.cpp"), input.to_str());
-        assert_eq!(Language::Cxx, language);
-        assert_eq!(Some("-c"), compilation_flag.to_str());
-        assert_map_contains!(
-            outputs,
-            (
-                "obj",
-                ArtifactDescriptor {
-                    path: "foo.o".into(),
-                    optional: false
-                }
-            )
-        );
-        assert!(preprocessor_args.is_empty());
-        assert_eq!(ovec!["-fPIC"], common_args);
-        assert_eq!(ovec!["-arch", "arm64", "-arch", "i386"], arch_args);
-        assert!(!msvc_show_includes);
+            match parse_arguments_(
+                stringvec!["-arch", "arm64", "-arch", "arm64", "-o", "foo.o", "-c", "foo.cpp"],
+                false,
+            ) {
+                CompilerArguments::Ok(_) => {}
+                o => panic!("Got unexpected parse result: {:?}", o),
+            }
+
+            let args =
+                stringvec!["-fPIC", "-arch", "arm64", "-arch", "i386", "-o", "foo.o", "-c", "foo.cpp"];
+            let ParsedArguments {
+                input,
+                language,
+                compilation_flag,
+                outputs,
+                preprocessor_args,
+                msvc_show_includes,
+                common_args,
+                arch_args,
+                ..
+            } = match parse_arguments_(args, false) {
+                CompilerArguments::Ok(args) => args,
+                o => panic!("Got unexpected parse result: {:?}", o),
+            };
+            assert_eq!(Some("foo.cpp"), input.to_str());
+            assert_eq!(Language::Cxx, language);
+            assert_eq!(Some("-c"), compilation_flag.to_str());
+            assert_map_contains!(
+                outputs,
+                (
+                    "obj",
+                    ArtifactDescriptor {
+                        path: "foo.o".into(),
+                        optional: false
+                    }
+                )
+            );
+            assert!(preprocessor_args.is_empty());
+            assert_eq!(ovec!["-fPIC"], common_args);
+            assert_eq!(ovec!["-arch", "arm64", "-arch", "i386"], arch_args);
+            assert!(!msvc_show_includes);
+        });
     }
 
     #[test]


### PR DESCRIPTION
Added an environment variable SCCACHE_CACHE_MULTIARCH to enable caching of multiarch compilations.

This should help in cases such as that raised in https://github.com/mozilla/sccache/issues/847#issuecomment-1517546993