### PR TITLE
compiler cache stats now display information on a per lang+compiler basis

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -441,6 +441,10 @@ where
     fn box_clone(&self) -> Box<dyn CompilerHasher<T>> {
         Box::new((*self).clone())
     }
+
+    fn language(&self) -> &'static str {
+        return self.parsed_args.language.as_str();
+    }
 }
 
 impl<I: CCompilerImpl> Compilation for CCompilation<I> {

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -101,13 +101,17 @@ pub enum CompilerKind {
 }
 
 impl CompilerKind {
-    pub fn lang_kind(&self) -> String {
+    pub fn lang_kind(&self, lang: &'static str) -> String {
+        let lang_and_compiler = lang.to_string();
         match self {
-            CompilerKind::C(CCompilerKind::Nvcc) => "CUDA",
-            CompilerKind::C(_) => "C/C++",
-            CompilerKind::Rust => "Rust",
+            CompilerKind::C(CCompilerKind::Clang) => lang_and_compiler + " [clang]",
+            CompilerKind::C(CCompilerKind::Diab) => lang_and_compiler + " [diab]",
+            CompilerKind::C(CCompilerKind::Gcc) => lang_and_compiler + " [gcc]",
+            CompilerKind::C(CCompilerKind::Msvc) => lang_and_compiler + " [msvc]",
+            CompilerKind::C(CCompilerKind::Nvcc) => lang_and_compiler + " [nvcc]",
+            CompilerKind::C(CCompilerKind::TaskingVX) => lang_and_compiler + " [taskingVX]",
+            CompilerKind::Rust => "Rust".to_string(),
         }
-        .to_string()
     }
 }
 
@@ -425,6 +429,8 @@ where
     fn output_pretty(&self) -> Cow<'_, str>;
 
     fn box_clone(&self) -> Box<dyn CompilerHasher<T>>;
+
+    fn language(&self) -> &'static str;
 }
 
 #[cfg(not(feature = "dist-client"))]

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1589,6 +1589,10 @@ where
     fn box_clone(&self) -> Box<dyn CompilerHasher<T>> {
         Box::new((*self).clone())
     }
+
+    fn language(&self) -> &'static str {
+        return "Rust";
+    }
 }
 
 impl Compilation for RustCompilation {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1164,6 +1164,7 @@ where
         let color_mode = hasher.color_mode();
         let me = self.clone();
         let kind = compiler.kind();
+        let lang = hasher.language();
         let creator = self.creator.clone();
         let storage = self.storage.clone();
         let pool = self.rt.clone();
@@ -1199,12 +1200,12 @@ where
                         CompileResult::Error => {
                             debug!("compile result: cache error");
 
-                            stats.cache_errors.increment(&kind);
+                            stats.cache_errors.increment(&kind, &lang);
                         }
                         CompileResult::CacheHit(duration) => {
                             debug!("compile result: cache hit");
 
-                            stats.cache_hits.increment(&kind);
+                            stats.cache_hits.increment(&kind, &lang);
                             stats.cache_read_hit_duration += duration;
                         }
                         CompileResult::CacheMiss(miss_type, dist_type, duration, future) => {
@@ -1229,10 +1230,10 @@ where
                                     stats.cache_timeouts += 1;
                                 }
                                 MissType::CacheReadError => {
-                                    stats.cache_errors.increment(&kind);
+                                    stats.cache_errors.increment(&kind, &lang);
                                 }
                             }
-                            stats.cache_misses.increment(&kind);
+                            stats.cache_misses.increment(&kind, &lang);
                             stats.compiler_write_duration += duration;
                             debug!("stats after compile result: {stats:?}");
                             cache_write = Some(future);
@@ -1240,7 +1241,7 @@ where
                         CompileResult::NotCacheable => {
                             debug!("compile result: not cacheable");
 
-                            stats.cache_misses.increment(&kind);
+                            stats.cache_misses.increment(&kind, &lang);
                             stats.non_cacheable_compilations += 1;
                         }
                         CompileResult::CompileFailed => {
@@ -1298,7 +1299,7 @@ where
                                     error!("[{:?}] \t{}", out_pretty, e);
                                     let _ = writeln!(error, "sccache: caused by: {}", e);
                                 }
-                                stats.cache_errors.increment(&kind);
+                                stats.cache_errors.increment(&kind, &lang);
                                 //TODO: figure out a better way to communicate this?
                                 res.retcode = Some(-2);
                                 res.stderr = error.into_bytes();
@@ -1353,8 +1354,8 @@ pub struct PerLanguageCount {
 }
 
 impl PerLanguageCount {
-    fn increment(&mut self, kind: &CompilerKind) {
-        let key = kind.lang_kind();
+    fn increment(&mut self, kind: &CompilerKind, lang: &'static str) {
+        let key = kind.lang_kind(lang);
         let count = self.counts.entry(key).or_insert(0);
         *count += 1;
     }


### PR DESCRIPTION
So with the proposed expansion of clang as a CUDA compiler ( https://github.com/mozilla/sccache/pull/1892 ) I have noticed that the stats tracking for `sccache` binned the clang++ cuda compilations as a C/C++ invocation due to the presumption that the clang compiler meant `C/C++`.

So this PR breaks down stats to be tracked on a way finer granulatiry so that people can see exactly what compinations of language + compiler are causing hits or misses.