### PR TITLE
ci: Bump MSRV to 1.70.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           components: ${{ matrix.component }}
           # Oldest supported version, keep in sync with README.md
-          toolchain: "1.67.1"
+          toolchain: "1.70.0"
 
       - name: clippy version
         run: cargo clippy --version
@@ -67,10 +67,10 @@ jobs:
         include:
           - os: ubuntu-20.04
             # Oldest supported version, keep in sync with README.md
-            rustc: "1.67.1"
+            rustc: "1.70.0"
           - os: ubuntu-22.04
             # Oldest supported version, keep in sync with README.md
-            rustc: "1.67.1"
+            rustc: "1.70.0"
             extra_desc: dist-server
             extra_args: --no-default-features --features=dist-tests test_dist_ -- --test-threads 1
           - os: ubuntu-20.04
@@ -85,7 +85,7 @@ jobs:
           - os: macOS-11
           - os: windows-2019
             # Oldest supported version, keep in sync with README.md
-            rustc: "1.67.1"
+            rustc: "1.70.0"
           - os: windows-2019
             rustc: nightly
             allow_failure: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "sccache"
-rust-version = "1.67.1"
+rust-version = "1.70.0"
 version = "0.7.6"
 
 categories = ["command-line-utilities", "development-tools::build-utils"]

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ And you can build code as usual without any additional flags in the command line
 Build Requirements
 ------------------
 
-sccache is a [Rust](https://www.rust-lang.org/) program. Building it requires `cargo` (and thus`rustc`). sccache currently requires **Rust 1.67.1**. We recommend you install Rust via [Rustup](https://rustup.rs/).
+sccache is a [Rust](https://www.rust-lang.org/) program. Building it requires `cargo` (and thus`rustc`). sccache currently requires **Rust 1.70.0**. We recommend you install Rust via [Rustup](https://rustup.rs/).
 
 Build
 -----

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,7 +35,7 @@ apps:
 parts:
     sccache:
         plugin: rust
-        rust-channel: 1.67.1
+        rust-channel: 1.70.0
         rust-use-global-lto: true
         source: .
         override-pull: |


### PR DESCRIPTION
More and more deps are requiring 1.70.0 now. Let's bump!