### PR TITLE
Add i686 and armv7 musl build via container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
   build:
     name: build ${{ matrix.binary || 'sccache' }} ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    container: ${{ fromJson(matrix.container || '{"image":null}') }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -123,6 +124,9 @@ jobs:
             target: x86_64-unknown-linux-musl
           - os: ubuntu-20.04
             target: aarch64-unknown-linux-musl
+          - os: ubuntu-20.04
+            target: arm32v7-unknown-linux-musleabi
+            container: '{"image": "messense/rust-musl-cross:i686-musl"}'
           - os: macOS-11
             target: x86_64-apple-darwin
             macosx_deployment_target: 10.13
@@ -145,6 +149,7 @@ jobs:
         with:
           toolchain: ${{ matrix.target == 'aarch64-apple-darwin' && 'beta' || 'stable' }}
           target: ${{ matrix.target }}
+        if: ${{ !matrix.container }}
 
       - name: Install musl-tools (x86_64)
         run: sudo apt-get install musl-tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           - os: ubuntu-20.04
             target: aarch64-unknown-linux-musl
           - os: ubuntu-20.04
-            target: arm32v7-unknown-linux-musleabi
+            target: armv7-unknown-linux-musleabi
             container: '{"image": "messense/rust-musl-cross:i686-musl"}'
           - os: macOS-11
             target: x86_64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,9 @@ jobs:
             target: aarch64-unknown-linux-musl
           - os: ubuntu-20.04
             target: armv7-unknown-linux-musleabi
+            container: '{"image": "messense/rust-musl-cross:armv7-musleabi"}'
+          - os: ubuntu-20.04
+            target: i686-unknown-linux-musl
             container: '{"image": "messense/rust-musl-cross:i686-musl"}'
           - os: macOS-11
             target: x86_64-apple-darwin


### PR DESCRIPTION
This PR adds an i686 and armv7 musl build to CI by using a container, ala https://github.com/mozilla/sccache/issues/216#issuecomment-357822514.

The ci config is a little jank, but I think it is the best way to do without having to duplicate the steps or move things around too much.

Closes #216.