### PR TITLE
Add nvc and nvc++ as supported C/C++ compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ export RUSTC_WRAPPER=/path/to/sccache
 cargo build
 ```
 
-sccache supports gcc, clang, MSVC, rustc, NVCC, and [Wind River's diab compiler](https://www.windriver.com/products/development-tools/#diab_compiler). Both gcc and msvc support Response Files, read more about their implementation [here](docs/ResponseFiles.md).
+sccache supports gcc, clang, MSVC, rustc, [NVCC](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html), [NVC++](https://docs.nvidia.com/hpc-sdk//compilers/hpc-compilers-user-guide/index.html), and [Wind River's diab compiler](https://www.windriver.com/products/development-tools/#diab_compiler). Both gcc and msvc support Response Files, read more about their implementation [here](docs/ResponseFiles.md).
 
 If you don't [specify otherwise](#storage-options), sccache will use a local disk cache.
 

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -190,6 +190,8 @@ pub enum CCompilerKind {
     Msvc,
     /// NVIDIA cuda compiler
     Nvcc,
+    /// NVIDIA hpc c, c++ compiler
+    Nvhpc,
     /// Tasking VX
     TaskingVX,
 }
@@ -680,6 +682,15 @@ impl pkg::ToolchainPackager for CToolchainPackager {
                 add_named_file(&mut package_builder, "fatbinary")?;
                 add_named_prog(&mut package_builder, "nvlink")?;
                 add_named_prog(&mut package_builder, "ptxas")?;
+            }
+
+            CCompilerKind::Nvhpc => {
+                // Various programs called by the nvc nvc++ front end.
+                add_named_file(&mut package_builder, "cpp1")?;
+                add_named_file(&mut package_builder, "cpp2")?;
+                add_named_file(&mut package_builder, "opt")?;
+                add_named_prog(&mut package_builder, "llc")?;
+                add_named_prog(&mut package_builder, "acclnk")?;
             }
 
             _ => unreachable!(),

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -23,6 +23,7 @@ mod diab;
 mod gcc;
 mod msvc;
 mod nvcc;
+mod nvhpc;
 mod rust;
 mod tasking_vx;
 #[macro_use]

--- a/src/compiler/nvhpc.rs
+++ b/src/compiler/nvhpc.rs
@@ -1,0 +1,390 @@
+// Copyright 2016 Mozilla Foundation
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(unused_imports, dead_code, unused_variables)]
+
+use crate::compiler::args::*;
+use crate::compiler::c::{
+    ArtifactDescriptor, CCompilerImpl, CCompilerKind, Language, ParsedArguments,
+};
+use crate::compiler::gcc::ArgData::*;
+use crate::compiler::{gcc, write_temp_file, Cacheable, CompileCommand, CompilerArguments};
+use crate::mock_command::{CommandCreator, CommandCreatorSync, RunCommand};
+use crate::util::{run_input_output, OsStrExt};
+use crate::{counted_array, dist};
+use async_trait::async_trait;
+use fs::File;
+use fs_err as fs;
+use log::Level::Trace;
+use std::ffi::OsString;
+use std::future::Future;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process;
+
+use crate::errors::*;
+
+/// A unit struct on which to implement `CCompilerImpl`.
+#[derive(Clone, Debug)]
+pub struct Nvhpc {
+    /// true iff this is nvc++.
+    pub nvcplusplus: bool,
+    pub version: Option<String>,
+}
+
+#[async_trait]
+impl CCompilerImpl for Nvhpc {
+    fn kind(&self) -> CCompilerKind {
+        CCompilerKind::Nvhpc
+    }
+    fn plusplus(&self) -> bool {
+        self.nvcplusplus
+    }
+    fn version(&self) -> Option<String> {
+        self.version.clone()
+    }
+    fn parse_arguments(
+        &self,
+        arguments: &[OsString],
+        cwd: &Path,
+    ) -> CompilerArguments<ParsedArguments> {
+        gcc::parse_arguments(
+            arguments,
+            cwd,
+            (&gcc::ARGS[..], &ARGS[..]),
+            self.nvcplusplus,
+            self.kind(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn preprocess<T>(
+        &self,
+        creator: &T,
+        executable: &Path,
+        parsed_args: &ParsedArguments,
+        cwd: &Path,
+        env_vars: &[(OsString, OsString)],
+        may_dist: bool,
+        rewrite_includes_only: bool,
+    ) -> Result<process::Output>
+    where
+        T: CommandCreatorSync,
+    {
+        let language = match parsed_args.language {
+            Language::C => Ok("c"),
+            Language::Cxx => Ok("c++"),
+            Language::ObjectiveC => Ok("objective-c"),
+            Language::ObjectiveCxx => Ok("objective-c++"),
+            Language::Cuda => Err(anyhow!("CUDA compilation not supported by nvhpc")),
+            _ => Err(anyhow!("PCH not supported by nvhpc")),
+        }?;
+
+        let initialize_cmd_and_args = || {
+            let mut command = creator.clone().new_command_sync(executable);
+            command.args(&parsed_args.preprocessor_args);
+            command.args(&parsed_args.common_args);
+            command.arg("-x").arg(language).arg(&parsed_args.input);
+
+            command
+        };
+
+        let dep_before_preprocessor = || {
+            //nvhpc doesn't support generating both the dependency information
+            //and the preprocessor output at the same time. So if we have
+            //need for both we need separate compiler invocations
+            let mut dep_cmd = initialize_cmd_and_args();
+            let mut transformed_deps = vec![];
+            for item in parsed_args.dependency_args.iter() {
+                if item == "-MD" {
+                    transformed_deps.push(OsString::from("-M"));
+                } else if item == "-MMD" {
+                    transformed_deps.push(OsString::from("-MM"));
+                } else {
+                    transformed_deps.push(item.clone());
+                }
+            }
+            dep_cmd
+                .args(&transformed_deps)
+                .env_clear()
+                .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
+                .current_dir(cwd);
+
+            if log_enabled!(Trace) {
+                trace!("dep-gen command: {:?}", dep_cmd);
+            }
+            dep_cmd
+        };
+
+        trace!("preprocess");
+        let mut cmd = initialize_cmd_and_args();
+
+        //NVHPC doesn't support disabling line info when outputing to console
+        cmd.arg("-E")
+            .env_clear()
+            .envs(env_vars.iter().map(|&(ref k, ref v)| (k, v)))
+            .current_dir(cwd);
+        if log_enabled!(Trace) {
+            trace!("preprocess: {:?}", cmd);
+        }
+
+        //Need to chain the dependency generation and the preprocessor
+        //to emulate a `proper` front end
+        if !parsed_args.dependency_args.is_empty() {
+            let first = run_input_output(dep_before_preprocessor(), None);
+            let second = run_input_output(cmd, None);
+            // TODO: If we need to chain these to emulate a frontend, shouldn't
+            // we explicitly wait on the first one before starting the second one?
+            // (rather than via which drives these concurrently)
+            let (_f, s) = futures::future::try_join(first, second).await?;
+            Ok(s)
+        } else {
+            run_input_output(cmd, None).await
+        }
+    }
+
+    fn generate_compile_commands(
+        &self,
+        path_transformer: &mut dist::PathTransformer,
+        executable: &Path,
+        parsed_args: &ParsedArguments,
+        cwd: &Path,
+        env_vars: &[(OsString, OsString)],
+        rewrite_includes_only: bool,
+    ) -> Result<(CompileCommand, Option<dist::CompileCommand>, Cacheable)> {
+        gcc::generate_compile_commands(
+            path_transformer,
+            executable,
+            parsed_args,
+            cwd,
+            env_vars,
+            self.kind(),
+            rewrite_includes_only,
+        )
+    }
+}
+
+counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
+    //todo: refactor show_includes into dependency_args
+    take_arg!("--gcc-toolchain", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("--include-path", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+    take_arg!("--linker-options", OsString, CanBeSeparated, PassThrough),
+    take_arg!("--system-include-path", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
+
+    take_arg!("-Mconcur", OsString, CanBeSeparated('='), PassThrough),
+    flag!("-Mnostdlib", PreprocessorArgumentFlag),
+    take_arg!("-Werror", OsString, CanBeSeparated, PreprocessorArgument),
+    take_arg!("-Xcompiler", OsString, CanBeSeparated('='), PreprocessorArgument),
+    take_arg!("-Xfatbinary", OsString, CanBeSeparated, PassThrough),
+    take_arg!("-Xlinker", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-Xnvlink", OsString, CanBeSeparated, PassThrough),
+    take_arg!("-Xptxas", OsString, CanBeSeparated, PassThrough),
+    take_arg!("-acc", OsString, CanBeSeparated('='), PassThrough),
+    flag!("-acclibs", PassThroughFlag),
+    take_arg!("-c++", OsString, Concatenated, Standard),
+    flag!("-c++libs", PassThroughFlag),
+    flag!("-cuda", PreprocessorArgumentFlag),
+    flag!("-cudaforlibs", PassThroughFlag),
+    take_arg!("-cudalib", OsString, CanBeSeparated('='), PassThrough),
+    flag!("-fortranlibs", PassThroughFlag),
+    flag!("-gopt", PassThroughFlag),
+    take_arg!("-gpu", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-mcmodel", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-mcpu", OsString, CanBeSeparated('='), PassThrough),
+    flag!("-noswitcherror", PassThroughFlag),
+    take_arg!("-ta", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-target", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-tp", OsString, CanBeSeparated('='), PassThrough),
+    take_arg!("-x", OsString, CanBeSeparated('='), Language)
+]);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::compiler::gcc;
+    use crate::compiler::*;
+    use crate::mock_command::*;
+    use crate::test::utils::*;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    fn parse_arguments_(arguments: Vec<String>) -> CompilerArguments<ParsedArguments> {
+        let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
+        Nvhpc {
+            nvcplusplus: false,
+            version: None,
+        }
+        .parse_arguments(&arguments, ".".as_ref())
+    }
+
+    macro_rules! parses {
+        ( $( $s:expr ),* ) => {
+            match parse_arguments_(vec![ $( $s.to_string(), )* ]) {
+                CompilerArguments::Ok(a) => a,
+                o => panic!("Got unexpected parse result: {:?}", o),
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_arguments_simple_c() {
+        let a = parses!("-c", "foo.c", "-o", "foo.o");
+        assert_eq!(Some("foo.c"), a.input.to_str());
+        assert_eq!(Language::C, a.language);
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
+        assert!(a.preprocessor_args.is_empty());
+        assert!(a.common_args.is_empty());
+    }
+
+    #[test]
+    fn test_parse_arguments_simple_cxx() {
+        let a = parses!("-c", "foo.cxx", "-o", "foo.o");
+        assert_eq!(Some("foo.cxx"), a.input.to_str());
+        assert_eq!(Language::Cxx, a.language);
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
+        assert!(a.preprocessor_args.is_empty());
+        assert!(a.common_args.is_empty());
+    }
+
+    #[test]
+    fn test_parse_arguments_values() {
+        let a = parses!(
+            "-c",
+            "foo.cpp",
+            "-fabc",
+            "-I",
+            "include-file",
+            "-o",
+            "foo.o",
+            "--include-path",
+            "include-file",
+            "-isystem",
+            "/system/include/file",
+            "-gpu=ccnative",
+            "-Werror",
+            "an_error"
+        );
+        assert_eq!(Some("foo.cpp"), a.input.to_str());
+        assert_eq!(Language::Cxx, a.language);
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
+        assert_eq!(
+            ovec![
+                "-Iinclude-file",
+                "--include-path",
+                "include-file",
+                "-isystem",
+                "/system/include/file",
+                "-Werror",
+                "an_error"
+            ],
+            a.preprocessor_args
+        );
+        assert!(a.dependency_args.is_empty());
+        assert_eq!(ovec!["-fabc", "-gpu", "ccnative"], a.common_args);
+    }
+
+    #[test]
+    fn test_parse_md_mt_flags_cxx() {
+        let a = parses!(
+            "-x", "c++", "-c", "foo.c", "-fabc", "-MD", "-MT", "foo.o", "-MF", "foo.o.d", "-o",
+            "foo.o"
+        );
+        assert_eq!(Some("foo.c"), a.input.to_str());
+        assert_eq!(Language::Cxx, a.language);
+        assert_eq!(Some("-c"), a.compilation_flag.to_str());
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
+        assert_eq!(
+            ovec!["-MD", "-MF", "foo.o.d", "-MT", "foo.o"],
+            a.dependency_args
+        );
+        assert_eq!(ovec!["-fabc"], a.common_args);
+    }
+
+    #[test]
+    fn test_parse_generate_code_flags() {
+        let a = parses!(
+            "-x",
+            "c++",
+            "-cuda",
+            "-gpu=cc60,cc70",
+            "-c",
+            "foo.c",
+            "-o",
+            "foo.o"
+        );
+        assert_eq!(Some("foo.c"), a.input.to_str());
+        assert_eq!(Language::Cxx, a.language);
+        assert_map_contains!(
+            a.outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: "foo.o".into(),
+                    optional: false
+                }
+            )
+        );
+        assert_eq!(ovec!["-cuda"], a.preprocessor_args);
+        assert_eq!(ovec!["-gpu", "cc60,cc70"], a.common_args);
+    }
+
+    #[test]
+    fn test_parse_cant_cache_flags() {
+        assert_eq!(
+            CompilerArguments::CannotCache("-E", None),
+            parse_arguments_(stringvec!["-c", "foo.c", "-o", "foo.o", "-E"])
+        );
+        assert_eq!(
+            CompilerArguments::CannotCache("-M", None),
+            parse_arguments_(stringvec!["-c", "foo.c", "-o", "foo.o", "-M"])
+        );
+    }
+}

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -51,7 +51,7 @@ struct Compiler {
 
 // Test GCC + clang on non-OS X platforms.
 #[cfg(all(unix, not(target_os = "macos")))]
-const COMPILERS: &[&str] = &["gcc", "clang", "clang++"];
+const COMPILERS: &[&str] = &["gcc", "clang", "clang++", "nvc", "nvc++"];
 
 // OS X ships a `gcc` that's just a clang wrapper, so only test clang there.
 #[cfg(target_os = "macos")]
@@ -77,7 +77,7 @@ fn compile_cmdline<T: AsRef<OsStr>>(
     mut extra_args: Vec<OsString>,
 ) -> Vec<OsString> {
     let mut arg = match compiler {
-        "gcc" | "clang" | "clang++" | "nvcc" => {
+        "gcc" | "clang" | "clang++" | "nvc" | "nvc++" | "nvcc" => {
             vec_from!(OsString, exe.as_ref(), "-c", input, "-o", output)
         }
         "cl.exe" => vec_from!(OsString, exe, "-c", input, format!("-Fo{}", output)),


### PR DESCRIPTION
Currently based on https://github.com/mozilla/sccache/pull/1889 to get the refactoring of the compiler detection needed to support `nvc`, and `nvc++`.

The nvhpc compiler suite has implicit force includes which effects the pre-processor output  as seen below:
```
root@6c8ec2a4e037:~# cat test.cpp 
root@6c8ec2a4e037:~# nvc -E test.cpp 
# 1 "test.cpp"
# 1 "/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/include/_cplus_macros.h" 1 3
# 1 "test.cpp" 2
# 1 "/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/include/_cplus_preinclude.h" 1 3
 

struct __va_list_tag {
  unsigned int gp_offset;
  unsigned int fp_offset;
  char *overflow_arg_area;
  char *reg_save_area;
};

# 27 "/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/include/_cplus_preinclude.h" 3

typedef struct __va_list_tag __pgi_va_list[1];

# 41 "/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/include/_cplus_preinclude.h" 3

# 1 "test.cpp" 2
```
