### PR TITLE
Add nvcc cubin,fatbin,optix-ir compilation mode support

### DIFF
--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -420,6 +420,46 @@ mod test {
     }
 
     #[test]
+    fn test_parse_arguments_fatbin_compile_flag() {
+        let a = parses!("-x", "cu", "-fatbin", "foo.c", "-o", "foo.o");
+        assert_eq!(Some("foo.c"), a.input.to_str());
+        assert_eq!(Language::Cuda, a.language);
+        assert_eq!(Some("-fatbin"), a.compilation_flag.to_str());
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
+        assert!(a.preprocessor_args.is_empty());
+        assert_eq!(ovec!["-fatbin"], a.common_args);
+    }
+
+    #[test]
+    fn test_parse_arguments_cubin_compile_flag() {
+        let a = parses!("-x", "cu", "-cubin", "foo.c", "-o", "foo.o");
+        assert_eq!(Some("foo.c"), a.input.to_str());
+        assert_eq!(Language::Cuda, a.language);
+        assert_eq!(Some("-cubin"), a.compilation_flag.to_str());
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
+        assert!(a.preprocessor_args.is_empty());
+        assert_eq!(ovec!["-cubin"], a.common_args);
+    }
+
+    #[test]
     fn test_parse_arguments_values() {
         let a = parses!(
             "-c",

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -70,14 +70,12 @@ impl CCompilerImpl for Nvcc {
             CompilerArguments::Ok(pargs) => {
                 if pargs.compilation_flag != "-c" {
                     let mut new_args = pargs.clone();
-                    new_args.common_args.push(pargs.compilation_flag.clone());
+                    new_args.common_args.push(pargs.compilation_flag);
                     return CompilerArguments::Ok(new_args);
                 }
-                return CompilerArguments::Ok(pargs);
+                CompilerArguments::Ok(pargs)
             }
-            CompilerArguments::CannotCache(_, _) | CompilerArguments::NotCompilation => {
-                return parsed_args;
-            }
+            CompilerArguments::CannotCache(_, _) | CompilerArguments::NotCompilation => parsed_args,
         }
     }
 


### PR DESCRIPTION
These compilation modes have different output from the compiler but the same input. So we add the compilation mode flag to the `common_args` when it doesn't match the default mode ( -c )