### PR TITLE
fix(src/compiler/c): take common_args into account during preprocessor hashing

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -303,6 +303,8 @@ where
         // use in creating a hash key
         let mut preprocessor_and_arch_args = parsed_args.preprocessor_args.clone();
         preprocessor_and_arch_args.extend(parsed_args.arch_args.to_vec());
+        // common_args is used in preprocessing too
+        preprocessor_and_arch_args.extend(parsed_args.common_args.to_vec());
 
         let absolute_input_path: Cow<'_, _> = if parsed_args.input.is_absolute() {
             Cow::Borrowed(&parsed_args.input)


### PR DESCRIPTION
Fixes #2038.

Since `common_args` represents the flags that are used both for compilation and for preprocessing, during preprocessor caching `common_args` should be taken into account as well.