### PR TITLE
Fix detection of clang version and v14+ unit tests

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -63,7 +63,7 @@ impl Clang {
             None => return false,
         };
 
-        let parsed_version = match Version::parse(version_str) {
+        let parsed_version = match Version::parse(version_str.trim_end_matches('"')) {
             Ok(parsed_version) => parsed_version,
             Err(e) => return false,
         };

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -254,40 +254,34 @@ mod test {
 
     #[test]
     fn test_is_minversion() {
-        assert_eq!(
-            Clang {
-                clangplusplus: false,
-                is_appleclang: false,
-                version: Some("\"Ubuntu Clang 14.0.0\"".to_string()),
-            }
-            .is_minversion(14),
-            true
-        );
-        assert_eq!(
-            Clang {
-                clangplusplus: false,
-                is_appleclang: false,
-                version: Some("\"Ubuntu Clang 13.0.0\"".to_string()),
-            }
-            .is_minversion(14),
-            false
-        );
-        assert_eq!(Clang {
+        assert!(Clang {
+            clangplusplus: false,
+            is_appleclang: false,
+            version: Some("\"Ubuntu Clang 14.0.0\"".to_string()),
+        }
+        .is_minversion(14));
+        assert!(!Clang {
+            clangplusplus: false,
+            is_appleclang: false,
+            version: Some("\"Ubuntu Clang 13.0.0\"".to_string()),
+        }
+        .is_minversion(14));
+        assert!(Clang {
             clangplusplus: false,
             is_appleclang: false,
             version: Some("\"FreeBSD Clang 14.0.5 (https://github.com/llvm/llvm-project.git llvmorg-14.0.5-0-gc12386ae247c)\"".to_string()),
-        }.is_minversion(14), true);
-        assert_eq!(Clang {
+        }.is_minversion(14));
+        assert!(!Clang {
             clangplusplus: false,
             is_appleclang: false,
             version: Some("\"FreeBSD Clang 13.0.0 (git@github.com:llvm/llvm-project.git llvmorg-13.0.0-0-gd7b669b3a303)\"".to_string()),
-        }.is_minversion(14), false);
+        }.is_minversion(14));
 
-        assert_eq!(Clang {
+        assert!(!Clang {
             clangplusplus: false,
             is_appleclang: true,
             version: Some("\"FreeBSD Clang 14.0.5 (https://github.com/llvm/llvm-project.git llvmorg-14.0.5-0-gc12386ae247c)\"".to_string()),
-        }.is_minversion(14), false); // is_appleclang wins
+        }.is_minversion(14)); // is_appleclang wins
     }
 
     #[test]

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -253,6 +253,44 @@ mod test {
     }
 
     #[test]
+    fn test_is_minversion() {
+        assert_eq!(
+            Clang {
+                clangplusplus: false,
+                is_appleclang: false,
+                version: Some("\"Ubuntu Clang 14.0.0\"".to_string()),
+            }
+            .is_minversion(14),
+            true
+        );
+        assert_eq!(
+            Clang {
+                clangplusplus: false,
+                is_appleclang: false,
+                version: Some("\"Ubuntu Clang 13.0.0\"".to_string()),
+            }
+            .is_minversion(14),
+            false
+        );
+        assert_eq!(Clang {
+            clangplusplus: false,
+            is_appleclang: false,
+            version: Some("\"FreeBSD Clang 14.0.5 (https://github.com/llvm/llvm-project.git llvmorg-14.0.5-0-gc12386ae247c)\"".to_string()),
+        }.is_minversion(14), true);
+        assert_eq!(Clang {
+            clangplusplus: false,
+            is_appleclang: false,
+            version: Some("\"FreeBSD Clang 13.0.0 (git@github.com:llvm/llvm-project.git llvmorg-13.0.0-0-gd7b669b3a303)\"".to_string()),
+        }.is_minversion(14), false);
+
+        assert_eq!(Clang {
+            clangplusplus: false,
+            is_appleclang: true,
+            version: Some("\"FreeBSD Clang 14.0.5 (https://github.com/llvm/llvm-project.git llvmorg-14.0.5-0-gc12386ae247c)\"".to_string()),
+        }.is_minversion(14), false); // is_appleclang wins
+    }
+
+    #[test]
     fn test_parse_arguments_simple() {
         let a = parses!("-c", "foo.c", "-o", "foo.o");
         assert_eq!(Some("foo.c"), a.input.to_str());

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -415,8 +415,8 @@ fn run_sccache_command_tests(compiler: Compiler, tempdir: &Path) {
     }
 
     // If we are testing with clang-14 or later, we expect the -fminimize-whitespace flag to be used.
-    if compiler.name == "clang" {
-        let version_cmd = Command::new(compiler.name)
+    if compiler.name == "clang" || compiler.name == "clang++" {
+        let version_cmd = Command::new(compiler.exe.clone())
             .arg("--version")
             .output()
             .expect("Failure when getting compiler version");
@@ -432,7 +432,7 @@ fn run_sccache_command_tests(compiler: Compiler, tempdir: &Path) {
         let (major, is_appleclang) = match re.captures(version_output) {
             Some(c) => (
                 c.name("major").unwrap().as_str().parse::<usize>().unwrap(),
-                c.name("apple").is_none(),
+                c.name("apple").is_some(),
             ),
             None => panic!(
                 "Version info not found in --version output: {}",

--- a/tests/test_clang_multicall.c
+++ b/tests/test_clang_multicall.c
@@ -1,7 +1,7 @@
 #include <iostream>
 
 // this is c++ code, but the extension is .c,
-// so clang doesn't change it's behavior because of the extension
+// so clang doesn't change its behavior because of the extension
 
 int main() {
     std::cout << "Hello, world!" << std::endl;


### PR DESCRIPTION
Compiler version (`__VERSION__`) is always enclosed in quotes.
This only fixes version detection for clang to keep the scope small.
Stripping quotes could also be done globally in compiler.rs.