### PR TITLE
feat(redis): add support for ttl, fix #1666

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -121,7 +121,7 @@ will default to `us-east-1`.
 #### redis
 
 * `SCCACHE_REDIS` full redis url, including auth and access token/passwd
-* `SCCACHE_REDIS_TTL` ttl for redis keys, don't set for default behavior.
+* `SCCACHE_REDIS_TTL` ttl for redis cache, don't set for default behavior.
 
 The full url appears then as `redis://user:passwd@1.2.3.4:6379/1`.
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -121,6 +121,7 @@ will default to `us-east-1`.
 #### redis
 
 * `SCCACHE_REDIS` full redis url, including auth and access token/passwd
+* `SCCACHE_REDIS_TTL` ttl for redis keys, don't set for default behavior.
 
 The full url appears then as `redis://user:passwd@1.2.3.4:6379/1`.
 

--- a/docs/Redis.md
+++ b/docs/Redis.md
@@ -3,3 +3,5 @@
 Set `SCCACHE_REDIS` to a [Redis](https://redis.io/) url in format `redis://[:<passwd>@]<hostname>[:port][/<db>]` to store the cache in a Redis instance. Redis can be configured as a LRU (least recently used) cache with a fixed maximum cache size. Set `maxmemory` and `maxmemory-policy` according to the [Redis documentation](https://redis.io/topics/lru-cache). The `allkeys-lru` policy which discards the *least recently accessed or modified* key fits well for the sccache use case.
 
 Redis over TLS is supported. Use the [`rediss://`](https://www.iana.org/assignments/uri-schemes/prov/rediss) url scheme (note `rediss` vs `redis`). Append `#insecure` the the url to disable hostname verification and accept self-signed certificates (dangerous!). Note that this also disables [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication).
+
+Set `SCCACHE_REDIS_TTL` in seconds if you don't want your keys to live forever. This will override the default behavior of redis.

--- a/docs/Redis.md
+++ b/docs/Redis.md
@@ -4,4 +4,4 @@ Set `SCCACHE_REDIS` to a [Redis](https://redis.io/) url in format `redis://[:<pa
 
 Redis over TLS is supported. Use the [`rediss://`](https://www.iana.org/assignments/uri-schemes/prov/rediss) url scheme (note `rediss` vs `redis`). Append `#insecure` the the url to disable hostname verification and accept self-signed certificates (dangerous!). Note that this also disables [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication).
 
-Set `SCCACHE_REDIS_TTL` in seconds if you don't want your keys to live forever. This will override the default behavior of redis.
+Set `SCCACHE_REDIS_TTL` in seconds if you don't want your cache to live forever. This will override the default behavior of redis.

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -612,7 +612,7 @@ pub fn storage_from_config(
                 return Ok(Arc::new(storage));
             }
             #[cfg(feature = "redis")]
-            CacheType::Redis(config::RedisCacheConfig { ref url , ref ttl}) => {
+            CacheType::Redis(config::RedisCacheConfig { ref url, ref ttl }) => {
                 debug!("Init redis cache with url {url}");
                 let storage = RedisCache::build(url, *ttl)
                     .map_err(|err| anyhow!("create redis cache failed: {err:?}"))?;

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -612,9 +612,9 @@ pub fn storage_from_config(
                 return Ok(Arc::new(storage));
             }
             #[cfg(feature = "redis")]
-            CacheType::Redis(config::RedisCacheConfig { ref url }) => {
+            CacheType::Redis(config::RedisCacheConfig { ref url , ref ttl}) => {
                 debug!("Init redis cache with url {url}");
-                let storage = RedisCache::build(url)
+                let storage = RedisCache::build(url, *ttl)
                     .map_err(|err| anyhow!("create redis cache failed: {err:?}"))?;
                 return Ok(Arc::new(storage));
             }

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -18,6 +18,7 @@ use opendal::layers::LoggingLayer;
 use opendal::services::Redis;
 use opendal::Operator;
 use std::collections::HashMap;
+use std::time::Duration;
 use url::Url;
 
 /// A cache that stores entries in a Redis.
@@ -25,13 +26,16 @@ pub struct RedisCache;
 
 impl RedisCache {
     /// Create a new `RedisCache`.
-    pub fn build(url: &str) -> Result<Operator> {
+    pub fn build(url: &str, ttl: u64) -> Result<Operator> {
         let parsed = Url::parse(url)?;
 
         let mut builder = Redis::default();
         builder.endpoint(parsed.as_str());
         builder.username(parsed.username());
         builder.password(parsed.password().unwrap_or_default());
+        if ttl != 0 {
+            builder.default_ttl(Duration::from_secs(ttl));
+        }
 
         let options: HashMap<_, _> = parsed
             .query_pairs()

--- a/src/config.rs
+++ b/src/config.rs
@@ -223,10 +223,21 @@ pub struct MemcachedCacheConfig {
     pub expiration: u32,
 }
 
+
+/// redis has no default TTL - all keys live forever
+///
+/// We keep the TTL as 0 here as redis does
+///
+/// Please change this value freely if we have a better choice.
+const DEFAULT_REDIS_CACHE_TTL: u64 = 0;
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RedisCacheConfig {
     pub url: String,
+    /// the ttl time in seconds.
+    ///
+    /// Default to infinity (0)
+    pub ttl: u64,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -563,9 +574,15 @@ fn config_from_env() -> Result<EnvConfig> {
     }
 
     // ======= redis =======
-    let redis = env::var("SCCACHE_REDIS")
-        .ok()
-        .map(|url| RedisCacheConfig { url });
+    let ttl = match env::var("SCCACHE_REDIS_TTL") {
+        Ok(v) => v
+            .parse()
+            .map_err(|err| anyhow!("SCCACHE_REDIS_TTL value is invalid: {err:?}"))?,
+        Err(_) => DEFAULT_REDIS_CACHE_TTL,
+    };
+    let redis = env::var("SCCACHE_REDIS").ok().map(|url| {
+        RedisCacheConfig { url, ttl }
+    });
 
     // ======= memcached =======
     let expiration = match env::var("SCCACHE_MEMCACHED_EXPIRATION").ok() {
@@ -1075,6 +1092,7 @@ fn config_overrides() {
             }),
             redis: Some(RedisCacheConfig {
                 url: "myotherredisurl".to_owned(),
+                ttl: 24 * 3600,
             }),
             ..Default::default()
         },
@@ -1093,6 +1111,7 @@ fn config_overrides() {
             }),
             redis: Some(RedisCacheConfig {
                 url: "myredisurl".to_owned(),
+                ttl: 24 * 3600,
             }),
             ..Default::default()
         },
@@ -1104,7 +1123,8 @@ fn config_overrides() {
         Config::from_env_and_file_configs(env_conf, file_conf),
         Config {
             cache: Some(CacheType::Redis(RedisCacheConfig {
-                url: "myotherredisurl".to_owned()
+                url: "myotherredisurl".to_owned(),
+                ttl: 24 * 3600,
             }),),
             fallback_cache: DiskCacheConfig {
                 dir: "/env-cache".into(),
@@ -1269,6 +1289,7 @@ expiration = 86400
 
 [cache.redis]
 url = "redis://user:passwd@1.2.3.4:6379/1"
+ttl = 86400
 
 [cache.s3]
 bucket = "name"
@@ -1312,6 +1333,7 @@ token = "webdavtoken"
                 }),
                 redis: Some(RedisCacheConfig {
                     url: "redis://user:passwd@1.2.3.4:6379/1".to_owned(),
+                    ttl: 24 * 3600,
                 }),
                 memcached: Some(MemcachedCacheConfig {
                     url: "...".to_owned(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -223,7 +223,6 @@ pub struct MemcachedCacheConfig {
     pub expiration: u32,
 }
 
-
 /// redis has no default TTL - all keys live forever
 ///
 /// We keep the TTL as 0 here as redis does
@@ -580,9 +579,9 @@ fn config_from_env() -> Result<EnvConfig> {
             .map_err(|err| anyhow!("SCCACHE_REDIS_TTL value is invalid: {err:?}"))?,
         Err(_) => DEFAULT_REDIS_CACHE_TTL,
     };
-    let redis = env::var("SCCACHE_REDIS").ok().map(|url| {
-        RedisCacheConfig { url, ttl }
-    });
+    let redis = env::var("SCCACHE_REDIS")
+        .ok()
+        .map(|url| RedisCacheConfig { url, ttl });
 
     // ======= memcached =======
     let expiration = match env::var("SCCACHE_MEMCACHED_EXPIRATION").ok() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -223,7 +223,7 @@ pub struct MemcachedCacheConfig {
     pub expiration: u32,
 }
 
-/// redis has no default TTL - all keys live forever
+/// redis has no default TTL - all caches live forever
 ///
 /// We keep the TTL as 0 here as redis does
 ///


### PR DESCRIPTION
Fixes #1666 

Adds a ttl to `opendal` if `SCCACHE_REDIS_TTL` env var is set and not zero.