### PR TITLE
chore(CI): update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
           ID: ${{ startsWith(github.ref, 'refs/tags/') && github.ref || github.sha }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.binary || 'sccache' }}-${{ steps.id.outputs.id }}-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/${{ matrix.binary || 'sccache' }}${{ endsWith(matrix.target, '-msvc') && '.exe' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
           fi
 
       - name: Get artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Create release assets
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -204,7 +204,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure Cache Env
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -433,7 +433,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Configure Cache Env
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -483,7 +483,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Configure Cache Env
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -528,7 +528,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Configure Cache Env
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -584,7 +584,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Configure Cache Env
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           toolchain: "stable"
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: integration-tests
           path: /home/runner/.cargo/bin/
@@ -110,7 +110,7 @@ jobs:
         with:
           toolchain: "stable"
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: integration-tests
           path: /home/runner/.cargo/bin/
@@ -166,7 +166,7 @@ jobs:
         with:
           toolchain: "stable"
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: integration-tests
           path: /home/runner/.cargo/bin/
@@ -215,7 +215,7 @@ jobs:
         with:
           toolchain: "stable"
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: integration-tests
           path: /home/runner/.cargo/bin/
@@ -270,7 +270,7 @@ jobs:
         with:
           toolchain: "stable"
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: integration-tests
           path: /home/runner/.cargo/bin/
@@ -322,7 +322,7 @@ jobs:
         with:
           toolchain: "stable"
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: integration-tests
           path: /home/runner/.cargo/bin/
@@ -445,7 +445,7 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh "${LLVM_VERSION}"
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: integration-tests
           path: /home/runner/.cargo/bin/
@@ -489,7 +489,7 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: integration-tests
           path: /home/runner/.cargo/bin/
@@ -534,7 +534,7 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: integration-tests
           path: /home/runner/.cargo/bin/
@@ -590,7 +590,7 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: integration-tests
           path: /home/runner/.cargo/bin/
@@ -642,7 +642,7 @@ jobs:
       RUSTDOCFLAGS: "-Cpanic=abort"
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: integration-tests
           path: /home/runner/.cargo/bin/

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           cargo build --all-features
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: integration-tests
           path: ./target/debug/sccache


### PR DESCRIPTION
This pull request updates the GitHub Actions external dependencies to their latest versions.

This pull request includes the changes from auto-generated pull requests #1974, #2002, and #2003. Those pull requests need to be rolled into one branch in order to pass the build.