### PR TITLE
Only activate direct mode by default for local

### DIFF
--- a/docs/Local.md
+++ b/docs/Local.md
@@ -30,7 +30,7 @@ Preprocessor cache mode will be disabled if any of the following holds:
 
 Configuration options and their default values:
 
-- `use_preprocessor_cache_mode`: `false`. Whether to use preprocessor cache mode entirely.
+- `use_preprocessor_cache_mode`: `true`. Whether to use preprocessor cache mode entirely.
 - `file_stat_matches`: `false`. If false, only compare header files by hashing their contents. If true, will use size + ctime + mtime to check whether a file has changed. See other flags below for more control over this behavior.
 - `use_ctime_for_stat`: `true`. If true, uses the ctime (file status change on UNIX, creation time on Windows) to check that a file has/hasn't changed. Can be useful to disable when backdating modification times in a controlled manner.
 

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -366,7 +366,7 @@ pub trait Storage: Send + Sync {
 
     /// Return the config for preprocessor cache mode if applicable
     fn preprocessor_cache_mode_config(&self) -> PreprocessorCacheModeConfig {
-        // Disabled by default, only enabled in local mode
+        // Enable by default, only in local mode
         PreprocessorCacheModeConfig::default()
     }
     /// Return the preprocessor cache entry for a given preprocessor key,
@@ -427,6 +427,16 @@ impl Default for PreprocessorCacheModeConfig {
             ignore_time_macros: false,
             skip_system_headers: false,
             hash_working_directory: true,
+        }
+    }
+}
+
+impl PreprocessorCacheModeConfig {
+    /// Return a default [`Self`], but with the cache active.
+    pub fn activated() -> Self {
+        Self {
+            use_preprocessor_cache_mode: true,
+            ..Default::default()
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -169,7 +169,7 @@ impl Default for DiskCacheConfig {
         DiskCacheConfig {
             dir: default_disk_cache_dir(),
             size: default_disk_cache_size(),
-            preprocessor_cache_mode: Default::default(),
+            preprocessor_cache_mode: PreprocessorCacheModeConfig::activated(),
         }
     }
 }
@@ -1296,7 +1296,7 @@ token = "webdavtoken"
                 disk: Some(DiskCacheConfig {
                     dir: PathBuf::from("/tmp/.cache/sccache"),
                     size: 7 * 1024 * 1024 * 1024,
-                    preprocessor_cache_mode: Default::default(),
+                    preprocessor_cache_mode: PreprocessorCacheModeConfig::activated(),
                 }),
                 gcs: Some(GCSCacheConfig {
                     bucket: "bucket".to_owned(),


### PR DESCRIPTION
45386750a48b6ed7daf9019db88a22dc7a7361c5 reverted my initial change.

This re-enables direct mode by default, making sure only the disk cache is affected. There may still be an issue with Windows, but details are sparse and no reproduction has been found yet.

@sylvestre