### PR TITLE
Implement read-only local cache

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -100,6 +100,7 @@ configuration variables
 * `SCCACHE_DIR` local on disk artifact cache directory
 * `SCCACHE_CACHE_SIZE` maximum size of the local on disk cache i.e. `2G` - default is 10G
 * `SCCACHE_DIRECT` enable/disable preprocessor caching (see [the local doc](Local.md))
+* `SCCACHE_LOCAL_RW_MODE` the mode that the cache will operate in (`READ_ONLY` or `READ_WRITE`)
 
 #### s3 compatible
 

--- a/docs/Local.md
+++ b/docs/Local.md
@@ -43,3 +43,7 @@ Configuration options and their default values:
 See where to write the config in [the configuration doc](Configuration.md).
 
 *Note that preprocessor caching is currently only implemented for GCC and Clang and when using local storage.*
+
+## Read-only cache mode
+
+By default, the local cache operates in read/write mode. The `SCCACHE_LOCAL_RW_MODE` environment variable can be set to `READ_ONLY` (or `READ_WRITE`) to modify this behavior.

--- a/docs/Local.md
+++ b/docs/Local.md
@@ -47,3 +47,7 @@ See where to write the config in [the configuration doc](Configuration.md).
 ## Read-only cache mode
 
 By default, the local cache operates in read/write mode. The `SCCACHE_LOCAL_RW_MODE` environment variable can be set to `READ_ONLY` (or `READ_WRITE`) to modify this behavior.
+
+You can use read-only mode to prevent sccache from writing new cache items to the disk. This can be useful, for example, if you want to use items that have already been cached, but not add new ones to the cache. 
+
+Note that this feature is only effective if you already have items in your cache. Using this option on an empty cache will cause sccache to simply do nothing.

--- a/docs/Local.md
+++ b/docs/Local.md
@@ -50,4 +50,4 @@ By default, the local cache operates in read/write mode. The `SCCACHE_LOCAL_RW_M
 
 You can use read-only mode to prevent sccache from writing new cache items to the disk. This can be useful, for example, if you want to use items that have already been cached, but not add new ones to the cache. 
 
-Note that this feature is only effective if you already have items in your cache. Using this option on an empty cache will cause sccache to simply do nothing.
+Note that this feature is only effective if you already have items in your cache. Using this option on an empty cache will cause sccache to simply do nothing, just add overhead.

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -121,15 +121,6 @@ pub enum CacheMode {
     ReadWrite,
 }
 
-impl From<config::CacheRWMode> for CacheMode {
-    fn from(value: config::CacheRWMode) -> Self {
-        match value {
-            config::CacheRWMode::ReadOnly => CacheMode::ReadOnly,
-            config::CacheRWMode::ReadWrite => CacheMode::ReadWrite,
-        }
-    }
-}
-
 /// Trait objects can't be bounded by more than one non-builtin trait.
 pub trait ReadSeek: Read + Seek + Send {}
 

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -113,7 +113,7 @@ impl fmt::Debug for Cache {
 }
 
 /// CacheMode is used to represent which mode we are using.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CacheMode {
     /// Only read cache from storage.
     ReadOnly,
@@ -655,7 +655,7 @@ pub fn storage_from_config(
 
     let (dir, size) = (&config.fallback_cache.dir, config.fallback_cache.size);
     let preprocessor_cache_mode_config = config.fallback_cache.preprocessor_cache_mode;
-    let rw_mode = config.fallback_cache.rw_mode;
+    let rw_mode = config.fallback_cache.rw_mode.into();
     debug!("Init disk cache with dir {:?}, size {}", dir, size);
     Ok(Arc::new(DiskCache::new(
         dir,

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -688,7 +688,10 @@ mod test {
             .unwrap();
 
         // Use disk cache.
-        let mut config = Config { cache: None, ..Default::default() };
+        let mut config = Config {
+            cache: None,
+            ..Default::default()
+        };
 
         let tempdir = tempfile::Builder::new()
             .prefix("sccache_test_rust_cargo")
@@ -707,10 +710,7 @@ mod test {
             let cache = storage_from_config(&config, runtime.handle()).unwrap();
 
             runtime.block_on(async move {
-                cache
-                    .put("test1", CacheWrite::default())
-                    .await
-                    .unwrap();
+                cache.put("test1", CacheWrite::default()).await.unwrap();
                 cache
                     .put_preprocessor_cache_entry("test1", PreprocessorCacheEntry::default())
                     .unwrap();
@@ -724,13 +724,21 @@ mod test {
             let cache = storage_from_config(&config, runtime.handle()).unwrap();
 
             runtime.block_on(async move {
-                cache
-                    .put("test1", CacheWrite::default())
-                    .await
-                    .unwrap_err();
-                cache
-                    .put_preprocessor_cache_entry("test1", PreprocessorCacheEntry::default())
-                    .unwrap_err();
+                assert_eq!(
+                    cache
+                        .put("test1", CacheWrite::default())
+                        .await
+                        .unwrap_err()
+                        .to_string(),
+                    "Cannot write to a read-only cache"
+                );
+                assert_eq!(
+                    cache
+                        .put_preprocessor_cache_entry("test1", PreprocessorCacheEntry::default())
+                        .unwrap_err()
+                        .to_string(),
+                    "Cannot write to a read-only cache"
+                );
             });
         }
     }

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -687,9 +687,8 @@ mod test {
             .build()
             .unwrap();
 
-        let mut config = Config::default();
         // Use disk cache.
-        config.cache = None;
+        let mut config = Config { cache: None, ..Default::default() };
 
         let tempdir = tempfile::Builder::new()
             .prefix("sccache_test_rust_cargo")
@@ -709,11 +708,11 @@ mod test {
 
             runtime.block_on(async move {
                 cache
-                    .put("test1".into(), CacheWrite::default())
+                    .put("test1", CacheWrite::default())
                     .await
                     .unwrap();
                 cache
-                    .put_preprocessor_cache_entry("test1".into(), PreprocessorCacheEntry::default())
+                    .put_preprocessor_cache_entry("test1", PreprocessorCacheEntry::default())
                     .unwrap();
             });
         }
@@ -726,11 +725,11 @@ mod test {
 
             runtime.block_on(async move {
                 cache
-                    .put("test1".into(), CacheWrite::default())
+                    .put("test1", CacheWrite::default())
                     .await
                     .unwrap_err();
                 cache
-                    .put_preprocessor_cache_entry("test1".into(), PreprocessorCacheEntry::default())
+                    .put_preprocessor_cache_entry("test1", PreprocessorCacheEntry::default())
                     .unwrap_err();
             });
         }

--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -136,7 +136,7 @@ impl Storage for DiskCache {
         trace!("DiskCache::finish_put({})", key);
 
         if self.rw_mode == CacheRWMode::ReadOnly {
-            return Err(anyhow!("Cannot write to a read-only cache1"));
+            return Err(anyhow!("Cannot write to a read-only cache"));
         }
 
         let lru = self.lru.clone();
@@ -185,7 +185,7 @@ impl Storage for DiskCache {
         preprocessor_cache_entry: PreprocessorCacheEntry,
     ) -> Result<()> {
         if self.rw_mode == CacheRWMode::ReadOnly {
-            return Err(anyhow!("Cannot write to a read-only cache2"));
+            return Err(anyhow!("Cannot write to a read-only cache"));
         }
 
         let key = normalize_key(key);

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::config;
 use crate::errors::*;
 use opendal::Operator;
 use opendal::{layers::LoggingLayer, services::Gcs};
@@ -32,6 +33,15 @@ impl RWMode {
         match self {
             RWMode::ReadOnly => "https://www.googleapis.com/auth/devstorage.read_only",
             RWMode::ReadWrite => "https://www.googleapis.com/auth/devstorage.read_write",
+        }
+    }
+}
+
+impl From<config::CacheRWMode> for RWMode {
+    fn from(value: config::CacheRWMode) -> Self {
+        match value {
+            config::CacheRWMode::ReadOnly => RWMode::ReadOnly,
+            config::CacheRWMode::ReadWrite => RWMode::ReadWrite,
         }
     }
 }

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::config;
 use crate::errors::*;
 use opendal::Operator;
 use opendal::{layers::LoggingLayer, services::Gcs};
@@ -33,15 +32,6 @@ impl RWMode {
         match self {
             RWMode::ReadOnly => "https://www.googleapis.com/auth/devstorage.read_only",
             RWMode::ReadWrite => "https://www.googleapis.com/auth/devstorage.read_write",
-        }
-    }
-}
-
-impl From<config::CacheRWMode> for RWMode {
-    fn from(value: config::CacheRWMode) -> Self {
-        match value {
-            config::CacheRWMode::ReadOnly => RWMode::ReadOnly,
-            config::CacheRWMode::ReadWrite => RWMode::ReadWrite,
         }
     }
 }

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1381,8 +1381,7 @@ where
 mod test {
     use super::*;
     use crate::cache::disk::DiskCache;
-    use crate::cache::{CacheRead, PreprocessorCacheModeConfig};
-    use crate::config::CacheRWMode;
+    use crate::cache::{CacheMode, CacheRead, PreprocessorCacheModeConfig};
     use crate::mock_command::*;
     use crate::test::mock_storage::MockStorage;
     use crate::test::utils::*;
@@ -1825,7 +1824,7 @@ LLVM version: 6.0",
                 use_preprocessor_cache_mode: preprocessor_cache_mode,
                 ..Default::default()
             },
-            CacheRWMode::ReadWrite,
+            CacheMode::ReadWrite,
         );
         // Write a dummy input file so the preprocessor cache mode can work
         std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
@@ -1951,7 +1950,7 @@ LLVM version: 6.0",
                 use_preprocessor_cache_mode: preprocessor_cache_mode,
                 ..Default::default()
             },
-            CacheRWMode::ReadWrite,
+            CacheMode::ReadWrite,
         );
         // Write a dummy input file so the preprocessor cache mode can work
         std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
@@ -2239,7 +2238,7 @@ LLVM version: 6.0",
                 use_preprocessor_cache_mode: preprocessor_cache_mode,
                 ..Default::default()
             },
-            CacheRWMode::ReadWrite,
+            CacheMode::ReadWrite,
         );
         let storage = Arc::new(storage);
         // Write a dummy input file so the preprocessor cache mode can work
@@ -2365,7 +2364,7 @@ LLVM version: 6.0",
                 use_preprocessor_cache_mode: preprocessor_cache_mode,
                 ..Default::default()
             },
-            CacheRWMode::ReadWrite,
+            CacheMode::ReadWrite,
         );
         let storage = Arc::new(storage);
         // Pretend to be GCC.  Also inject a fake object file that the subsequent
@@ -2459,7 +2458,7 @@ LLVM version: 6.0",
                 use_preprocessor_cache_mode: preprocessor_cache_mode,
                 ..Default::default()
             },
-            CacheRWMode::ReadWrite,
+            CacheMode::ReadWrite,
         );
         let storage = Arc::new(storage);
         // Pretend to be GCC.

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1382,6 +1382,7 @@ mod test {
     use super::*;
     use crate::cache::disk::DiskCache;
     use crate::cache::{CacheRead, PreprocessorCacheModeConfig};
+    use crate::config::CacheRWMode;
     use crate::mock_command::*;
     use crate::test::mock_storage::MockStorage;
     use crate::test::utils::*;
@@ -1824,6 +1825,7 @@ LLVM version: 6.0",
                 use_preprocessor_cache_mode: preprocessor_cache_mode,
                 ..Default::default()
             },
+            CacheRWMode::ReadWrite,
         );
         // Write a dummy input file so the preprocessor cache mode can work
         std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
@@ -1949,6 +1951,7 @@ LLVM version: 6.0",
                 use_preprocessor_cache_mode: preprocessor_cache_mode,
                 ..Default::default()
             },
+            CacheRWMode::ReadWrite,
         );
         // Write a dummy input file so the preprocessor cache mode can work
         std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
@@ -2236,6 +2239,7 @@ LLVM version: 6.0",
                 use_preprocessor_cache_mode: preprocessor_cache_mode,
                 ..Default::default()
             },
+            CacheRWMode::ReadWrite,
         );
         let storage = Arc::new(storage);
         // Write a dummy input file so the preprocessor cache mode can work
@@ -2361,6 +2365,7 @@ LLVM version: 6.0",
                 use_preprocessor_cache_mode: preprocessor_cache_mode,
                 ..Default::default()
             },
+            CacheRWMode::ReadWrite,
         );
         let storage = Arc::new(storage);
         // Pretend to be GCC.  Also inject a fake object file that the subsequent
@@ -2454,6 +2459,7 @@ LLVM version: 6.0",
                 use_preprocessor_cache_mode: preprocessor_cache_mode,
                 ..Default::default()
             },
+            CacheRWMode::ReadWrite,
         );
         let storage = Arc::new(storage);
         // Pretend to be GCC.

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::cache::gcs::RWMode;
+use crate::cache::CacheMode;
 use directories::ProjectDirs;
 use fs::File;
 use fs_err as fs;
@@ -183,6 +185,24 @@ pub enum CacheRWMode {
     ReadOnly,
     #[serde(rename = "READ_WRITE")]
     ReadWrite,
+}
+
+impl From<CacheRWMode> for CacheMode {
+    fn from(value: CacheRWMode) -> Self {
+        match value {
+            CacheRWMode::ReadOnly => CacheMode::ReadOnly,
+            CacheRWMode::ReadWrite => CacheMode::ReadWrite,
+        }
+    }
+}
+
+impl From<CacheRWMode> for RWMode {
+    fn from(value: CacheRWMode) -> Self {
+        match value {
+            CacheRWMode::ReadOnly => RWMode::ReadOnly,
+            CacheRWMode::ReadWrite => RWMode::ReadWrite,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::cache::gcs::RWMode;
 use crate::cache::CacheMode;
 use directories::ProjectDirs;
 use fs::File;
@@ -192,15 +191,6 @@ impl From<CacheRWMode> for CacheMode {
         match value {
             CacheRWMode::ReadOnly => CacheMode::ReadOnly,
             CacheRWMode::ReadWrite => CacheMode::ReadWrite,
-        }
-    }
-}
-
-impl From<CacheRWMode> for RWMode {
-    fn from(value: CacheRWMode) -> Self {
-        match value {
-            CacheRWMode::ReadOnly => RWMode::ReadOnly,
-            CacheRWMode::ReadWrite => RWMode::ReadWrite,
         }
     }
 }

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -16,6 +16,7 @@ use crate::cache::disk::DiskCache;
 use crate::cache::PreprocessorCacheModeConfig;
 use crate::client::connect_to_server;
 use crate::commands::{do_compile, request_shutdown, request_stats};
+use crate::config::CacheRWMode;
 use crate::jobserver::Client;
 use crate::mock_command::*;
 use crate::server::{DistClientContainer, SccacheServer, ServerMessage};
@@ -85,6 +86,7 @@ where
             cache_size,
             runtime.handle(),
             PreprocessorCacheModeConfig::default(),
+            CacheRWMode::ReadWrite,
         ));
 
         let client = unsafe { Client::new() };

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 use crate::cache::disk::DiskCache;
-use crate::cache::PreprocessorCacheModeConfig;
+use crate::cache::{CacheMode, PreprocessorCacheModeConfig};
 use crate::client::connect_to_server;
 use crate::commands::{do_compile, request_shutdown, request_stats};
-use crate::config::CacheRWMode;
 use crate::jobserver::Client;
 use crate::mock_command::*;
 use crate::server::{DistClientContainer, SccacheServer, ServerMessage};
@@ -86,7 +85,7 @@ where
             cache_size,
             runtime.handle(),
             PreprocessorCacheModeConfig::default(),
-            CacheRWMode::ReadWrite,
+            CacheMode::ReadWrite,
         ));
 
         let client = unsafe { Client::new() };

--- a/tests/sccache_cargo.rs
+++ b/tests/sccache_cargo.rs
@@ -338,16 +338,13 @@ fn test_rust_cargo_cmd_readonly(cmd: &str, test_info: SccacheTest) -> Result<()>
     test_info
         .show_stats()?
         .try_stdout(
-            predicates::str::contains(
-                r#""cache_hits":{"counts":{},"adv_counts":{}}"#,
-            )
-                .from_utf8(),
+            predicates::str::contains(r#""cache_hits":{"counts":{},"adv_counts":{}}"#).from_utf8(),
         )?
         .try_stdout(
             predicates::str::contains(
                 r#""cache_misses":{"counts":{"Rust":2},"adv_counts":{"rust":2}}"#,
             )
-                .from_utf8(),
+            .from_utf8(),
         )?
         .try_success()?;
 
@@ -367,16 +364,13 @@ fn test_rust_cargo_cmd_readonly(cmd: &str, test_info: SccacheTest) -> Result<()>
     test_info
         .show_stats()?
         .try_stdout(
-            predicates::str::contains(
-                r#""cache_hits":{"counts":{},"adv_counts":{}}"#,
-            )
-                .from_utf8(),
+            predicates::str::contains(r#""cache_hits":{"counts":{},"adv_counts":{}}"#).from_utf8(),
         )?
         .try_stdout(
             predicates::str::contains(
                 r#""cache_misses":{"counts":{"Rust":2},"adv_counts":{"rust":2}}"#,
             )
-                .from_utf8(),
+            .from_utf8(),
         )?
         .try_success()?;
 
@@ -402,9 +396,7 @@ fn test_rust_cargo_cmd_readonly(cmd: &str, test_info: SccacheTest) -> Result<()>
             .from_utf8(),
         )?
         .try_stdout(
-            predicates::str::contains(
-                r#""cache_misses":{"counts":{},"adv_counts":{}}"#,
-            )
+            predicates::str::contains(r#""cache_misses":{"counts":{},"adv_counts":{}}"#)
                 .from_utf8(),
         )?
         .try_success()?;

--- a/tests/sccache_cargo.rs
+++ b/tests/sccache_cargo.rs
@@ -133,8 +133,20 @@ fn test_rust_cargo_check() -> Result<()> {
 
 #[test]
 #[serial]
+fn test_rust_cargo_check_readonly() -> Result<()> {
+    test_rust_cargo_cmd_readonly("check", SccacheTest::new(None)?)
+}
+
+#[test]
+#[serial]
 fn test_rust_cargo_build() -> Result<()> {
     test_rust_cargo_cmd("build", SccacheTest::new(None)?)
+}
+
+#[test]
+#[serial]
+fn test_rust_cargo_build_readonly() -> Result<()> {
+    test_rust_cargo_cmd_readonly("build", SccacheTest::new(None)?)
 }
 
 #[test]
@@ -196,8 +208,28 @@ fn test_rust_cargo_check_nightly() -> Result<()> {
 #[cfg(feature = "unstable")]
 #[test]
 #[serial]
+fn test_rust_cargo_check_nightly_readonly() -> Result<()> {
+    test_rust_cargo_cmd_readonly(
+        "check",
+        SccacheTest::new(Some(&[("RUSTFLAGS", OsString::from("-Zprofile"))]))?,
+    )
+}
+
+#[cfg(feature = "unstable")]
+#[test]
+#[serial]
 fn test_rust_cargo_build_nightly() -> Result<()> {
     test_rust_cargo_cmd(
+        "build",
+        SccacheTest::new(Some(&[("RUSTFLAGS", OsString::from("-Zprofile"))]))?,
+    )
+}
+
+#[cfg(feature = "unstable")]
+#[test]
+#[serial]
+fn test_rust_cargo_build_nightly_readonly() -> Result<()> {
+    test_rust_cargo_cmd_readonly(
         "build",
         SccacheTest::new(Some(&[("RUSTFLAGS", OsString::from("-Zprofile"))]))?,
     )
@@ -245,6 +277,135 @@ fn test_rust_cargo_cmd(cmd: &str, test_info: SccacheTest) -> Result<()> {
                 r#""cache_hits":{"counts":{"Rust":2},"adv_counts":{"rust":2}}"#,
             )
             .from_utf8(),
+        )?
+        .try_success()?;
+
+    Ok(())
+}
+
+fn restart_sccache(
+    test_info: &SccacheTest,
+    additional_envs: Option<Vec<(String, String)>>,
+) -> Result<()> {
+    let cache_dir = test_info.tempdir.path().join("cache");
+
+    stop_sccache()?;
+
+    trace!("sccache --start-server");
+
+    let mut cmd = Command::new(SCCACHE_BIN.as_os_str());
+    cmd.arg("--start-server");
+    cmd.env("SCCACHE_DIR", &cache_dir);
+
+    if let Some(additional_envs) = additional_envs {
+        cmd.envs(additional_envs);
+    }
+
+    cmd.assert()
+        .try_success()
+        .context("Failed to start sccache server")?;
+
+    Ok(())
+}
+
+/// Test that building a simple Rust crate with cargo using sccache results in the following behaviors (for three different runs):
+/// - In read-only mode, a cache miss.
+/// - In read-write mode, a cache miss.
+/// - In read-only mode, a cache hit.
+///
+/// The environment variable for read/write mode is added by this function.
+fn test_rust_cargo_cmd_readonly(cmd: &str, test_info: SccacheTest) -> Result<()> {
+    // `cargo clean` first, just to be sure there's no leftover build objects.
+    cargo_clean(&test_info)?;
+
+    // The cache must be put into read-only mode, and that can only be configured
+    // when the server starts up, so we need to restart it.
+    restart_sccache(
+        &test_info,
+        Some(vec![("SCCACHE_LOCAL_RW_MODE".into(), "READ_ONLY".into())]),
+    )?;
+
+    // Now build the crate with cargo.
+    Command::new(CARGO.as_os_str())
+        .args([cmd, "--color=never"])
+        .envs(test_info.env.iter().cloned())
+        .current_dir(CRATE_DIR.as_os_str())
+        .assert()
+        .try_stderr(predicates::str::contains("\x1b[").from_utf8().not())?
+        .try_success()?;
+
+    // Stats reset on server restart, so this needs to be run for each build.
+    test_info
+        .show_stats()?
+        .try_stdout(
+            predicates::str::contains(
+                r#""cache_hits":{"counts":{},"adv_counts":{}}"#,
+            )
+                .from_utf8(),
+        )?
+        .try_stdout(
+            predicates::str::contains(
+                r#""cache_misses":{"counts":{"Rust":2},"adv_counts":{"rust":2}}"#,
+            )
+                .from_utf8(),
+        )?
+        .try_success()?;
+
+    cargo_clean(&test_info)?;
+    restart_sccache(
+        &test_info,
+        Some(vec![("SCCACHE_LOCAL_RW_MODE".into(), "READ_WRITE".into())]),
+    )?;
+    Command::new(CARGO.as_os_str())
+        .args([cmd, "--color=always"])
+        .envs(test_info.env.iter().cloned())
+        .current_dir(CRATE_DIR.as_os_str())
+        .assert()
+        .try_stderr(predicates::str::contains("\x1b[").from_utf8())?
+        .try_success()?;
+
+    test_info
+        .show_stats()?
+        .try_stdout(
+            predicates::str::contains(
+                r#""cache_hits":{"counts":{},"adv_counts":{}}"#,
+            )
+                .from_utf8(),
+        )?
+        .try_stdout(
+            predicates::str::contains(
+                r#""cache_misses":{"counts":{"Rust":2},"adv_counts":{"rust":2}}"#,
+            )
+                .from_utf8(),
+        )?
+        .try_success()?;
+
+    cargo_clean(&test_info)?;
+    restart_sccache(
+        &test_info,
+        Some(vec![("SCCACHE_LOCAL_RW_MODE".into(), "READ_ONLY".into())]),
+    )?;
+    Command::new(CARGO.as_os_str())
+        .args([cmd, "--color=always"])
+        .envs(test_info.env.iter().cloned())
+        .current_dir(CRATE_DIR.as_os_str())
+        .assert()
+        .try_stderr(predicates::str::contains("\x1b[").from_utf8())?
+        .try_success()?;
+
+    test_info
+        .show_stats()?
+        .try_stdout(
+            predicates::str::contains(
+                r#""cache_hits":{"counts":{"Rust":2},"adv_counts":{"rust":2}}"#,
+            )
+            .from_utf8(),
+        )?
+        .try_stdout(
+            predicates::str::contains(
+                r#""cache_misses":{"counts":{},"adv_counts":{}}"#,
+            )
+                .from_utf8(),
         )?
         .try_success()?;
 


### PR DESCRIPTION
This allows the local cache to be set as read-only (similar to GCS read-only) when the `SCCACHE_LOCAL_RW_MODE` environment variable is set to `READ_ONLY` (or the corresponding config option). 

Closes #1852.