### PR TITLE
chore(src/compiler/msvc): replace rust-encoding with encoding-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,70 +658,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
-name = "encoding"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
-dependencies = [
- "encoding-index-japanese",
- "encoding-index-korean",
- "encoding-index-simpchinese",
- "encoding-index-singlebyte",
- "encoding-index-tradchinese",
-]
-
-[[package]]
-name = "encoding-index-japanese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-korean"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-simpchinese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-singlebyte"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-tradchinese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding_index_tests"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,7 +2340,7 @@ dependencies = [
  "clap",
  "daemonize",
  "directories",
- "encoding",
+ "encoding_rs",
  "env_logger",
  "filetime",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bytes = "1"
 chrono = "0.4"
 clap = { version = "4.3.24", features = ["derive", "env", "wrap_help"] }
 directories = "5.0.1"
-encoding = "0.2"
+encoding_rs = "0.8"
 env_logger = "0.10"
 filetime = "0.2"
 flate2 = { version = "1.0", optional = true, default-features = false, features = [

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -2292,13 +2292,15 @@ mod test {
             .unwrap();
         let cmd_file_path = td.path().join("foo");
         {
-            use encoding_rs::UTF_16LE;
             let mut file = File::create(&cmd_file_path).unwrap();
-            let (content, _, has_error) = UTF_16LE.encode("-c foo€.c -o foo.o");
-            if has_error {
-                panic!("Failed to encode as UTF-16LE");
-            }
-            file.write_all(&[0xFF, 0xFE]).unwrap(); // little endian BOM
+            // pre-encoded with utf16le
+            let content: [u8; 0x26] = [
+                0xFF, 0xFE, // little endian BOM
+                // `-c foo€.c -o foo.o`
+                0x2D, 0x00, 0x63, 0x00, 0x20, 0x00, 0x66, 0x00, 0x6F, 0x00, 0x6F, 0x00, 0xAC, 0x20,
+                0x2E, 0x00, 0x63, 0x00, 0x20, 0x00, 0x2D, 0x00, 0x6F, 0x00, 0x20, 0x00, 0x66, 0x00,
+                0x6F, 0x00, 0x6F, 0x00, 0x2E, 0x00, 0x6F, 0x00,
+            ];
             file.write_all(&content).unwrap();
         }
         let arg = format!("@{}", cmd_file_path.display());


### PR DESCRIPTION
This pull request replaces `rust-encoding` with `encoding-rs`. 

The former is unmaintained and uses ambiguous encoding for `ISO 8859-1` (note that `CP1252` aka "Latin-1" on Windows(R) is a superset of `ISO 8859-1`). This pull request also corrects this issue by using the `WINDOWS-1252` encoding to match the encoding more closely.
