### PR TITLE
Properly implement PCH compilation

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -66,6 +66,9 @@ where
 pub enum Language {
     C,
     Cxx,
+    GenericHeader,
+    CHeader,
+    CxxHeader,
     ObjectiveC,
     ObjectiveCxx,
     Cuda,
@@ -131,12 +134,14 @@ impl Language {
         match file.extension().and_then(|e| e.to_str()) {
             // gcc: https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html
             Some("c") => Some(Language::C),
+            // Could be C or C++
+            Some("h") => Some(Language::GenericHeader),
             // TODO i
             Some("C") | Some("cc") | Some("cp") | Some("cpp") | Some("CPP") | Some("cxx")
             | Some("c++") => Some(Language::Cxx),
             // TODO ii
-            // TODO H hh hp hpp HPP hxx h++
-            // TODO tcc
+            Some("H") | Some("hh") | Some("hp") | Some("hpp") | Some("HPP") | Some("hxx")
+            | Some("h++") | Some("tcc") => Some(Language::CxxHeader),
             Some("m") => Some(Language::ObjectiveC),
             // TODO mi
             Some("M") | Some("mm") => Some(Language::ObjectiveCxx),
@@ -151,8 +156,9 @@ impl Language {
 
     pub fn as_str(self) -> &'static str {
         match self {
-            Language::C => "c",
-            Language::Cxx => "c++",
+            Language::C | Language::CHeader => "c",
+            Language::Cxx | Language::CxxHeader => "c++",
+            Language::GenericHeader => "c/c++",
             Language::ObjectiveC => "objc",
             Language::ObjectiveCxx => "objc++",
             Language::Cuda => "cuda",
@@ -874,6 +880,17 @@ mod test {
         t("cxx", Language::Cxx);
         t("c++", Language::Cxx);
 
+        t("h", Language::GenericHeader);
+
+        t("hh", Language::CxxHeader);
+        t("H", Language::CxxHeader);
+        t("hp", Language::CxxHeader);
+        t("hxx", Language::CxxHeader);
+        t("hpp", Language::CxxHeader);
+        t("HPP", Language::CxxHeader);
+        t("h++", Language::CxxHeader);
+        t("tcc", Language::CxxHeader);
+
         t("m", Language::ObjectiveC);
 
         t("M", Language::ObjectiveCxx);
@@ -895,6 +912,8 @@ mod test {
         // gcc parses file-extensions as case-sensitive
         t("Cp");
         t("Cpp");
+        t("Hp");
+        t("Hpp");
         t("Mm");
         t("Cu");
     }

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -365,7 +365,7 @@ mod test {
             "pch.hxx.cxx"
         );
         assert_eq!(Some("pch.hxx.cxx"), a.input.to_str());
-        assert_eq!(Language::Cxx, a.language);
+        assert_eq!(Language::CxxHeader, a.language);
         assert_map_contains!(
             a.outputs,
             (

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -782,10 +782,8 @@ pub fn generate_compile_commands(
     #[cfg(feature = "dist-client")]
     let dist_command = (|| {
         // https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Overall-Options.html
-        let mut language: Option<String> = match language_to_gcc_arg(parsed_args.language) {
-            Some(lang) => Some(lang.into()),
-            None => None,
-        };
+        let mut language: Option<String> =
+            language_to_gcc_arg(parsed_args.language).map(|lang| lang.into());
         if !rewrite_includes_only {
             match parsed_args.language {
                 Language::C => language = Some("cpp-output".into()),

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -1963,4 +1963,76 @@ mod test {
         assert!(common_args.is_empty());
         assert!(!msvc_show_includes);
     }
+
+    #[test]
+    fn test_pch_explicit() {
+        let args = stringvec!["-c", "-x", "c++-header", "pch.h", "-o", "pch.pch"];
+        let parsed_args = match parse_arguments_(args, false) {
+            CompilerArguments::Ok(args) => args,
+            o => panic!("Got unexpected parse result: {:?}", o),
+        };
+        let mut cmd = MockCommand {
+            child: None,
+            args: vec![],
+        };
+        preprocess_cmd(
+            &mut cmd,
+            &parsed_args,
+            Path::new(""),
+            &[],
+            true,
+            CCompilerKind::Gcc,
+            true,
+            vec![],
+        );
+        assert!(cmd.args.contains(&"-x".into()) && cmd.args.contains(&"c++-header".into()));
+    }
+
+    #[test]
+    fn test_pch_implicit() {
+        let args = stringvec!["-c", "pch.hpp", "-o", "pch.pch"];
+        let parsed_args = match parse_arguments_(args, false) {
+            CompilerArguments::Ok(args) => args,
+            o => panic!("Got unexpected parse result: {:?}", o),
+        };
+        let mut cmd = MockCommand {
+            child: None,
+            args: vec![],
+        };
+        preprocess_cmd(
+            &mut cmd,
+            &parsed_args,
+            Path::new(""),
+            &[],
+            true,
+            CCompilerKind::Gcc,
+            true,
+            vec![],
+        );
+        assert!(cmd.args.contains(&"-x".into()) && cmd.args.contains(&"c++-header".into()));
+    }
+
+    #[test]
+    fn test_pch_generic() {
+        let args = stringvec!["-c", "pch.h", "-o", "pch.pch"];
+        let parsed_args = match parse_arguments_(args, false) {
+            CompilerArguments::Ok(args) => args,
+            o => panic!("Got unexpected parse result: {:?}", o),
+        };
+        let mut cmd = MockCommand {
+            child: None,
+            args: vec![],
+        };
+        preprocess_cmd(
+            &mut cmd,
+            &parsed_args,
+            Path::new(""),
+            &[],
+            true,
+            CCompilerKind::Gcc,
+            true,
+            vec![],
+        );
+        assert!(!cmd.args.contains(&"-x".into()));
+    }
 }

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -361,7 +361,7 @@ where
             Some(Language(lang)) => {
                 language = match lang.to_string_lossy().as_ref() {
                     "c" => Some(Language::C),
-                    "c++" | "c++-header" => Some(Language::Cxx),
+                    "c++" => Some(Language::Cxx),
                     "objective-c" => Some(Language::ObjectiveC),
                     "objective-c++" => Some(Language::ObjectiveCxx),
                     "cu" => Some(Language::Cuda),

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -82,12 +82,13 @@ impl CCompilerImpl for Nvcc {
         T: CommandCreatorSync,
     {
         let language = match parsed_args.language {
-            Language::C => "c",
-            Language::Cxx => "c++",
-            Language::ObjectiveC => "objective-c",
-            Language::ObjectiveCxx => "objective-c++",
-            Language::Cuda => "cu",
-        };
+            Language::C => Ok("c"),
+            Language::Cxx => Ok("c++"),
+            Language::ObjectiveC => Ok("objective-c"),
+            Language::ObjectiveCxx => Ok("objective-c++"),
+            Language::Cuda => Ok("cu"),
+            _ => Err(anyhow!("PCH not supported by nvcc")),
+        }?;
 
         let initialize_cmd_and_args = || {
             let mut command = creator.clone().new_command_sync(executable);


### PR DESCRIPTION
Fixes https://github.com/mozilla/sccache/issues/1748.
A proper bug explanation is provided in the above mentioned issue. 

Since we need to differentiate between header and source for PCH compilation, we store the file type information (header vs source) and then pass that along to clang/gcc via ```-x```. Since ```.h``` ("GenericHeader") can be either a header or a source, the ```-x``` will be omitted for ```.h``` unless manually specified by the user, so the compiler can decide what to do. 