### PR TITLE
Changes to the local daemon setup in the test harness

### DIFF
--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -46,11 +46,11 @@ pub fn start_local_daemon(cfg_path: &Path, cached_cfg_path: &Path) {
     if !sccache_command()
         .arg("--start-server")
         // Uncomment following lines to debug locally.
-        .env("SCCACHE_LOG", "debug")
-        .env(
-            "SCCACHE_ERROR_LOG",
-            env::temp_dir().join("sccache_local_daemon.txt"),
-        )
+        // .env("SCCACHE_LOG", "debug")
+        // .env(
+        //     "SCCACHE_ERROR_LOG",
+        //     env::temp_dir().join("sccache_local_daemon.txt"),
+        // )
         .env("SCCACHE_CONF", cfg_path)
         .env("SCCACHE_CACHED_CONF", cached_cfg_path)
         .status()

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -47,7 +47,10 @@ pub fn start_local_daemon(cfg_path: &Path, cached_cfg_path: &Path) {
         .arg("--start-server")
         // Uncomment following lines to debug locally.
         .env("SCCACHE_LOG", "debug")
-        .env("SCCACHE_ERROR_LOG", "/tmp/sccache_local_daemon.txt")
+        .env(
+            "SCCACHE_ERROR_LOG",
+            env::temp_dir().join("sccache_local_daemon.txt"),
+        )
         .env("SCCACHE_CONF", cfg_path)
         .env("SCCACHE_CACHED_CONF", cached_cfg_path)
         .status()


### PR DESCRIPTION
- The location of the log is not cross-platform and currently fails on Windows (it's the cause of the failures in PR #1963)
- Those logging environment variables were, in fact, not expected to be set in the first place.