### PR TITLE
feat: initial support for Clang HIP

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -520,6 +520,78 @@ jobs:
 
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
+  hip:
+    # Probably wouldn't matter anyway since we run in a container, but staying 
+    # close to the version is better than not.
+    runs-on: ubuntu-22.04
+    needs: build
+    container:
+      image: rocm/dev-ubuntu-22.04:6.0
+
+    env:
+      # SCCACHE_GHA_ENABLED: "on"
+      ROCM_PATH: "/opt/rocm"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # I don't want to break the cache during testing. Will turn on after I
+      # make sure it's working.
+      #
+      # - name: Configure Cache Env
+      #   uses: actions/github-script@v7
+      #   with:
+      #     script: |
+      #       core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+      #       core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
+
+      # - name: Configure ROCm Env
+      #   uses: actions/github-script@v7
+      #   with:
+      #     script: |
+      #       core.exportVariable('ROCM_PATH', process.env.ROCM_PATH || '');
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: integration-tests
+          path: /home/runner/.cargo/bin/
+      - name: Chmod for binary
+        run: chmod +x ${SCCACHE_PATH}
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          ## Install dependencies
+          sudo apt-get update
+          sudo apt-get install -y cmake
+
+      # Ensure that HIPCC isn't already borken
+      - name: Sanity Check
+        run: |
+          hipcc -o vectoradd_hip --offload-arch=gfx900 tests/cmake-hip/vectoradd_hip.cpp
+
+      - name: Test
+        run: |
+          cmake -B build -S tests/cmake-hip -DCMAKE_HIP_COMPILER_LAUNCHER=${SCCACHE_PATH} -DCMAKE_HIP_ARCHITECTURES=gfx900
+          cmake --build build
+
+      - name: Output
+        run: |
+          ${SCCACHE_PATH} --show-stats
+
+      - name: Test Twice for Cache Read
+        run: |
+          rm -rf build
+          cmake -B build -S tests/cmake-hip -DCMAKE_HIP_COMPILER_LAUNCHER=${SCCACHE_PATH} -DCMAKE_HIP_ARCHITECTURES=gfx900
+          cmake --build build
+
+      - name: Output
+        run: |
+          ${SCCACHE_PATH} --show-stats
+
+          ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
+
+
   gcc:
     runs-on: ubuntu-latest
     needs: build

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -292,20 +292,18 @@ impl<T: CommandCreatorSync, I: CCompilerImpl> Compiler<T> for CCompiler<I> {
                         }
                     }
 
-                    let hip_device_lib_path: Option<String> = hip_device_lib_path_arg
+                    let hip_device_lib_path: String = hip_device_lib_path_arg
                         .or(hip_device_lib_path_env)
                         .or(rocm_path_arg)
-                        .or(rocm_path_env);
+                        .or(rocm_path_env)
+                        // This is the default location in official AMD packages and containers.
+                        .unwrap_or("/opt/rocm/amdgcn/bitcode".to_string());
 
-                    if let Some(hip_device_lib_path) = hip_device_lib_path {
-                        if let Ok(files) = Path::new(&hip_device_lib_path).read_dir() {
-                            for file in files {
-                                if let Ok(file) = file {
-                                    if let Some(ext) = file.path().extension() {
-                                        if ext == "bc" {
-                                            args.extra_hash_files.push(file.path());
-                                        }
-                                    }
+                    if let Ok(files) = Path::new(&hip_device_lib_path).read_dir() {
+                        for file in files.flatten() {
+                            if let Some(ext) = file.path().extension() {
+                                if ext == "bc" {
+                                    args.extra_hash_files.push(file.path());
                                 }
                             }
                         }

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -1490,6 +1490,7 @@ mod test {
         t("mm", Language::ObjectiveCxx);
 
         t("cu", Language::Cuda);
+        t("hip", Language::Hip);
     }
 
     #[test]

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -113,6 +113,7 @@ pub enum Language {
     ObjectiveCxx,
     Cuda,
     Rust,
+    Hip,
 }
 
 impl Language {
@@ -135,6 +136,7 @@ impl Language {
             Some("cu") => Some(Language::Cuda),
             // TODO cy
             Some("rs") => Some(Language::Rust),
+            Some("hip") => Some(Language::Hip),
             e => {
                 trace!("Unknown source extension: {}", e.unwrap_or("(None)"));
                 None
@@ -151,6 +153,7 @@ impl Language {
             Language::ObjectiveCxx => "objc++",
             Language::Cuda => "cuda",
             Language::Rust => "rust",
+            Language::Hip => "hip",
         }
     }
 }
@@ -167,6 +170,7 @@ impl CompilerKind {
             | Language::ObjectiveCxx => "C/C++",
             Language::Cuda => "CUDA",
             Language::Rust => "Rust",
+            Language::Hip => "HIP",
         }
         .to_string()
     }

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -381,6 +381,7 @@ where
                     "cu" => Some(Language::Cuda),
                     "rs" => Some(Language::Rust),
                     "cuda" => Some(Language::Cuda),
+                    "hip" => Some(Language::Hip),
                     _ => cannot_cache!("-x"),
                 };
             }
@@ -643,7 +644,8 @@ fn language_to_gcc_arg(lang: Language) -> Option<&'static str> {
         Language::ObjectiveC => Some("objective-c"),
         Language::ObjectiveCxx => Some("objective-c++"),
         Language::Cuda => Some("cu"),
-        Language::Rust => None,          // Let the compiler decide
+        Language::Rust => None, // Let the compiler decide
+        Language::Hip => Some("hip"),
         Language::GenericHeader => None, // Let the compiler decide
     }
 }

--- a/tests/cmake-hip/CMakeLists.txt
+++ b/tests/cmake-hip/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(myproject LANGUAGES CXX HIP)
+
+add_library(vectoradd_hip vectoradd_hip.cpp)
+set_source_files_properties(vectoradd_hip.cpp PROPERTIES LANGUAGE HIP)

--- a/tests/cmake-hip/vectoradd_hip.cpp
+++ b/tests/cmake-hip/vectoradd_hip.cpp
@@ -1,0 +1,150 @@
+/*
+Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#include <assert.h>
+#include <stdio.h>
+#include <algorithm>
+#include <stdlib.h>
+#include<iostream>
+#include "hip/hip_runtime.h"
+
+
+#define HIP_ASSERT(x) (assert((x)==hipSuccess))
+
+
+#define WIDTH     1024
+#define HEIGHT    1024
+
+#define NUM       (WIDTH*HEIGHT)
+
+#define THREADS_PER_BLOCK_X  16
+#define THREADS_PER_BLOCK_Y  16
+#define THREADS_PER_BLOCK_Z  1
+
+__global__ void 
+vectoradd_float(float* __restrict__ a, const float* __restrict__ b, const float* __restrict__ c, int width, int height) 
+
+  {
+ 
+      int x = hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x;
+      int y = hipBlockDim_y * hipBlockIdx_y + hipThreadIdx_y;
+
+      int i = y * width + x;
+      if ( i < (width * height)) {
+        a[i] = b[i] + c[i];
+      }
+
+
+
+  }
+
+#if 0
+__kernel__ void vectoradd_float(float* a, const float* b, const float* c, int width, int height) {
+
+  
+  int x = blockDimX * blockIdx.x + threadIdx.x;
+  int y = blockDimY * blockIdy.y + threadIdx.y;
+
+  int i = y * width + x;
+  if ( i < (width * height)) {
+    a[i] = b[i] + c[i];
+  }
+}
+#endif
+
+using namespace std;
+
+int main() {
+  
+  float* hostA;
+  float* hostB;
+  float* hostC;
+
+  float* deviceA;
+  float* deviceB;
+  float* deviceC;
+
+  hipDeviceProp_t devProp;
+  hipGetDeviceProperties(&devProp, 0);
+  cout << " System minor " << devProp.minor << endl;
+  cout << " System major " << devProp.major << endl;
+  cout << " agent prop name " << devProp.name << endl;
+
+
+
+  cout << "hip Device prop succeeded " << endl ;
+
+
+  int i;
+  int errors;
+
+  hostA = (float*)malloc(NUM * sizeof(float));
+  hostB = (float*)malloc(NUM * sizeof(float));
+  hostC = (float*)malloc(NUM * sizeof(float));
+  
+  // initialize the input data
+  for (i = 0; i < NUM; i++) {
+    hostB[i] = (float)i;
+    hostC[i] = (float)i*100.0f;
+  }
+  
+  HIP_ASSERT(hipMalloc((void**)&deviceA, NUM * sizeof(float)));
+  HIP_ASSERT(hipMalloc((void**)&deviceB, NUM * sizeof(float)));
+  HIP_ASSERT(hipMalloc((void**)&deviceC, NUM * sizeof(float)));
+  
+  HIP_ASSERT(hipMemcpy(deviceB, hostB, NUM*sizeof(float), hipMemcpyHostToDevice));
+  HIP_ASSERT(hipMemcpy(deviceC, hostC, NUM*sizeof(float), hipMemcpyHostToDevice));
+
+
+  hipLaunchKernelGGL(vectoradd_float, 
+                  dim3(WIDTH/THREADS_PER_BLOCK_X, HEIGHT/THREADS_PER_BLOCK_Y),
+                  dim3(THREADS_PER_BLOCK_X, THREADS_PER_BLOCK_Y),
+                  0, 0,
+                  deviceA ,deviceB ,deviceC ,WIDTH ,HEIGHT);
+
+
+  HIP_ASSERT(hipMemcpy(hostA, deviceA, NUM*sizeof(float), hipMemcpyDeviceToHost));
+
+  // verify the results
+  errors = 0;
+  for (i = 0; i < NUM; i++) {
+    if (hostA[i] != (hostB[i] + hostC[i])) {
+      errors++;
+    }
+  }
+  if (errors!=0) {
+    printf("FAILED: %d errors\n",errors);
+  } else {
+      printf ("PASSED!\n");
+  }
+
+  HIP_ASSERT(hipFree(deviceA));
+  HIP_ASSERT(hipFree(deviceB));
+  HIP_ASSERT(hipFree(deviceC));
+
+  free(hostA);
+  free(hostB);
+  free(hostC);
+
+  //hipResetDefaultAccelerator();
+
+  return errors;
+}

--- a/tests/test_a.hip
+++ b/tests/test_a.hip
@@ -1,0 +1,10 @@
+
+#include <stdio.h>
+#include <hip/hip_runtime.h>
+
+__global__ void cuda_entry_point(int*, int*) {}
+__device__ void cuda_device_func(int*, int*) {}
+
+int main() {
+  printf("%s says hello world\n", __FILE__);
+}

--- a/tests/test_b.hip
+++ b/tests/test_b.hip
@@ -1,0 +1,10 @@
+
+#include <stdio.h>
+#include <hip/hip_runtime.h>
+
+__global__ void cuda_entry_point(int*, int*) {}
+__device__ void cuda_device_func(int*, int*) {}
+
+int main() {
+  printf("%s says hello world\n", __FILE__);
+}

--- a/tests/test_c.hip
+++ b/tests/test_c.hip
@@ -1,0 +1,10 @@
+
+#include <stdio.h>
+#include <hip/hip_runtime.h>
+
+__global__ void cuda_entry_point(int*, int*) {}
+__device__ void cuda_device_func(int*, int*) {}
+
+int main() {
+  printf("%s says hello world\n", __FILE__);
+}


### PR DESCRIPTION
Fixes #2044.

~~Still needs to distinguished between different ROCm versions, due to implicit dependencies that may be introduced by `$HIP_DEVICE_LIB_PATH/*.bc` and header files located at `$HIP_PATH/include/hip/**/*.h`~~ No need to concern about header files, but for the bitcode libraries I'm still thinking. 

I currently have an experimental support for detecting and adding the bitcode libraries into `extra_hash_files`. If the implementation is undesired, then my idea is to just ignore bitcode libraries and explicitly mention in the docs to add the bitcode libraries to `SCCACHE_EXTRA_FILES` if the user is worried about erroneous cache hits.

<!--
This shouldn't be needed for almost any user except perhaps AMD themselves, because I believe every ROCm version bump should change at least one of the HIP runtime library headers or the ROCm clang binary.
!-->