### PR TITLE
 Add MacPorts as a new installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ On macOS sccache can be installed via [Homebrew](https://brew.sh/):
 brew install sccache
 ```
 
+or via [MacPorts](https://www.macports.org/):
+
+```bash
+sudo port install sccache
+```
+
 ### Windows
 
 On Windows, sccache can be installed via [scoop](https://scoop.sh/):


### PR DESCRIPTION
I have updated sccache to the latest version in macports/macports-ports#20343. Now users can install the latest version of sccache through MacPorts. This PR add this information to the README.

Also, I will do my best to keep up with the release.