### PR TITLE
Remove uses of Lazy<Mutex<T>>

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -37,7 +37,7 @@ pub use crate::cache::PreprocessorCacheModeConfig;
 use crate::errors::*;
 
 static CACHED_CONFIG_PATH: Lazy<PathBuf> = Lazy::new(CachedConfig::file_config_path);
-static CACHED_CONFIG: Lazy<Mutex<Option<CachedFileConfig>>> = Lazy::new(|| Mutex::new(None));
+static CACHED_CONFIG: Mutex<Option<CachedFileConfig>> = Mutex::new(None);
 
 const ORGANIZATION: &str = "Mozilla";
 const APP_NAME: &str = "sccache";

--- a/src/dist/client_auth.rs
+++ b/src/dist/client_auth.rs
@@ -89,7 +89,6 @@ mod code_grant_pkce {
     use base64::Engine;
     use futures::channel::oneshot;
     use hyper::{Body, Method, Request, Response, StatusCode};
-    use once_cell::sync::Lazy;
     use rand::{rngs::OsRng, RngCore};
     use serde::{Deserialize, Serialize};
     use sha2::{Digest, Sha256};
@@ -142,7 +141,7 @@ mod code_grant_pkce {
         pub shutdown_tx: Option<oneshot::Sender<()>>,
     }
 
-    pub static STATE: Lazy<Mutex<Option<State>>> = Lazy::new(|| Mutex::new(None));
+    pub static STATE: Mutex<Option<State>> = Mutex::new(None);
 
     pub fn generate_verifier_and_challenge() -> Result<(String, String)> {
         let mut code_verifier_bytes = vec![0; NUM_CODE_VERIFIER_BYTES];
@@ -279,7 +278,6 @@ mod implicit {
     };
     use futures::channel::oneshot;
     use hyper::{Body, Method, Request, Response, StatusCode};
-    use once_cell::sync::Lazy;
     use std::collections::HashMap;
     use std::sync::mpsc;
     use std::sync::Mutex;
@@ -308,7 +306,7 @@ mod implicit {
         pub shutdown_tx: Option<oneshot::Sender<()>>,
     }
 
-    pub static STATE: Lazy<Mutex<Option<State>>> = Lazy::new(|| Mutex::new(None));
+    pub static STATE: Mutex<Option<State>> = Mutex::new(None);
 
     pub fn finish_url(client_id: &str, url: &mut Url, redirect_uri: &str, state: &str) {
         url.query_pairs_mut()


### PR DESCRIPTION
Mutex<T>::new has been const since 1.63.0.