### PR TITLE
Fix off-by-one in line number replacement code

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -684,7 +684,7 @@ fn process_preprocessor_line(
             // Replace the line number with the usual one.
             digest.update(&bytes[hash_start..start]);
             start += 1;
-            bytes[start..start + 2].copy_from_slice(b"# 1");
+            bytes[start..=start + 2].copy_from_slice(b"# 1");
             hash_start = start;
             slice = &bytes[start..];
         }


### PR DESCRIPTION
Going through the current code fails with:
```
thread 'tokio-runtime-worker' panicked at src/compiler/c.rs:687:37:
source slice length (3) does not match destination slice length (2)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```