### PR TITLE
Adding /Zl and /d1trimfile for MSVC compiler (addresses #1899)

### DIFF
--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -458,6 +458,7 @@ msvc_args!(static ARGS: [ArgInfo<ArgData>; _] = [
     msvc_take_arg!("Zc:", OsString, Concatenated, PassThroughWithSuffix),
     msvc_flag!("Ze", PassThrough),
     msvc_flag!("Zi", DebugInfo),
+    msvc_flag!("Zl", PassThrough), // omit default library name in .obj
     msvc_take_arg!("Zm", OsString, Concatenated, PassThroughWithSuffix),
     msvc_flag!("Zo", PassThrough),
     msvc_flag!("Zo-", PassThrough),
@@ -479,6 +480,8 @@ msvc_args!(static ARGS: [ArgInfo<ArgData>; _] = [
     msvc_flag!("clr", PassThrough),
     msvc_take_arg!("clr:", OsString, Concatenated, PassThroughWithSuffix),
     msvc_take_arg!("constexpr:", OsString, Concatenated, PassThroughWithSuffix),
+    msvc_take_arg!("d1nodatetime", PassThrough),
+    msvc_take_arg!("d1trimfile:", PathBuf, Concatenated, PreprocessorArgumentPath), // used to trim leading path for __FILE__ macro: see https://stackoverflow.com/a/68695554
     msvc_take_arg!("deps", PathBuf, Concatenated, DepFile),
     msvc_take_arg!("diagnostics:", OsString, Concatenated, PassThroughWithSuffix),
     msvc_take_arg!("doc", PathBuf, Concatenated, TooHardPath), // Creates an .xdc file.


### PR DESCRIPTION
- `/Zl` is used to omit the default library name (given a specified runtime, such as with `/MT`)
- `/d1trimfile:` is used to trim the leading path whereever the `__FILE__` macro is used

------

Please provide some guidance in case adjustments are required. This addresses part of #1899. I don't know why it shows "multiple input files", however. It's very misleading.