### PR TITLE
Activate preprocessor cache mode by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2390,6 +2390,7 @@ dependencies = [
  "tar",
  "temp-env",
  "tempfile",
+ "test-case",
  "thirtyfour_sync",
  "tokio",
  "tokio-serde",
@@ -2788,6 +2789,41 @@ name = "termtree"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
+
+[[package]]
+name = "test-case"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8f1e820b7f1d95a0cdbf97a5df9de10e1be731983ab943e56703ac1b8e9d425"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c25e2cb8f5fcd7318157634e8838aa6f7e4715c96637f969fabaccd1ef5462"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37cfd7bbc88a0104e304229fba519bdc45501a30b760fb72240342f1289ad257"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+ "test-case-core",
+]
 
 [[package]]
 name = "thirtyfour"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ version-compare = { version = "0.1.1", optional = true }
 assert_cmd = "2.0.12"
 cc = "1.0"
 chrono = "0.4.26"
+filetime = "0.2"
 itertools = "0.10"
 predicates = "=3.0.3"
 serial_test = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ itertools = "0.10"
 predicates = "=3.0.3"
 serial_test = "2.0"
 temp-env = "0.3.4"
+test-case = "3.2.1"
 thirtyfour_sync = "0.27"
 
 [target.'cfg(unix)'.dependencies]
@@ -137,16 +138,7 @@ features = ["fileapi", "handleapi", "stringapiset", "winnls"]
 version = "0.3"
 
 [features]
-all = [
-  "dist-client",
-  "redis",
-  "s3",
-  "memcached",
-  "gcs",
-  "azure",
-  "gha",
-  "webdav",
-]
+all = ["dist-client", "redis", "s3", "memcached", "gcs", "azure", "gha", "webdav"]
 azure = ["opendal", "reqsign"]
 default = ["all"]
 gcs = ["opendal", "reqsign", "url", "reqwest/blocking", "trust-dns-resolver"]
@@ -163,27 +155,9 @@ vendored-openssl = ["openssl?/vendored", "opendal?/native-tls-vendored"]
 # Enable features that require unstable features of Nightly Rust.
 unstable = []
 # Enables distributed support in the sccache client
-dist-client = [
-  "flate2",
-  "hyper",
-  "reqwest",
-  "url",
-  "sha2",
-  "trust-dns-resolver",
-]
+dist-client = ["flate2", "hyper", "reqwest", "url", "sha2", "trust-dns-resolver"]
 # Enables the sccache-dist binary
-dist-server = [
-  "jwt",
-  "flate2",
-  "libmount",
-  "nix",
-  "openssl",
-  "reqwest",
-  "rouille",
-  "syslog",
-  "trust-dns-resolver",
-  "version-compare",
-]
+dist-server = ["jwt", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "trust-dns-resolver", "version-compare"]
 # Enables dist tests with external requirements
 dist-tests = ["dist-client", "dist-server"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,16 @@ features = ["fileapi", "handleapi", "stringapiset", "winnls"]
 version = "0.3"
 
 [features]
-all = ["dist-client", "redis", "s3", "memcached", "gcs", "azure", "gha", "webdav"]
+all = [
+  "dist-client",
+  "redis",
+  "s3",
+  "memcached",
+  "gcs",
+  "azure",
+  "gha",
+  "webdav",
+]
 azure = ["opendal", "reqsign"]
 default = ["all"]
 gcs = ["opendal", "reqsign", "url", "reqwest/blocking", "trust-dns-resolver"]
@@ -155,9 +164,27 @@ vendored-openssl = ["openssl?/vendored", "opendal?/native-tls-vendored"]
 # Enable features that require unstable features of Nightly Rust.
 unstable = []
 # Enables distributed support in the sccache client
-dist-client = ["flate2", "hyper", "reqwest", "url", "sha2", "trust-dns-resolver"]
+dist-client = [
+  "flate2",
+  "hyper",
+  "reqwest",
+  "url",
+  "sha2",
+  "trust-dns-resolver",
+]
 # Enables the sccache-dist binary
-dist-server = ["jwt", "flate2", "libmount", "nix", "openssl", "reqwest", "rouille", "syslog", "trust-dns-resolver", "version-compare"]
+dist-server = [
+  "jwt",
+  "flate2",
+  "libmount",
+  "nix",
+  "openssl",
+  "reqwest",
+  "rouille",
+  "syslog",
+  "trust-dns-resolver",
+  "version-compare",
+]
 # Enables dist tests with external requirements
 dist-tests = ["dist-client", "dist-server"]
 

--- a/docs/Local.md
+++ b/docs/Local.md
@@ -30,7 +30,7 @@ Preprocessor cache mode will be disabled if any of the following holds:
 
 Configuration options and their default values:
 
-- `use_preprocessor_cache_mode`: `false`. Whether to use preprocessor cache mode entirely.
+- `use_preprocessor_cache_mode`: `true`. Whether to use preprocessor cache mode entirely.
 - `file_stat_matches`: `false`. If false, only compare header files by hashing their contents. If true, will use size + ctime + mtime to check whether a file has changed. See other flags below for more control over this behavior.
 - `use_ctime_for_stat`: `true`. If true, uses the ctime (file status change on UNIX, creation time on Windows) to check that a file has/hasn't changed. Can be useful to disable when backdating modification times in a controlled manner.
 

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -366,7 +366,7 @@ pub trait Storage: Send + Sync {
 
     /// Return the config for preprocessor cache mode if applicable
     fn preprocessor_cache_mode_config(&self) -> PreprocessorCacheModeConfig {
-        // Disabled by default, only enabled in local mode
+        // Enabled by default, only enabled in local mode
         PreprocessorCacheModeConfig::default()
     }
     /// Return the preprocessor cache entry for a given preprocessor key,
@@ -421,7 +421,7 @@ pub struct PreprocessorCacheModeConfig {
 impl Default for PreprocessorCacheModeConfig {
     fn default() -> Self {
         Self {
-            use_preprocessor_cache_mode: false,
+            use_preprocessor_cache_mode: true,
             file_stat_matches: false,
             use_ctime_for_stat: true,
             ignore_time_macros: false,

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1677,6 +1677,8 @@ LLVM version: 6.0",
         let pool = runtime.handle();
         let arguments = ovec!["-c", "foo.c", "-o", "foo.o"];
         let cwd = f.tempdir.path();
+        // Write a dummy input file so the preprocessor cache mode can work
+        std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
 
         let results: Vec<_> = [11, 12]
             .iter()
@@ -1754,6 +1756,8 @@ LLVM version: 6.0",
             &pool,
             Default::default(),
         );
+        // Write a dummy input file so the preprocessor cache mode can work
+        std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
         let storage = Arc::new(storage);
         // Pretend to be GCC.
         next_command(
@@ -1873,6 +1877,8 @@ LLVM version: 6.0",
             &pool,
             Default::default(),
         );
+        // Write a dummy input file so the preprocessor cache mode can work
+        std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
         let storage = Arc::new(storage);
         // Pretend to be GCC.
         next_command(
@@ -1984,6 +1990,8 @@ LLVM version: 6.0",
         let pool = runtime.handle().clone();
         let storage = MockStorage::new(None);
         let storage: Arc<MockStorage> = Arc::new(storage);
+        // Write a dummy input file so the preprocessor cache mode can work
+        std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
         // Pretend to be GCC.
         next_command(
             &creator,
@@ -2064,6 +2072,8 @@ LLVM version: 6.0",
         let f = TestFixture::new();
         let runtime = Runtime::new().unwrap();
         let pool = runtime.handle().clone();
+        // Write a dummy input file so the preprocessor cache mode can work
+        std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
         // Make our storage wait 2ms for each get/put operation.
         let storage_delay = Duration::from_millis(2);
         let storage = MockStorage::new(Some(storage_delay));
@@ -2149,6 +2159,8 @@ LLVM version: 6.0",
             Default::default(),
         );
         let storage = Arc::new(storage);
+        // Write a dummy input file so the preprocessor cache mode can work
+        std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
         // Pretend to be GCC.
         next_command(
             &creator,
@@ -2271,6 +2283,8 @@ LLVM version: 6.0",
         // Pretend to be GCC.  Also inject a fake object file that the subsequent
         // preprocessor failure should remove.
         let obj = f.tempdir.path().join("foo.o");
+        // Write a dummy input file so the preprocessor cache mode can work
+        std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
         let o = obj.clone();
         next_command_calls(&creator, move |_| {
             let mut f = File::create(&o)?;
@@ -2346,6 +2360,8 @@ LLVM version: 6.0",
             test_dist::ErrorSubmitToolchainClient::new(),
             test_dist::ErrorRunJobClient::new(),
         ];
+        // Write a dummy input file so the preprocessor cache mode can work
+        std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
         let storage = DiskCache::new(
             f.tempdir.path().join("cache"),
             u64::MAX,

--- a/src/compiler/preprocessor_cache.rs
+++ b/src/compiler/preprocessor_cache.rs
@@ -416,7 +416,8 @@ pub fn preprocessor_cache_entry_hash_key(
     let mut buf = vec![];
     encode_path(&mut buf, input_file)?;
     m.update(&buf);
-    let reader = std::fs::File::open(input_file).context("while hashing the input file")?;
+    let reader = std::fs::File::open(input_file)
+        .with_context(|| format!("while hashing the input file '{}'", input_file.display()))?;
 
     let digest = if config.ignore_time_macros {
         Digest::reader_sync(reader)?

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -2435,6 +2435,7 @@ mod test {
     use std::ffi::OsStr;
     use std::io::{self, Write};
     use std::sync::{Arc, Mutex};
+    use test_case::test_case;
 
     fn _parse_arguments(arguments: &[String]) -> CompilerArguments<ParsedArguments> {
         let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
@@ -3076,8 +3077,9 @@ proc_macro false
         );
     }
 
-    #[test]
-    fn test_generate_hash_key() {
+    #[test_case(true ; "with preprocessor cache")]
+    #[test_case(false ; "without preprocessor cache")]
+    fn test_generate_hash_key(preprocessor_cache_mode: bool) {
         use ar::{Builder, Header};
         drop(env_logger::try_init());
         let f = TestFixture::new();
@@ -3160,7 +3162,7 @@ proc_macro false
                 false,
                 &pool,
                 false,
-                Arc::new(MockStorage::new(None)),
+                Arc::new(MockStorage::new(None, preprocessor_cache_mode)),
                 CacheControl::Default,
             )
             .wait()
@@ -3205,6 +3207,7 @@ proc_macro false
         args: &[&'static str],
         env_vars: &[(OsString, OsString)],
         pre_func: F,
+        preprocessor_cache_mode: bool,
     ) -> String
     where
         F: Fn(&Path) -> Result<()>,
@@ -3251,7 +3254,7 @@ proc_macro false
                 false,
                 &pool,
                 false,
-                Arc::new(MockStorage::new(None)),
+                Arc::new(MockStorage::new(None, preprocessor_cache_mode)),
                 CacheControl::Default,
             )
             .wait()
@@ -3264,8 +3267,9 @@ proc_macro false
         Ok(())
     }
 
-    #[test]
-    fn test_equal_hashes_externs() {
+    #[test_case(true ; "with preprocessor cache")]
+    #[test_case(false ; "without preprocessor cache")]
+    fn test_equal_hashes_externs(preprocessor_cache_mode: bool) {
         // Put some content in the extern rlibs so we can verify that the content hashes are
         // used in the right order.
         fn mk_files(tempdir: &Path) -> Result<()> {
@@ -3293,7 +3297,8 @@ proc_macro false
                     "b=b.rlib"
                 ],
                 &[],
-                mk_files
+                mk_files,
+                preprocessor_cache_mode,
             ),
             hash_key(
                 &f,
@@ -3313,13 +3318,15 @@ proc_macro false
                     "lib"
                 ],
                 &[],
-                mk_files
+                mk_files,
+                preprocessor_cache_mode,
             )
         );
     }
 
-    #[test]
-    fn test_equal_hashes_link_paths() {
+    #[test_case(true ; "with preprocessor cache")]
+    #[test_case(false ; "without preprocessor cache")]
+    fn test_equal_hashes_link_paths(preprocessor_cache_mode: bool) {
         let f = TestFixture::new();
         assert_eq!(
             hash_key(
@@ -3340,7 +3347,8 @@ proc_macro false
                     "y=y"
                 ],
                 &[],
-                nothing
+                nothing,
+                preprocessor_cache_mode,
             ),
             hash_key(
                 &f,
@@ -3360,13 +3368,15 @@ proc_macro false
                     "lib"
                 ],
                 &[],
-                nothing
+                nothing,
+                preprocessor_cache_mode,
             )
         );
     }
 
-    #[test]
-    fn test_equal_hashes_ignored_args() {
+    #[test_case(true ; "with preprocessor cache")]
+    #[test_case(false ; "without preprocessor cache")]
+    fn test_equal_hashes_ignored_args(preprocessor_cache_mode: bool) {
         let f = TestFixture::new();
         assert_eq!(
             hash_key(
@@ -3389,7 +3399,8 @@ proc_macro false
                     "y=y"
                 ],
                 &[],
-                nothing
+                nothing,
+                preprocessor_cache_mode,
             ),
             hash_key(
                 &f,
@@ -3411,13 +3422,15 @@ proc_macro false
                     "lib"
                 ],
                 &[],
-                nothing
+                nothing,
+                preprocessor_cache_mode,
             )
         );
     }
 
-    #[test]
-    fn test_equal_hashes_cfg_features() {
+    #[test_case(true ; "with preprocessor cache")]
+    #[test_case(false ; "without preprocessor cache")]
+    fn test_equal_hashes_cfg_features(preprocessor_cache_mode: bool) {
         let f = TestFixture::new();
         assert_eq!(
             hash_key(
@@ -3438,7 +3451,8 @@ proc_macro false
                     "feature=b"
                 ],
                 &[],
-                nothing
+                nothing,
+                preprocessor_cache_mode,
             ),
             hash_key(
                 &f,
@@ -3458,7 +3472,8 @@ proc_macro false
                     "lib"
                 ],
                 &[],
-                nothing
+                nothing,
+                preprocessor_cache_mode,
             )
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,8 @@ use std::result::Result as StdResult;
 use std::str::FromStr;
 use std::sync::Mutex;
 
-use crate::{cache::PreprocessorCacheModeConfig, errors::*};
+pub use crate::cache::PreprocessorCacheModeConfig;
+use crate::errors::*;
 
 static CACHED_CONFIG_PATH: Lazy<PathBuf> = Lazy::new(CachedConfig::file_config_path);
 static CACHED_CONFIG: Lazy<Mutex<Option<CachedFileConfig>>> = Lazy::new(|| Mutex::new(None));

--- a/src/test/mock_storage.rs
+++ b/src/test/mock_storage.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::cache::{Cache, CacheWrite, Storage};
+use crate::cache::{Cache, CacheWrite, PreprocessorCacheModeConfig, Storage};
 use crate::errors::*;
 use async_trait::async_trait;
 use futures::channel::mpsc;
@@ -26,16 +26,18 @@ pub struct MockStorage {
     rx: Arc<Mutex<mpsc::UnboundedReceiver<Result<Cache>>>>,
     tx: mpsc::UnboundedSender<Result<Cache>>,
     delay: Option<Duration>,
+    preprocessor_cache_mode: bool,
 }
 
 impl MockStorage {
     /// Create a new `MockStorage`. if `delay` is `Some`, wait for that amount of time before returning from operations.
-    pub(crate) fn new(delay: Option<Duration>) -> MockStorage {
+    pub(crate) fn new(delay: Option<Duration>, preprocessor_cache_mode: bool) -> MockStorage {
         let (tx, rx) = mpsc::unbounded();
         Self {
             tx,
             rx: Arc::new(Mutex::new(rx)),
             delay,
+            preprocessor_cache_mode,
         }
     }
 
@@ -71,5 +73,11 @@ impl Storage for MockStorage {
     }
     async fn max_size(&self) -> Result<Option<u64>> {
         Ok(None)
+    }
+    fn preprocessor_cache_mode_config(&self) -> PreprocessorCacheModeConfig {
+        PreprocessorCacheModeConfig {
+            use_preprocessor_cache_mode: self.preprocessor_cache_mode,
+            ..Default::default()
+        }
     }
 }

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -229,6 +229,8 @@ fn test_server_compile() {
     const STDOUT: &[u8] = b"some stdout";
     const STDERR: &[u8] = b"some stderr";
     let conn = connect_to_server(port).unwrap();
+    // Write a dummy input file so the preprocessor cache mode can work
+    std::fs::write(f.tempdir.path().join("file.c"), "whatever").unwrap();
     {
         let mut c = server_creator.lock().unwrap();
         // The server will check the compiler. Pretend it's GCC.

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -52,7 +52,7 @@ pub fn dist_test_sccache_client_cfg(
     tmpdir: &Path,
     scheduler_url: HTTPUrl,
 ) -> sccache::config::FileConfig {
-    let mut sccache_cfg = harness::sccache_client_cfg(tmpdir);
+    let mut sccache_cfg = harness::sccache_client_cfg(tmpdir, false);
     sccache_cfg.cache.disk.as_mut().unwrap().size = 0;
     sccache_cfg.dist.scheduler_url = Some(scheduler_url);
     sccache_cfg

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -128,7 +128,10 @@ pub fn sccache_dist_path() -> PathBuf {
     assert_cmd::cargo::cargo_bin("sccache-dist")
 }
 
-pub fn sccache_client_cfg(tmpdir: &Path) -> sccache::config::FileConfig {
+pub fn sccache_client_cfg(
+    tmpdir: &Path,
+    preprocessor_cache_mode: bool,
+) -> sccache::config::FileConfig {
     let cache_relpath = "client-cache";
     let dist_cache_relpath = "client-dist-cache";
     fs::create_dir(tmpdir.join(cache_relpath)).unwrap();
@@ -136,6 +139,10 @@ pub fn sccache_client_cfg(tmpdir: &Path) -> sccache::config::FileConfig {
 
     let disk_cache = sccache::config::DiskCacheConfig {
         dir: tmpdir.join(cache_relpath),
+        preprocessor_cache_mode: sccache::config::PreprocessorCacheModeConfig {
+            use_preprocessor_cache_mode: preprocessor_cache_mode,
+            ..Default::default()
+        },
         ..Default::default()
     };
     sccache::config::FileConfig {


### PR DESCRIPTION
Preprocessor cache mode (or "direct mode" in ccache speak), offers a measurable improvement for C/C++ caching.

A non-scientific test of compiling Firefox on a Ryzen 7950x with hot caches saw this mode changing the wall time from ~48s to ~13s. This is the overall time spent in `mach build` with the only work needed is to recompile all C++, kinda like so:

```
$ mach build
[...]
$ fd '\.o$' obj-* | xargs rm && time ./mach build
```

As noted in the docs, this applies only to local storage.