### PR TITLE
services/gcs: Fix typo in to_scope

### DIFF
--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -30,7 +30,7 @@ pub enum RWMode {
 impl RWMode {
     fn to_scope(self) -> &'static str {
         match self {
-            RWMode::ReadOnly => "https://www.googleapis.com/auth/devstorage.readonly",
+            RWMode::ReadOnly => "https://www.googleapis.com/auth/devstorage.read_only",
             RWMode::ReadWrite => "https://www.googleapis.com/auth/devstorage.read_write",
         }
     }


### PR DESCRIPTION
Closes https://github.com/mozilla/sccache/issues/1886