### PR TITLE
sccache 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "sccache"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "sccache"
 rust-version = "1.67.1"
-version = "0.5.4"
+version = "0.6.0"
 
 categories = ["command-line-utilities", "development-tools::build-utils"]
 description = "Sccache is a ccache-like tool. It is used as a compiler wrapper and avoids compilation when possible, storing a cache in a remote storage using various cloud storage."


### PR DESCRIPTION
bumping the version because of the recent changes from Nvidia by @robertmaynard and @miscco

I will probably make a version 1.0.0 once https://github.com/mozilla/sccache/pull/1882 lands (cc @Alphare )
