### PR TITLE
Expand cfg for operator storage impl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       matrix:
         feature: [azure, gcs, gha, memcached, redis, s3, webdav]
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
       - name: Check feature ${{ matrix.feature }}
         run: cargo check --no-default-features --features ${{ matrix.feature }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         feature: [azure, gcs, gha, memcached, redis, s3, webdav]
     steps:
       - name: Check feature ${{ matrix.feature }}
-        run: cargo check --no-default-features --feature ${{ matrix.feature }}
+        run: cargo check --no-default-features --features ${{ matrix.feature }}
 
   toml_format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,15 @@ jobs:
       - name: Check
         run: cargo ${{ matrix.cargo_cmd }}
 
+  check_features:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        feature: [azure, gcs, gha, memcached, redis, s3, webdav]
+    steps:
+      - name: Check feature ${{ matrix.feature }}
+        run: cargo check --no-default-features --feature ${{ matrix.feature }}
+
   toml_format:
     runs-on: ubuntu-latest
     steps:

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -442,7 +442,15 @@ impl PreprocessorCacheModeConfig {
 }
 
 /// Implement storage for operator.
-#[cfg(any(feature = "s3", feature = "azure", feature = "gcs", feature = "redis"))]
+#[cfg(any(
+    feature = "azure",
+    feature = "gcs",
+    feature = "gha",
+    feature = "memcached",
+    feature = "redis",
+    feature = "s3",
+    feature = "webdav",
+))]
 #[async_trait]
 impl Storage for opendal::Operator {
     async fn get(&self, key: &str) -> Result<Cache> {


### PR DESCRIPTION
Previously, trying to build with only e.g. `gha` feature enabled would not compile.