### PR TITLE
fix: Revert OpenDAL bump to fix the hang while connecting ghac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,9 +502,9 @@ checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "der"
-version = "0.7.6"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -1610,9 +1610,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opendal"
-version = "0.36.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3555168d4cc9a83c332e1416ff00e3be36a6d78447dff472829962afbc91bb3d"
+checksum = "005c877c4f788a7749825bbc61031ccc950217fac6bcf9965641fbf1bdf991b0"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1638,7 +1638,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
  "tokio",
  "uuid",
 ]
@@ -1747,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
 dependencies = [
  "base64ct",
 ]
@@ -1794,20 +1793,21 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.7.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
 dependencies = [
  "der",
  "pkcs8",
  "spki",
+ "zeroize",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
@@ -2027,9 +2027,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "reqsign"
-version = "0.12.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04f5fccb94d61c154f0d8520ec42e79afdc145f4b1a392faa269874995fda66"
+checksum = "5d36dae58fbc1db90e1cf14ca8fabcba92b7aa3c282d5e46bcdf16b9c28ab04c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2161,12 +2161,11 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.2"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab43bb47d23c1a631b4b680199a45255dce26fa9ab2fa902581f624ff13e6a8"
+checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
 dependencies = [
  "byteorder",
- "const-oid",
  "digest",
  "num-bigint-dig",
  "num-integer",
@@ -2176,7 +2175,6 @@ dependencies = [
  "pkcs8",
  "rand_core",
  "signature",
- "spki",
  "subtle",
  "zeroize",
 ]
@@ -2602,9 +2600,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,14 +38,10 @@ directories = "5.0.0"
 encoding = "0.2"
 env_logger = "0.10"
 filetime = "0.2"
-flate2 = { version = "1.0", optional = true, default-features = false, features = [
-    "rust_backend",
-] }
+flate2 = { version = "1.0", optional = true, default-features = false, features = ["rust_backend"] }
 fs-err = "2.9"
 futures = "0.3"
-gzp = { version = "0.11.3", default-features = false, features = [
-    "deflate_rust",
-] }
+gzp = { version = "0.11.3", default-features = false, features = ["deflate_rust"]  }
 http = "0.2"
 hyper = { version = "0.14.25", optional = true, features = ["server"] }
 is-terminal = "0.4.5"
@@ -60,13 +56,7 @@ number_prefix = "0.4"
 openssl = { version = "0.10.49", optional = true }
 rand = "0.8.4"
 regex = "1.7.3"
-reqwest = { version = "0.11", features = [
-    "json",
-    "blocking",
-    "stream",
-    "rustls-tls",
-    "trust-dns",
-], optional = true }
+reqwest = { version = "0.11", features = ["json", "blocking", "stream", "rustls-tls", "trust-dns"], optional = true }
 retry = "2"
 semver = "1.0"
 sha2 = { version = "0.10.6", optional = true }
@@ -76,20 +66,9 @@ strip-ansi-escapes = "0.1"
 tar = "0.4.36"
 tempfile = "3"
 # trust-dns-resolver must be kept in sync with the version reqwest uses
-trust-dns-resolver = { version = "0.22.0", features = [
-    "dnssec-ring",
-    "dns-over-rustls",
-    "dns-over-https-rustls",
-] }
+trust-dns-resolver = { version = "0.22.0", features = ["dnssec-ring", "dns-over-rustls", "dns-over-https-rustls"] }
 mime = "0.3"
-tokio = { version = "1", features = [
-    "rt-multi-thread",
-    "io-util",
-    "time",
-    "net",
-    "process",
-    "macros",
-] }
+tokio = { version = "1", features = ["rt-multi-thread", "io-util", "time", "net", "process", "macros"] }
 tokio-serde = "0.8"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
 tower = "0.4"
@@ -104,9 +83,7 @@ zstd = "0.12"
 
 # dist-server only
 nix = { version = "0.26.2", optional = true }
-rouille = { version = "3.5", optional = true, default-features = false, features = [
-    "ssl",
-] }
+rouille = { version = "3.5", optional = true, default-features = false, features = ["ssl"] }
 syslog = { version = "6", optional = true }
 version-compare = { version = "0.1.1", optional = true }
 object = "0.30"
@@ -131,23 +108,19 @@ version = "0.1.10"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"
-features = ["fileapi", "handleapi", "stringapiset", "winnls"]
+features = [
+    "fileapi",
+    "handleapi",
+    "stringapiset",
+    "winnls",
+]
 
 [features]
 default = ["all"]
-all = [
-    "dist-client",
-    "redis",
-    "s3",
-    "memcached",
-    "gcs",
-    "azure",
-    "gha",
-    "webdav",
-]
-azure = ["opendal", "reqsign"]
-s3 = ["opendal", "reqsign"]
-gcs = ["opendal", "reqsign", "url", "reqwest/blocking"]
+all = ["dist-client", "redis", "s3", "memcached", "gcs", "azure", "gha", "webdav"]
+azure = ["opendal","reqsign"]
+s3 = ["opendal","reqsign"]
+gcs = ["opendal","reqsign", "url", "reqwest/blocking"]
 gha = ["opendal"]
 webdav = ["opendal"]
 memcached = ["opendal/services-memcached"]
@@ -162,17 +135,7 @@ unstable = []
 # Enables distributed support in the sccache client
 dist-client = ["flate2", "hyper", "reqwest", "url", "sha2"]
 # Enables the sccache-dist binary
-dist-server = [
-    "jwt",
-    "flate2",
-    "libmount",
-    "nix",
-    "openssl",
-    "reqwest",
-    "rouille",
-    "syslog",
-    "version-compare",
-]
+dist-server = ["jwt", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "version-compare"]
 # Enables dist tests with external requirements
 dist-tests = ["dist-client", "dist-server"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,17 +31,21 @@ bincode = "1"
 blake3 = "1"
 byteorder = "1.0"
 bytes = "1"
-opendal = { version= "0.36.0", optional = true }
-reqsign = { version = "0.12.0", optional = true }
+opendal = { version = "0.34.0", optional = true }
+reqsign = { version = "0.10.1", optional = true }
 clap = { version = "4.1.11", features = ["derive", "env", "wrap_help"] }
 directories = "5.0.0"
 encoding = "0.2"
 env_logger = "0.10"
 filetime = "0.2"
-flate2 = { version = "1.0", optional = true, default-features = false, features = ["rust_backend"] }
+flate2 = { version = "1.0", optional = true, default-features = false, features = [
+    "rust_backend",
+] }
 fs-err = "2.9"
 futures = "0.3"
-gzp = { version = "0.11.3", default-features = false, features = ["deflate_rust"]  }
+gzp = { version = "0.11.3", default-features = false, features = [
+    "deflate_rust",
+] }
 http = "0.2"
 hyper = { version = "0.14.25", optional = true, features = ["server"] }
 is-terminal = "0.4.5"
@@ -56,7 +60,13 @@ number_prefix = "0.4"
 openssl = { version = "0.10.49", optional = true }
 rand = "0.8.4"
 regex = "1.7.3"
-reqwest = { version = "0.11", features = ["json", "blocking", "stream", "rustls-tls", "trust-dns"], optional = true }
+reqwest = { version = "0.11", features = [
+    "json",
+    "blocking",
+    "stream",
+    "rustls-tls",
+    "trust-dns",
+], optional = true }
 retry = "2"
 semver = "1.0"
 sha2 = { version = "0.10.6", optional = true }
@@ -66,9 +76,20 @@ strip-ansi-escapes = "0.1"
 tar = "0.4.36"
 tempfile = "3"
 # trust-dns-resolver must be kept in sync with the version reqwest uses
-trust-dns-resolver = { version = "0.22.0", features = ["dnssec-ring", "dns-over-rustls", "dns-over-https-rustls"] }
+trust-dns-resolver = { version = "0.22.0", features = [
+    "dnssec-ring",
+    "dns-over-rustls",
+    "dns-over-https-rustls",
+] }
 mime = "0.3"
-tokio = { version = "1", features = ["rt-multi-thread", "io-util", "time", "net", "process", "macros"] }
+tokio = { version = "1", features = [
+    "rt-multi-thread",
+    "io-util",
+    "time",
+    "net",
+    "process",
+    "macros",
+] }
 tokio-serde = "0.8"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
 tower = "0.4"
@@ -83,7 +104,9 @@ zstd = "0.12"
 
 # dist-server only
 nix = { version = "0.26.2", optional = true }
-rouille = { version = "3.5", optional = true, default-features = false, features = ["ssl"] }
+rouille = { version = "3.5", optional = true, default-features = false, features = [
+    "ssl",
+] }
 syslog = { version = "6", optional = true }
 version-compare = { version = "0.1.1", optional = true }
 object = "0.30"
@@ -108,19 +131,23 @@ version = "0.1.10"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"
-features = [
-    "fileapi",
-    "handleapi",
-    "stringapiset",
-    "winnls",
-]
+features = ["fileapi", "handleapi", "stringapiset", "winnls"]
 
 [features]
 default = ["all"]
-all = ["dist-client", "redis", "s3", "memcached", "gcs", "azure", "gha", "webdav"]
-azure = ["opendal","reqsign"]
-s3 = ["opendal","reqsign"]
-gcs = ["opendal","reqsign", "url", "reqwest/blocking"]
+all = [
+    "dist-client",
+    "redis",
+    "s3",
+    "memcached",
+    "gcs",
+    "azure",
+    "gha",
+    "webdav",
+]
+azure = ["opendal", "reqsign"]
+s3 = ["opendal", "reqsign"]
+gcs = ["opendal", "reqsign", "url", "reqwest/blocking"]
 gha = ["opendal"]
 webdav = ["opendal"]
 memcached = ["opendal/services-memcached"]
@@ -135,7 +162,17 @@ unstable = []
 # Enables distributed support in the sccache client
 dist-client = ["flate2", "hyper", "reqwest", "url", "sha2"]
 # Enables the sccache-dist binary
-dist-server = ["jwt", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "version-compare"]
+dist-server = [
+    "jwt",
+    "flate2",
+    "libmount",
+    "nix",
+    "openssl",
+    "reqwest",
+    "rouille",
+    "syslog",
+    "version-compare",
+]
 # Enables dist tests with external requirements
 dist-tests = ["dist-client", "dist-server"]
 


### PR DESCRIPTION
This PR will address https://github.com/mozilla/sccache/issues/1789

The root cause is still not found, but I'm confirmed that it's OpenDAL's issue. This PR will fix that and we need a new release for `0.5.3`.