### PR TITLE
Properly propagate cache write errors

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -398,14 +398,15 @@ where
                 let future = async move {
                     let start = Instant::now();
                     match storage.put(&key, entry).await {
-                        Ok(_) => debug!("[{}]: Stored in cache successfully!", out_pretty2),
-                        Err(ref e) => debug!("[{}]: Cache write error: {:?}", out_pretty2, e),
+                        Ok(_) => {
+                            debug!("[{}]: Stored in cache successfully!", out_pretty2);
+                            Ok(CacheWriteInfo {
+                                object_file_pretty: out_pretty2,
+                                duration: start.elapsed(),
+                            })
+                        }
+                        Err(e) => Err(e),
                     }
-
-                    Ok(CacheWriteInfo {
-                        object_file_pretty: out_pretty2,
-                        duration: start.elapsed(),
-                    })
                 };
                 let future = Box::pin(future);
                 Ok((


### PR DESCRIPTION
We leave it to the server code to handle printing the propagated error. One downside is that the log doesn't mention the associated output anymore, and the time spent on failing the cache write is not accounted for anymore either, but it's probably fine.

Fixes: #1832.