### PR TITLE
feat(tree-wide): migrate to Hyper 1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap",
  "slab",
  "tokio",
@@ -1037,13 +1037,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.0.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -1076,8 +1110,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1090,14 +1124,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -1110,10 +1162,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdea9aac0dbe5a9240d68cfd9501e2db94222c6dc06843e06640b9e07f0fdc67"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "hyper 1.1.0",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1621,7 +1691,7 @@ dependencies = [
  "flagset",
  "futures",
  "getrandom",
- "http",
+ "http 0.2.11",
  "log",
  "md-5",
  "once_cell",
@@ -2027,7 +2097,7 @@ dependencies = [
  "hex",
  "hmac",
  "home",
- "http",
+ "http 0.2.11",
  "jsonwebtoken",
  "log",
  "once_cell",
@@ -2056,9 +2126,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
@@ -2309,8 +2379,10 @@ dependencies = [
  "fs-err",
  "futures",
  "gzp",
- "http",
- "hyper",
+ "http 1.0.0",
+ "http-body-util",
+ "hyper 1.1.0",
+ "hyper-util",
  "is-terminal",
  "itertools 0.12.0",
  "jobserver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,13 @@ futures = "0.3"
 gzp = { version = "0.11.3", default-features = false, features = [
   "deflate_rust",
 ] }
-http = "0.2"
-hyper = { version = "0.14.27", optional = true, features = ["server"] }
+http = "1.0"
+http-body-util = { version = "0.1", optional = true }
+hyper = { version = "1.1", optional = true, features = ["server", "http1"] }
+hyper-util = { version = "0.1.2", optional = true, features = [
+  "tokio",
+  "server",
+] }
 is-terminal = "0.4.10"
 jobserver = "0.1"
 jwt = { package = "jsonwebtoken", version = "9", optional = true }
@@ -165,7 +170,15 @@ vendored-openssl = ["openssl?/vendored", "opendal?/native-tls-vendored"]
 # Enable features that require unstable features of Nightly Rust.
 unstable = []
 # Enables distributed support in the sccache client
-dist-client = ["flate2", "hyper", "reqwest", "url", "sha2"]
+dist-client = [
+  "flate2",
+  "hyper",
+  "http-body-util",
+  "hyper-util",
+  "reqwest",
+  "url",
+  "sha2",
+]
 # Enables the sccache-dist binary
 dist-server = [
   "jwt",

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -21,7 +21,7 @@ pub use self::server::{
 };
 
 mod common {
-    use http::header;
+    use reqwest::header;
     use serde::{Deserialize, Serialize};
     #[cfg(feature = "dist-server")]
     use std::collections::HashMap;
@@ -288,7 +288,7 @@ mod server {
     ) -> Result<T> {
         // Work around tiny_http issue #151 by disabling HTTP pipeline with
         // `Connection: close`.
-        let mut res = req.header(http::header::CONNECTION, "close").send()?;
+        let mut res = req.header(reqwest::header::CONNECTION, "close").send()?;
         let status = res.status();
         let mut body = vec![];
         res.copy_to(&mut body)


### PR DESCRIPTION
This pull request migrates the `hyper` crate to version 1.1.

I have to admit the situation is a bit disastrous due to the massive amount of API changes they have accumulated.

The following is a summary of the changes in this pull request:

- Due to `hyper` splitting the library. Some more crates were added to accommodate and retain the functionalities.
- Since `reqwest` (as of writing) still uses `hyper` 0.14, dependencies can not be shared anymore.
- `hyper` now requires the library user to provide the I/O interface, so you will find I have added an adapter/wrapper to avoid refactoring all the web-server-related functions to be `async`.
- The `make_service` macro is removed because the `make_service_fn` function was deleted. Instead, I added a taping-over function to stitch the services together like before.
- The shutdown handling is changed as `hyper` now delegates some event-loop responsibilities to the library user.