### PR TITLE
sccache fails to build on non x86_64/aarch64 arches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ trust-dns-resolver = { version = "0.22.0", features = [
   "dnssec-ring",
   "dns-over-rustls",
   "dns-over-https-rustls",
-] }
+], optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "1.3", features = ["v4"] }
 walkdir = "2"
@@ -147,7 +147,7 @@ all = [
 ]
 azure = ["opendal", "reqsign"]
 default = ["all"]
-gcs = ["opendal", "reqsign", "url", "reqwest/blocking"]
+gcs = ["opendal", "reqsign", "url", "reqwest/blocking", "trust-dns-resolver"]
 gha = ["opendal"]
 memcached = ["opendal/services-memcached"]
 native-zlib = []
@@ -161,7 +161,7 @@ vendored-openssl = ["openssl?/vendored"]
 # Enable features that require unstable features of Nightly Rust.
 unstable = []
 # Enables distributed support in the sccache client
-dist-client = ["flate2", "hyper", "reqwest", "url", "sha2"]
+dist-client = ["flate2", "hyper", "reqwest", "url", "sha2", "trust-dns-resolver"]
 # Enables the sccache-dist binary
 dist-server = [
   "jwt",
@@ -172,6 +172,7 @@ dist-server = [
   "reqwest",
   "rouille",
   "syslog",
+  "trust-dns-resolver",
   "version-compare",
 ]
 # Enables dist tests with external requirements


### PR DESCRIPTION
On all arches except x86_64/aarch64 sccache fails to build. This is due to the use of rustls/ring as a feature in trust-dns-resolver.

However, trust dns resolver isn't actually needed when you set --no-default-features, since this appears to only be to coerce features in trust-dns-resolver when reqwest is present.

As a result, trust-dns-resolver should be optional and only added when required.