### PR TITLE
msvc: fix detect_showincludes_prefix when VS_UNICODE_OUTPUT is set

### DIFF
--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -186,13 +186,9 @@ where
     if is_clang {
         cmd.arg("--driver-mode=cl");
     }
-    cmd.args(&["-nologo", "-showIncludes", "-c", "-Fonul", "-I."])
+    cmd.args(&["-nologo", "-showIncludes", "-c", "-Fonul", "-I.", "-E"])
         .arg(&input)
-        .current_dir(tempdir.path())
-        // The MSDN docs say the -showIncludes output goes to stderr,
-        // but that's not true unless running with -E.
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null());
+        .current_dir(tempdir.path());
     for (k, v) in env {
         cmd.env(k, v);
     }
@@ -205,12 +201,13 @@ where
     }
 
     let process::Output {
-        stdout: stdout_bytes,
+        stderr: stderr_bytes,
         ..
     } = output;
-    let stdout = from_local_codepage(&stdout_bytes)
-        .context("Failed to convert compiler stdout while detecting showIncludes prefix")?;
-    for line in stdout.lines() {
+    let output = from_local_codepage(&stderr_bytes)
+        .context("Failed to convert compiler stderr while detecting showIncludes prefix")?;
+
+    for line in output.lines() {
         if !line.ends_with("test.h") {
             continue;
         }
@@ -231,7 +228,7 @@ where
 
     debug!(
         "failed to detect showIncludes prefix with output: {}",
-        stdout
+        output
     );
 
     bail!("Failed to detect showIncludes prefix")


### PR DESCRIPTION
`VS_UNICODE_OUTPUT` is set by Visual Studio to a value that tells MS tools running from within the IDE where to send their output. Thus, `cl.exe` invocation used to retrieve the `/showIncludes` prefix returns an empty output when this variable is set to a valid value.

The proposed fix is to use `/E` option that tells `cl.exe` to output file content in stdout and retrieved headers in stderr. When set, `cl.exe` ignores the value of `VS_UNICODE_OUTPUT`.

Another fix could be to explicitly unset `VS_UNICODE_OUTPUT` in the command invocation.

#1830  #909 mentioning these issues as it may fix them.