### PR TITLE
enh(msvc): ignore /d2Zi+

### DIFF
--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -481,6 +481,7 @@ msvc_args!(static ARGS: [ArgInfo<ArgData>; _] = [
     msvc_flag!("clr", PassThrough),
     msvc_take_arg!("clr:", OsString, Concatenated, PassThroughWithSuffix),
     msvc_take_arg!("constexpr:", OsString, Concatenated, PassThroughWithSuffix),
+    msvc_flag!("d2Zi+", PassThrough),
     msvc_take_arg!("deps", PathBuf, Concatenated, DepFile),
     msvc_take_arg!("diagnostics:", OsString, Concatenated, PassThroughWithSuffix),
     msvc_take_arg!("doc", PathBuf, Concatenated, TooHardPath), // Creates an .xdc file.


### PR DESCRIPTION
https://learn.microsoft.com/en-us/cpp/build/reference/zo-enhance-optimized-debugging?view=msvc-170
`The /Zo option is available starting in Visual Studio 2013 Update 3, and it replaces the previously undocumented /d2Zi+ option.`
So /d2Zi+ should be ignored