### PR TITLE
Enable running sccache-dist in Docker.

### DIFF
--- a/docs/DistributedQuickstart.md
+++ b/docs/DistributedQuickstart.md
@@ -75,6 +75,12 @@ cache_dir = "/tmp/toolchains"
 # toolchain_cache_size = 10737418240
 # A public IP address and port that clients will use to connect to this builder.
 public_addr = "192.168.1.1:10501"
+
+# The address this builder will listen on.
+# If unspecified the default is `public_addr`.
+# If you are running builder in Docker, you need to set this to `0.0.0.0:10501`
+bind_addr = "192.168.1.1:10501"
+
 # The URL used to connect to the scheduler (should use https, given an ideal
 # setup of a HTTPS server in front of the scheduler)
 scheduler_url = "https://192.168.1.1"

--- a/src/bin/sccache-dist/main.rs
+++ b/src/bin/sccache-dist/main.rs
@@ -225,10 +225,12 @@ fn run(command: Command) -> Result<i32> {
             builder,
             cache_dir,
             public_addr,
+            bind_addr,
             scheduler_url,
             scheduler_auth,
             toolchain_cache_size,
         }) => {
+            let bind_addr = bind_addr.unwrap_or_else(|| public_addr);
             let builder: Box<dyn dist::BuilderIncoming> = match builder {
                 #[cfg(not(target_os = "freebsd"))]
                 server_config::BuilderType::Docker => {
@@ -289,6 +291,7 @@ fn run(command: Command) -> Result<i32> {
                 .context("Failed to create sccache server instance")?;
             let http_server = dist::http::Server::new(
                 public_addr,
+                bind_addr,
                 scheduler_url.to_url(),
                 scheduler_auth,
                 server,

--- a/src/bin/sccache-dist/token_check.rs
+++ b/src/bin/sccache-dist/token_check.rs
@@ -100,7 +100,7 @@ impl MozillaCheck {
     pub fn new(required_groups: Vec<String>) -> Self {
         Self {
             auth_cache: Mutex::new(HashMap::new()),
-            client: new_reqwest_blocking_client(),
+            client: new_reqwest_blocking_client(None),
             required_groups,
         }
     }
@@ -269,7 +269,7 @@ impl ProxyTokenCheck {
         let maybe_auth_cache: Option<Mutex<(HashMap<String, Instant>, Duration)>> =
             cache_secs.map(|secs| Mutex::new((HashMap::new(), Duration::from_secs(secs))));
         Self {
-            client: new_reqwest_blocking_client(),
+            client: new_reqwest_blocking_client(None),
             maybe_auth_cache,
             url,
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1165,6 +1165,7 @@ pub mod server {
         pub builder: BuilderType,
         pub cache_dir: PathBuf,
         pub public_addr: SocketAddr,
+        pub bind_addr: Option<SocketAddr>,
         pub scheduler_url: HTTPUrl,
         pub scheduler_auth: SchedulerAuth,
         #[serde(default = "default_toolchain_cache_size")]

--- a/src/dist/client_auth.rs
+++ b/src/dist/client_auth.rs
@@ -246,7 +246,7 @@ mod code_grant_pkce {
             grant_type: GRANT_TYPE_PARAM_VALUE,
             redirect_uri,
         };
-        let client = new_reqwest_blocking_client();
+        let client = new_reqwest_blocking_client(None);
         let res = client.post(token_url).json(&token_request).send()?;
         if !res.status().is_success() {
             bail!(

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -195,6 +195,7 @@ fn sccache_server_cfg(
         },
         cache_dir: Path::new(CONFIGS_CONTAINER_PATH).join(relpath),
         public_addr: SocketAddr::new(server_ip, SERVER_PORT),
+        bind_addr: None,
         scheduler_url,
         scheduler_auth: sccache::config::server::SchedulerAuth::Token {
             token: DIST_SERVER_TOKEN.to_owned(),
@@ -409,9 +410,14 @@ impl DistSystem {
             listener.local_addr().unwrap()
         };
         let token = create_server_token(ServerId::new(server_addr), DIST_SERVER_TOKEN);
-        let server =
-            dist::http::Server::new(server_addr, self.scheduler_url().to_url(), token, handler)
-                .unwrap();
+        let server = dist::http::Server::new(
+            server_addr,
+            server_addr,
+            self.scheduler_url().to_url(),
+            token,
+            handler,
+        )
+        .unwrap();
         let pid = match unsafe { nix::unistd::fork() }.unwrap() {
             ForkResult::Parent { child } => {
                 self.server_pids.push(child);


### PR DESCRIPTION
# Enable running sccache-dist in Docker.

## Description

When deploying sccache-dist using Docker on a machine, I noticed that the `public_addr` field passed from the build server to the scheduler is the same as the local address that sccache-dist is listening on. However, since the IP address of the Docker container is not the same as the physical machine's IP address, it cannot bind to it. To address this issue, I added an optional field called `bind_addr`. If this field is empty, its default value is set to `public_addr`. If sccache-dist is running inside a Docker container, users only need to set it to `0.0.0.0:port`.

I believe this is helpful for exposing the sccache-dist compilation cluster behind an access gateway using port mapping because it no longer requires the sccache-dist build server to run on a specific separate public IP address.

## What I do

1. Add 'bind_addr' param to 'sccache-dist server'.
2. Set `X-real-ip` header when 'bind_addr' is set.