### PR TITLE
Snap: Adapt Snapcraft manifest to Snapcraft 8.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,6 +29,8 @@ confinement: classic
 apps:
     sccache:
         command: bin/sccache
+    sccache-dist:
+        command: bin/sccache-dist
 
 parts:
     sccache:
@@ -44,8 +46,7 @@ parts:
         - make
         - pkg-config
         rust-features:
-        - gcs
-        - redis
-        - s3
+        - all
+        - dist-server
         build-attributes:
         - enable-patchelf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,7 @@ description: |
     using GitHub Actions cache.
 website: https://github.com/mozilla/sccache
 contact: https://github.com/mozilla/sccache/issues
+license: "Apache-2.0"
 grade: stable
 confinement: classic
 
@@ -33,12 +34,12 @@ parts:
     sccache:
         plugin: rust
         rust-channel: 1.67.1
+        rust-use-global-lto: true
         source: .
         override-pull: |
           craftctl default
-          craftctl set version=$( git -C ${CRAFT_PART_SRC} describe --tags )
+          craftctl set version="$( git -C "${CRAFT_PART_SRC}" describe --tags )"
         build-packages:
-        - cargo
         - libssl-dev
         - make
         - pkg-config


### PR DESCRIPTION
This pull request adapts the Snapcraft build manifest to the new Snapcraft tool version 8 changes.

This also includes a change to add the `sccache-dist` program to the Snap package.

> [!NOTE]
> If you want the user to use the `sccache-dist` program (instead of using the auto-renamed `sccache.sccache-dist` binary) from Snap, an alias request needs to be filed on the [Snapcraft forum](https://forum.snapcraft.io/c/store-requests/19). Please see <https://forum.snapcraft.io/t/process-for-aliases-auto-connections-and-tracks/455> for more information on the process.