### PR TITLE
chore: Make sure Cargo.toml is formatted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,8 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - uses: taiki-e/cache-cargo-install-action@v1
-        with:
-          tool: taplo-cli
-
       - name: Check
-        run: taplo fmt --check
+        run: npx --yes @taplo/cli fmt --check
 
   test:
     name: test ${{ matrix.os }} rust ${{ matrix.rustc || 'stable' }} ${{ matrix.extra_desc }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,19 @@ jobs:
       - name: Check
         run: cargo ${{ matrix.cargo_cmd }}
 
+  toml_format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - uses: taiki-e/cache-cargo-install-action@v1
+        with:
+          tool: taplo-cli
+
+      - name: Check
+        run: taplo fmt --check
+
   test:
     name: test ${{ matrix.os }} rust ${{ matrix.rustc || 'stable' }} ${{ matrix.extra_desc }}
     runs-on: ${{ matrix.os }}

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,30 @@
+include = ["Cargo.toml", "**/*.toml"]
+
+[formatting]
+# Align consecutive entries vertically.
+align_entries = false
+# Append trailing commas for multi-line arrays.
+array_trailing_comma = true
+# Expand arrays to multiple lines that exceed the maximum column width.
+array_auto_expand = true
+# Collapse arrays that don't exceed the maximum column width and don't contain comments.
+array_auto_collapse = true
+# Omit white space padding from single-line arrays
+compact_arrays = true
+# Omit white space padding from the start and end of inline tables.
+compact_inline_tables = false
+# Maximum column width in characters, affects array expansion and collapse, this doesn't take whitespace into account.
+# Note that this is not set in stone, and works on a best-effort basis.
+column_width = 80
+# Indent based on tables and arrays of tables and their subtables, subtables out of order are not indented.
+indent_tables = false
+# The substring that is used for indentation, should be tabs or spaces (but technically can be anything).
+indent_string = '  '
+# Add trailing newline at the end of the file if not present.
+trailing_newline = true
+# Alphabetically reorder keys that are not separated by empty lines.
+reorder_keys = true
+# Maximum amount of allowed consecutive blank lines. This does not affect the whitespace at the end of the document, as it is always stripped.
+allowed_blank_lines = 1
+# Use CRLF for line endings.
+crlf = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,14 @@ directories = "5.0.0"
 encoding = "0.2"
 env_logger = "0.10"
 filetime = "0.2"
-flate2 = { version = "1.0", optional = true, default-features = false, features = ["rust_backend"] }
+flate2 = { version = "1.0", optional = true, default-features = false, features = [
+    "rust_backend",
+] }
 fs-err = "2.9"
 futures = "0.3"
-gzp = { version = "0.11.3", default-features = false, features = ["deflate_rust"]  }
+gzp = { version = "0.11.3", default-features = false, features = [
+    "deflate_rust",
+] }
 http = "0.2"
 hyper = { version = "0.14.25", optional = true, features = ["server"] }
 is-terminal = "0.4.5"
@@ -56,7 +60,13 @@ number_prefix = "0.4"
 openssl = { version = "0.10.49", optional = true }
 rand = "0.8.4"
 regex = "1.7.3"
-reqwest = { version = "0.11", features = ["json", "blocking", "stream", "rustls-tls", "trust-dns"], optional = true }
+reqwest = { version = "0.11", features = [
+    "json",
+    "blocking",
+    "stream",
+    "rustls-tls",
+    "trust-dns",
+], optional = true }
 retry = "2"
 semver = "1.0"
 sha2 = { version = "0.10.6", optional = true }
@@ -66,9 +76,20 @@ strip-ansi-escapes = "0.1"
 tar = "0.4.36"
 tempfile = "3"
 # trust-dns-resolver must be kept in sync with the version reqwest uses
-trust-dns-resolver = { version = "0.22.0", features = ["dnssec-ring", "dns-over-rustls", "dns-over-https-rustls"] }
+trust-dns-resolver = { version = "0.22.0", features = [
+    "dnssec-ring",
+    "dns-over-rustls",
+    "dns-over-https-rustls",
+] }
 mime = "0.3"
-tokio = { version = "1", features = ["rt-multi-thread", "io-util", "time", "net", "process", "macros"] }
+tokio = { version = "1", features = [
+    "rt-multi-thread",
+    "io-util",
+    "time",
+    "net",
+    "process",
+    "macros",
+] }
 tokio-serde = "0.8"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
 tower = "0.4"
@@ -83,7 +104,9 @@ zstd = "0.12"
 
 # dist-server only
 nix = { version = "0.26.2", optional = true }
-rouille = { version = "3.5", optional = true, default-features = false, features = ["ssl"] }
+rouille = { version = "3.5", optional = true, default-features = false, features = [
+    "ssl",
+] }
 syslog = { version = "6", optional = true }
 version-compare = { version = "0.1.1", optional = true }
 object = "0.30"
@@ -108,19 +131,23 @@ version = "0.1.10"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"
-features = [
-    "fileapi",
-    "handleapi",
-    "stringapiset",
-    "winnls",
-]
+features = ["fileapi", "handleapi", "stringapiset", "winnls"]
 
 [features]
 default = ["all"]
-all = ["dist-client", "redis", "s3", "memcached", "gcs", "azure", "gha", "webdav"]
-azure = ["opendal","reqsign"]
-s3 = ["opendal","reqsign"]
-gcs = ["opendal","reqsign", "url", "reqwest/blocking"]
+all = [
+    "dist-client",
+    "redis",
+    "s3",
+    "memcached",
+    "gcs",
+    "azure",
+    "gha",
+    "webdav",
+]
+azure = ["opendal", "reqsign"]
+s3 = ["opendal", "reqsign"]
+gcs = ["opendal", "reqsign", "url", "reqwest/blocking"]
 gha = ["opendal"]
 webdav = ["opendal"]
 memcached = ["opendal/services-memcached"]
@@ -135,7 +162,17 @@ unstable = []
 # Enables distributed support in the sccache client
 dist-client = ["flate2", "hyper", "reqwest", "url", "sha2"]
 # Enables the sccache-dist binary
-dist-server = ["jwt", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "version-compare"]
+dist-server = [
+    "jwt",
+    "flate2",
+    "libmount",
+    "nix",
+    "openssl",
+    "reqwest",
+    "rouille",
+    "syslog",
+    "version-compare",
+]
 # Enables dist tests with external requirements
 dist-tests = ["dist-client", "dist-server"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
-name = "sccache"
-version = "0.5.3"
-license = "Apache-2.0"
-description = "Sccache is a ccache-like tool. It is used as a compiler wrapper and avoids compilation when possible, storing a cache in a remote storage using various cloud storage."
-repository = "https://github.com/mozilla/sccache/"
-readme = "README.md"
-categories = ["command-line-utilities", "development-tools::build-utils"]
-keywords = ["ccache"]
 edition = "2021"
+name = "sccache"
 rust-version = "1.65"
+version = "0.5.3"
+
+categories = ["command-line-utilities", "development-tools::build-utils"]
+description = "Sccache is a ccache-like tool. It is used as a compiler wrapper and avoids compilation when possible, storing a cache in a remote storage using various cloud storage."
+keywords = ["ccache"]
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/mozilla/sccache/"
 
 [[bin]]
 name = "sccache"
@@ -31,69 +32,69 @@ bincode = "1"
 blake3 = "1"
 byteorder = "1.0"
 bytes = "1"
-opendal = { version = "0.34.0", optional = true }
-reqsign = { version = "0.10.1", optional = true }
 clap = { version = "4.1.11", features = ["derive", "env", "wrap_help"] }
 directories = "5.0.0"
 encoding = "0.2"
 env_logger = "0.10"
 filetime = "0.2"
 flate2 = { version = "1.0", optional = true, default-features = false, features = [
-    "rust_backend",
+  "rust_backend",
 ] }
 fs-err = "2.9"
 futures = "0.3"
 gzp = { version = "0.11.3", default-features = false, features = [
-    "deflate_rust",
+  "deflate_rust",
 ] }
 http = "0.2"
 hyper = { version = "0.14.25", optional = true, features = ["server"] }
 is-terminal = "0.4.5"
 jobserver = "0.1"
 jwt = { package = "jsonwebtoken", version = "8", optional = true }
-once_cell = "1.17"
 libc = "0.2.140"
 linked-hash-map = "0.5"
 log = "0.4"
 num_cpus = "1.15"
 number_prefix = "0.4"
+once_cell = "1.17"
+opendal = { version = "0.34.0", optional = true }
 openssl = { version = "0.10.49", optional = true }
 rand = "0.8.4"
 regex = "1.7.3"
+reqsign = { version = "0.10.1", optional = true }
 reqwest = { version = "0.11", features = [
-    "json",
-    "blocking",
-    "stream",
-    "rustls-tls",
-    "trust-dns",
+  "json",
+  "blocking",
+  "stream",
+  "rustls-tls",
+  "trust-dns",
 ], optional = true }
 retry = "2"
 semver = "1.0"
-sha2 = { version = "0.10.6", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = { version = "0.10.6", optional = true }
 strip-ansi-escapes = "0.1"
 tar = "0.4.36"
 tempfile = "3"
 # trust-dns-resolver must be kept in sync with the version reqwest uses
-trust-dns-resolver = { version = "0.22.0", features = [
-    "dnssec-ring",
-    "dns-over-rustls",
-    "dns-over-https-rustls",
-] }
 mime = "0.3"
 tokio = { version = "1", features = [
-    "rt-multi-thread",
-    "io-util",
-    "time",
-    "net",
-    "process",
-    "macros",
+  "rt-multi-thread",
+  "io-util",
+  "time",
+  "net",
+  "process",
+  "macros",
 ] }
 tokio-serde = "0.8"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
-tower = "0.4"
 toml = "0.7"
+tower = "0.4"
+trust-dns-resolver = { version = "0.22.0", features = [
+  "dnssec-ring",
+  "dns-over-rustls",
+  "dns-over-https-rustls",
+] }
 url = { version = "2", optional = true }
 uuid = { version = "1.3", features = ["v4"] }
 walkdir = "2"
@@ -103,14 +104,14 @@ zip = { version = "0.6", default-features = false }
 zstd = "0.12"
 
 # dist-server only
+memmap2 = "0.6.2"
 nix = { version = "0.26.2", optional = true }
+object = "0.30"
 rouille = { version = "3.5", optional = true, default-features = false, features = [
-    "ssl",
+  "ssl",
 ] }
 syslog = { version = "6", optional = true }
 version-compare = { version = "0.1.1", optional = true }
-object = "0.30"
-memmap2 = "0.6.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.10"
@@ -118,9 +119,9 @@ cc = "1.0"
 chrono = "0.4.24"
 itertools = "0.10"
 predicates = "=3.0.2"
-thirtyfour_sync = "0.27"
 serial_test = "2.0"
 temp-env = "0.3.4"
+thirtyfour_sync = "0.27"
 
 [target.'cfg(unix)'.dependencies]
 daemonize = "0.5"
@@ -130,29 +131,29 @@ optional = true
 version = "0.1.10"
 
 [target.'cfg(windows)'.dependencies.winapi]
-version = "0.3"
 features = ["fileapi", "handleapi", "stringapiset", "winnls"]
+version = "0.3"
 
 [features]
-default = ["all"]
 all = [
-    "dist-client",
-    "redis",
-    "s3",
-    "memcached",
-    "gcs",
-    "azure",
-    "gha",
-    "webdav",
+  "dist-client",
+  "redis",
+  "s3",
+  "memcached",
+  "gcs",
+  "azure",
+  "gha",
+  "webdav",
 ]
 azure = ["opendal", "reqsign"]
-s3 = ["opendal", "reqsign"]
+default = ["all"]
 gcs = ["opendal", "reqsign", "url", "reqwest/blocking"]
 gha = ["opendal"]
-webdav = ["opendal"]
 memcached = ["opendal/services-memcached"]
 native-zlib = []
 redis = ["url", "opendal/services-redis"]
+s3 = ["opendal", "reqsign"]
+webdav = ["opendal"]
 # Enable features that will build a vendored version of openssl and
 # statically linked with it, instead of linking against the system-wide openssl
 # dynamically or statically.
@@ -163,15 +164,15 @@ unstable = []
 dist-client = ["flate2", "hyper", "reqwest", "url", "sha2"]
 # Enables the sccache-dist binary
 dist-server = [
-    "jwt",
-    "flate2",
-    "libmount",
-    "nix",
-    "openssl",
-    "reqwest",
-    "rouille",
-    "syslog",
-    "version-compare",
+  "jwt",
+  "flate2",
+  "libmount",
+  "nix",
+  "openssl",
+  "reqwest",
+  "rouille",
+  "syslog",
+  "version-compare",
 ]
 # Enables dist tests with external requirements
 dist-tests = ["dist-client", "dist-server"]

--- a/tests/test-crate/Cargo.toml
+++ b/tests/test-crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
+authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 name = "test-crate"
 version = "0.1.0"
-authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 
 [dependencies]
 # Arbitrary crate dependency that doesn't pull in any transitive dependencies.


### PR DESCRIPTION
This PR adds `taplo.toml` to make sure Cargo.toml is formatted.