### PR TITLE
Support msvc as the host compiler for nvcc

### DIFF
--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -263,7 +263,11 @@ mod test {
 
     fn parse_arguments_(arguments: Vec<String>) -> CompilerArguments<ParsedArguments> {
         let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
-        Nvcc { is_msvc: false, version: None }.parse_arguments(&arguments, ".".as_ref())
+        Nvcc {
+            is_msvc: false,
+            version: None,
+        }
+        .parse_arguments(&arguments, ".".as_ref())
     }
 
     macro_rules! parses {

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -39,6 +39,7 @@ use crate::errors::*;
 /// A unit struct on which to implement `CCompilerImpl`.
 #[derive(Clone, Debug)]
 pub struct Nvcc {
+    pub is_msvc: bool,
     pub version: Option<String>,
 }
 
@@ -148,8 +149,12 @@ impl CCompilerImpl for Nvcc {
 
         //NVCC only supports `-E` when it comes after preprocessor
         //and common flags.
+        let no_line_nums = match self.is_msvc {
+            true => "-Xcompiler=-EP",
+            false => "-Xcompiler=-P",
+        };
         cmd.arg("-E")
-            .arg("-Xcompiler=-P")
+            .arg(no_line_nums)
             .env_clear()
             .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
             .current_dir(cwd);
@@ -258,7 +263,7 @@ mod test {
 
     fn parse_arguments_(arguments: Vec<String>) -> CompilerArguments<ParsedArguments> {
         let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
-        Nvcc { version: None }.parse_arguments(&arguments, ".".as_ref())
+        Nvcc { is_msvc: false, version: None }.parse_arguments(&arguments, ".".as_ref())
     }
 
     macro_rules! parses {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -77,7 +77,9 @@ fn compile_cmdline<T: AsRef<OsStr>>(
     mut extra_args: Vec<OsString>,
 ) -> Vec<OsString> {
     let mut arg = match compiler {
-        "gcc" | "clang" | "clang++" | "nvcc" => vec_from!(OsString, exe.as_ref(), "-c", input, "-o", output),
+        "gcc" | "clang" | "clang++" | "nvcc" => {
+            vec_from!(OsString, exe.as_ref(), "-c", input, "-o", output)
+        }
         "cl.exe" => vec_from!(OsString, exe, "-c", input, format!("-Fo{}", output)),
         _ => panic!("Unsupported compiler: {}", compiler),
     };
@@ -94,8 +96,8 @@ const INPUT_WITH_WHITESPACE_ALT: &str = "test_whitespace_alt.c";
 const INPUT_ERR: &str = "test_err.c";
 const INPUT_MACRO_EXPANSION: &str = "test_macro_expansion.c";
 const INPUT_WITH_DEFINE: &str = "test_with_define.c";
-const INPUT_FOR_CUDA_A : &str = "test_a.cu";
-const INPUT_FOR_CUDA_B : &str = "test_b.cu";
+const INPUT_FOR_CUDA_A: &str = "test_a.cu";
+const INPUT_FOR_CUDA_B: &str = "test_b.cu";
 const OUTPUT: &str = "test.o";
 
 // Copy the source files into the tempdir so we can compile with relative paths, since the commandline winds up in the hash key.
@@ -450,7 +452,6 @@ fn run_sccache_command_tests(compiler: Compiler, tempdir: &Path) {
     }
 }
 
-
 fn test_cuda_compiles(compiler: Compiler, tempdir: &Path) {
     let Compiler {
         name,
@@ -464,7 +465,13 @@ fn test_cuda_compiles(compiler: Compiler, tempdir: &Path) {
     let out_file = tempdir.join(OUTPUT);
     trace!("compile A");
     sccache_command()
-        .args(&compile_cmdline(name, &exe, INPUT_FOR_CUDA_A, OUTPUT, Vec::new()))
+        .args(&compile_cmdline(
+            name,
+            &exe,
+            INPUT_FOR_CUDA_A,
+            OUTPUT,
+            Vec::new(),
+        ))
         .current_dir(tempdir)
         .envs(env_vars.clone())
         .assert()
@@ -481,7 +488,13 @@ fn test_cuda_compiles(compiler: Compiler, tempdir: &Path) {
     trace!("compile A");
     fs::remove_file(&out_file).unwrap();
     sccache_command()
-        .args(&compile_cmdline(name, &exe, INPUT_FOR_CUDA_A, OUTPUT, Vec::new()))
+        .args(&compile_cmdline(
+            name,
+            &exe,
+            INPUT_FOR_CUDA_A,
+            OUTPUT,
+            Vec::new(),
+        ))
         .current_dir(tempdir)
         .envs(env_vars.clone())
         .assert()
@@ -500,7 +513,13 @@ fn test_cuda_compiles(compiler: Compiler, tempdir: &Path) {
     // phase is correctly running and outputing text
     trace!("compile B");
     sccache_command()
-        .args(&compile_cmdline(name, &exe, INPUT_FOR_CUDA_B, OUTPUT, Vec::new()))
+        .args(&compile_cmdline(
+            name,
+            &exe,
+            INPUT_FOR_CUDA_B,
+            OUTPUT,
+            Vec::new(),
+        ))
         .current_dir(tempdir)
         .envs(env_vars)
         .assert()
@@ -516,7 +535,6 @@ fn test_cuda_compiles(compiler: Compiler, tempdir: &Path) {
         assert_eq!(&2, info.stats.cache_misses.get("CUDA").unwrap());
     });
 }
-
 
 fn run_sccache_cuda_command_tests(compiler: Compiler, tempdir: &Path) {
     test_cuda_compiles(compiler, tempdir);

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -519,7 +519,7 @@ fn test_cuda_compiles(compiler: Compiler, tempdir: &Path) {
 
 
 fn run_sccache_cuda_command_tests(compiler: Compiler, tempdir: &Path) {
-    test_cuda_compiles(compiler.clone(), tempdir);
+    test_cuda_compiles(compiler, tempdir);
 }
 
 fn test_clang_multicall(compiler: Compiler, tempdir: &Path) {

--- a/tests/test_a.cu
+++ b/tests/test_a.cu
@@ -1,0 +1,10 @@
+
+#include <stdio.h>
+#include "cuda_runtime.h"
+
+__global__ void cuda_entry_point(int*, int*) {}
+__device__ void cuda_device_func(int*, int*) {}
+
+int main() {
+  printf("%s says hello world\n", __FILE__);
+}

--- a/tests/test_b.cu
+++ b/tests/test_b.cu
@@ -1,0 +1,10 @@
+
+#include <stdio.h>
+#include "cuda_runtime.h"
+
+__global__ void cuda_entry_point(int*, int*) {}
+__device__ void cuda_device_func(int*, int*) {}
+
+int main() {
+  printf("%s says hello world\n", __FILE__);
+}


### PR DESCRIPTION
To support MSVC as the nvcc host compiler we need to pass `-EP` for the pre-processing step. If we pass `-P` the pre-processor will place the output in `<input_file>.i` and not the requested output file given by `-o`.