### PR TITLE
Support nvc++ and msvc as nvcc host compilers

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1086,7 +1086,8 @@ where
     //
     // We prefix the information we need with `compiler_id` and `compiler_version`
     // so that we can support compilers that insert pre-amble code even in `-E` mode
-    let test = b"#if defined(__NVCC__) && defined(__NVCOMPILER)
+    let test = b"
+#if defined(__NVCC__) && defined(__NVCOMPILER)
 compiler_id=nvcc-nvhpc
 #elif defined(__NVCC__) && defined(_MSC_VER)
 compiler_id=nvcc-msvc

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1233,14 +1233,14 @@ compiler_version=__VERSION__
             }
             "nvcc" | "nvcc-msvc" | "nvcc-nvhpc" => {
                 let host_compiler = match kind {
-                    "nvcc-nvhpc" => NvccHostCompiler::NVHPC,
-                    "nvcc-msvc" => NvccHostCompiler::MSVC,
-                    "nvcc" => NvccHostCompiler::GCC,
-                    &_ => NvccHostCompiler::GCC,
+                    "nvcc-nvhpc" => NvccHostCompiler::Nvhpc,
+                    "nvcc-msvc" => NvccHostCompiler::Msvc,
+                    "nvcc" => NvccHostCompiler::Gcc,
+                    &_ => NvccHostCompiler::Gcc,
                 };
                 return CCompiler::new(
                     Nvcc {
-                        host_compiler: host_compiler,
+                        host_compiler,
                         version: version.clone(),
                     },
                     executable,

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -39,9 +39,9 @@ use crate::errors::*;
 /// A unit struct on which to implement `CCompilerImpl`.
 #[derive(Clone, Debug)]
 pub enum NvccHostCompiler {
-    GCC,
-    MSVC,
-    NVHPC,
+    Gcc,
+    Msvc,
+    Nvhpc,
 }
 
 #[derive(Clone, Debug)]
@@ -161,9 +161,9 @@ impl CCompilerImpl for Nvcc {
         // msvc requires the `-EP` flag to output no line numbers to console
         // other host compilers are presumed to match `gcc` behavior
         let no_line_num_flag = match self.host_compiler {
-            NvccHostCompiler::NVHPC => "",
-            NvccHostCompiler::MSVC => "-Xcompiler=-EP",
-            NvccHostCompiler::GCC => "-Xcompiler=-P",
+            NvccHostCompiler::Nvhpc => "",
+            NvccHostCompiler::Msvc => "-Xcompiler=-EP",
+            NvccHostCompiler::Gcc => "-Xcompiler=-P",
         };
         cmd.arg("-E")
             .arg(no_line_num_flag)
@@ -277,7 +277,7 @@ mod test {
     fn parse_arguments_gcc(arguments: Vec<String>) -> CompilerArguments<ParsedArguments> {
         let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
         Nvcc {
-            host_compiler: NvccHostCompiler::GCC,
+            host_compiler: NvccHostCompiler::Gcc,
             version: None,
         }
         .parse_arguments(&arguments, ".".as_ref())
@@ -285,7 +285,7 @@ mod test {
     fn parse_arguments_nvc(arguments: Vec<String>) -> CompilerArguments<ParsedArguments> {
         let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
         Nvcc {
-            host_compiler: NvccHostCompiler::NVHPC,
+            host_compiler: NvccHostCompiler::Nvhpc,
             version: None,
         }
         .parse_arguments(&arguments, ".".as_ref())

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -38,8 +38,15 @@ use crate::errors::*;
 
 /// A unit struct on which to implement `CCompilerImpl`.
 #[derive(Clone, Debug)]
+pub enum NvccHostCompiler {
+    GCC,
+    MSVC,
+    NVHPC,
+}
+
+#[derive(Clone, Debug)]
 pub struct Nvcc {
-    pub is_msvc: bool,
+    pub host_compiler: NvccHostCompiler,
     pub version: Option<String>,
 }
 
@@ -149,12 +156,17 @@ impl CCompilerImpl for Nvcc {
 
         //NVCC only supports `-E` when it comes after preprocessor
         //and common flags.
-        let no_line_nums = match self.is_msvc {
-            true => "-Xcompiler=-EP",
-            false => "-Xcompiler=-P",
+        //
+        // nvc/nvc++  don't support no line numbers to console
+        // msvc requires the `-EP` flag to output no line numbers to console
+        // other host compilers are presumed to match `gcc` behavior
+        let no_line_num_flag = match self.host_compiler {
+            NvccHostCompiler::NVHPC => "",
+            NvccHostCompiler::MSVC => "-Xcompiler=-EP",
+            NvccHostCompiler::GCC => "-Xcompiler=-P",
         };
         cmd.arg("-E")
-            .arg(no_line_nums)
+            .arg(no_line_num_flag)
             .env_clear()
             .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
             .current_dir(cwd);
@@ -262,10 +274,18 @@ mod test {
     use std::collections::HashMap;
     use std::path::PathBuf;
 
-    fn parse_arguments_(arguments: Vec<String>) -> CompilerArguments<ParsedArguments> {
+    fn parse_arguments_gcc(arguments: Vec<String>) -> CompilerArguments<ParsedArguments> {
         let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
         Nvcc {
-            is_msvc: false,
+            host_compiler: NvccHostCompiler::GCC,
+            version: None,
+        }
+        .parse_arguments(&arguments, ".".as_ref())
+    }
+    fn parse_arguments_nvc(arguments: Vec<String>) -> CompilerArguments<ParsedArguments> {
+        let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
+        Nvcc {
+            host_compiler: NvccHostCompiler::NVHPC,
             version: None,
         }
         .parse_arguments(&arguments, ".".as_ref())
@@ -273,7 +293,15 @@ mod test {
 
     macro_rules! parses {
         ( $( $s:expr ),* ) => {
-            match parse_arguments_(vec![ $( $s.to_string(), )* ]) {
+            match parse_arguments_gcc(vec![ $( $s.to_string(), )* ]) {
+                CompilerArguments::Ok(a) => a,
+                o => panic!("Got unexpected parse result: {:?}", o),
+            }
+        }
+    }
+    macro_rules! parses_nvc {
+        ( $( $s:expr ),* ) => {
+            match parse_arguments_nvc(vec![ $( $s.to_string(), )* ]) {
                 CompilerArguments::Ok(a) => a,
                 o => panic!("Got unexpected parse result: {:?}", o),
             }
@@ -300,8 +328,27 @@ mod test {
     }
 
     #[test]
-    fn test_parse_arguments_simple_cu() {
+    fn test_parse_arguments_simple_cu_gcc() {
         let a = parses!("-c", "foo.cu", "-o", "foo.o");
+        assert_eq!(Some("foo.cu"), a.input.to_str());
+        assert_eq!(Language::Cuda, a.language);
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
+        assert!(a.preprocessor_args.is_empty());
+        assert!(a.common_args.is_empty());
+    }
+
+    #[test]
+    fn test_parse_arguments_simple_cu_nvc() {
+        let a = parses_nvc!("-c", "foo.cu", "-o", "foo.o");
         assert_eq!(Some("foo.cu"), a.input.to_str());
         assert_eq!(Language::Cuda, a.language);
         assert_map_contains!(
@@ -663,7 +710,18 @@ mod test {
     fn test_parse_dlink_is_not_compilation() {
         assert_eq!(
             CompilerArguments::NotCompilation,
-            parse_arguments_(stringvec![
+            parse_arguments_gcc(stringvec![
+                "-forward-unknown-to-host-compiler",
+                "--generate-code=arch=compute_50,code=[compute_50,sm_50,sm_52]",
+                "-dlink",
+                "main.cu.o",
+                "-o",
+                "device_link.o"
+            ])
+        );
+        assert_eq!(
+            CompilerArguments::NotCompilation,
+            parse_arguments_nvc(stringvec![
                 "-forward-unknown-to-host-compiler",
                 "--generate-code=arch=compute_50,code=[compute_50,sm_50,sm_52]",
                 "-dlink",
@@ -677,12 +735,20 @@ mod test {
     fn test_parse_cant_cache_flags() {
         assert_eq!(
             CompilerArguments::CannotCache("-E", None),
-            parse_arguments_(stringvec!["-x", "cu", "-c", "foo.c", "-o", "foo.o", "-E"])
+            parse_arguments_gcc(stringvec!["-x", "cu", "-c", "foo.c", "-o", "foo.o", "-E"])
+        );
+        assert_eq!(
+            CompilerArguments::CannotCache("-E", None),
+            parse_arguments_nvc(stringvec!["-x", "cu", "-c", "foo.c", "-o", "foo.o", "-E"])
         );
 
         assert_eq!(
             CompilerArguments::CannotCache("-M", None),
-            parse_arguments_(stringvec!["-x", "cu", "-c", "foo.c", "-o", "foo.o", "-M"])
+            parse_arguments_gcc(stringvec!["-x", "cu", "-c", "foo.c", "-o", "foo.o", "-M"])
+        );
+        assert_eq!(
+            CompilerArguments::CannotCache("-M", None),
+            parse_arguments_nvc(stringvec!["-x", "cu", "-c", "foo.c", "-o", "foo.o", "-M"])
         );
     }
 }

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -213,6 +213,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("--maxrregcount", OsString, CanBeSeparated('='), PassThrough),
     flag!("--no-host-device-initializer-list", PreprocessorArgumentFlag),
     take_arg!("--nvlink-options", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("--options-file", PathBuf, CanBeSeparated('='), ExtraHashFile),
     flag!("--optix-ir", DoCompilation),
     flag!("--ptx", DoCompilation),
     take_arg!("--ptxas-options", OsString, CanBeSeparated('='), PassThrough),

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -226,7 +226,7 @@ fn test_server_compile() {
     {
         let mut c = server_creator.lock().unwrap();
         // The server will check the compiler. Pretend it's GCC.
-        c.next_command_spawns(Ok(MockChild::new(exit_status(0), "gcc", "")));
+        c.next_command_spawns(Ok(MockChild::new(exit_status(0), "compiler_id=gcc", "")));
         // Preprocessor invocation.
         c.next_command_spawns(Ok(MockChild::new(
             exit_status(0),

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -77,7 +77,9 @@ fn compile_cmdline<T: AsRef<OsStr>>(
     mut extra_args: Vec<OsString>,
 ) -> Vec<OsString> {
     let mut arg = match compiler {
-        "gcc" | "clang" | "clang++" | "nvcc" => vec_from!(OsString, exe.as_ref(), "-c", input, "-o", output),
+        "gcc" | "clang" | "clang++" | "nvcc" => {
+            vec_from!(OsString, exe.as_ref(), "-c", input, "-o", output)
+        }
         "cl.exe" => vec_from!(OsString, exe, "-c", input, format!("-Fo{}", output)),
         _ => panic!("Unsupported compiler: {}", compiler),
     };
@@ -94,8 +96,8 @@ const INPUT_WITH_WHITESPACE_ALT: &str = "test_whitespace_alt.c";
 const INPUT_ERR: &str = "test_err.c";
 const INPUT_MACRO_EXPANSION: &str = "test_macro_expansion.c";
 const INPUT_WITH_DEFINE: &str = "test_with_define.c";
-const INPUT_FOR_CUDA_A : &str = "test_a.cu";
-const INPUT_FOR_CUDA_B : &str = "test_b.cu";
+const INPUT_FOR_CUDA_A: &str = "test_a.cu";
+const INPUT_FOR_CUDA_B: &str = "test_b.cu";
 const OUTPUT: &str = "test.o";
 
 // Copy the source files into the tempdir so we can compile with relative paths, since the commandline winds up in the hash key.
@@ -450,7 +452,6 @@ fn run_sccache_command_tests(compiler: Compiler, tempdir: &Path) {
     }
 }
 
-
 fn test_cuda_compiles(compiler: Compiler, tempdir: &Path) {
     let Compiler {
         name,
@@ -464,7 +465,13 @@ fn test_cuda_compiles(compiler: Compiler, tempdir: &Path) {
     let out_file = tempdir.join(OUTPUT);
     trace!("compile A");
     sccache_command()
-        .args(&compile_cmdline(name, &exe, INPUT_FOR_CUDA_A, OUTPUT, Vec::new()))
+        .args(&compile_cmdline(
+            name,
+            &exe,
+            INPUT_FOR_CUDA_A,
+            OUTPUT,
+            Vec::new(),
+        ))
         .current_dir(tempdir)
         .envs(env_vars.clone())
         .assert()
@@ -481,7 +488,13 @@ fn test_cuda_compiles(compiler: Compiler, tempdir: &Path) {
     trace!("compile A");
     fs::remove_file(&out_file).unwrap();
     sccache_command()
-        .args(&compile_cmdline(name, &exe, INPUT_FOR_CUDA_A, OUTPUT, Vec::new()))
+        .args(&compile_cmdline(
+            name,
+            &exe,
+            INPUT_FOR_CUDA_A,
+            OUTPUT,
+            Vec::new(),
+        ))
         .current_dir(tempdir)
         .envs(env_vars.clone())
         .assert()
@@ -500,7 +513,13 @@ fn test_cuda_compiles(compiler: Compiler, tempdir: &Path) {
     // phase is correctly running and outputing text
     trace!("compile B");
     sccache_command()
-        .args(&compile_cmdline(name, &exe, INPUT_FOR_CUDA_B, OUTPUT, Vec::new()))
+        .args(&compile_cmdline(
+            name,
+            &exe,
+            INPUT_FOR_CUDA_B,
+            OUTPUT,
+            Vec::new(),
+        ))
         .current_dir(tempdir)
         .envs(env_vars)
         .assert()
@@ -517,9 +536,8 @@ fn test_cuda_compiles(compiler: Compiler, tempdir: &Path) {
     });
 }
 
-
 fn run_sccache_cuda_command_tests(compiler: Compiler, tempdir: &Path) {
-    test_cuda_compiles(compiler.clone(), tempdir);
+    test_cuda_compiles(compiler, tempdir);
 }
 
 fn test_clang_multicall(compiler: Compiler, tempdir: &Path) {

--- a/tests/test_a.cu
+++ b/tests/test_a.cu
@@ -1,0 +1,10 @@
+
+#include <stdio.h>
+#include "cuda_runtime.h"
+
+__global__ void cuda_entry_point(int*, int*) {}
+__device__ void cuda_device_func(int*, int*) {}
+
+int main() {
+  printf("%s says hello world\n", __FILE__);
+}

--- a/tests/test_b.cu
+++ b/tests/test_b.cu
@@ -1,0 +1,10 @@
+
+#include <stdio.h>
+#include "cuda_runtime.h"
+
+__global__ void cuda_entry_point(int*, int*) {}
+__device__ void cuda_device_func(int*, int*) {}
+
+int main() {
+  printf("%s says hello world\n", __FILE__);
+}


### PR DESCRIPTION
Continues the work of https://github.com/mozilla/sccache/pull/1884

Extends the nvcc compiler to understand the unique requirements of using `nvc++` or `cl.exe` ( msvc ) as the host compiler. 

Due to the fact that  `nvc++`  pre-processing always has force includes the compiler detection can't presume that the first line of the file will hold the compiler id string. So we instead search for lines starting with a unique starting text.

