### PR TITLE
Don't pass wd4668 to clang-cl

### DIFF
--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -885,9 +885,6 @@ where
         .args(&parsed_args.preprocessor_args)
         .args(&parsed_args.dependency_args)
         .args(&parsed_args.common_args)
-        // Windows SDK generates C4668 during preprocessing, but compiles fine.
-        // Read for more info: https://github.com/mozilla/sccache/issues/1725
-        .arg("/wd4668")
         .env_clear()
         .envs(env_vars.iter().map(|(k, v)| (k, v)))
         .current_dir(cwd);
@@ -902,6 +899,9 @@ where
             cmd.arg("/sourceDependencies");
             cmd.arg(depfile);
         }
+        // Windows SDK generates C4668 during preprocessing, but compiles fine.
+        // Read for more info: https://github.com/mozilla/sccache/issues/1725
+        cmd.arg("/wd4668");
     }
 
     if rewrite_includes_only && is_clang {


### PR DESCRIPTION
Fixes #1843 

We should only pass `/wd4668` when the compiler is MSVC, not when it's clang-cl, as the later does not understand that flag (and the issue it fixes is not relevant to clang-cl-based builds).