### PR TITLE
Make --zero-stats just show a message that it's done its job

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -325,13 +325,13 @@ fn connect_or_start_server(
 }
 
 /// Send a `ZeroStats` request to the server, and return the `ServerInfo` request if successful.
-pub fn request_zero_stats(mut conn: ServerConnection) -> Result<ServerInfo> {
+pub fn request_zero_stats(mut conn: ServerConnection) -> Result<()> {
     debug!("request_stats");
     let response = conn.request(Request::ZeroStats).context(
         "failed to send zero statistics command to server or failed to receive response",
     )?;
-    if let Response::Stats(stats) = response {
-        Ok(*stats)
+    if let Response::ZeroStats = response {
+        Ok(())
     } else {
         bail!("Unexpected server response!")
     }
@@ -671,8 +671,8 @@ pub fn run_command(cmd: Command) -> Result<i32> {
         Command::ZeroStats => {
             trace!("Command::ZeroStats");
             let conn = connect_or_start_server(get_port(), startup_timeout)?;
-            let stats = request_zero_stats(conn).context("couldn't zero stats on server")?;
-            stats.print(false);
+            request_zero_stats(conn).context("couldn't zero stats on server")?;
+            eprintln!("Statistics zeroed.");
         }
         #[cfg(feature = "dist-client")]
         Command::DistAuth => {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -23,6 +23,8 @@ pub enum Request {
 pub enum Response {
     /// Response for `Request::Compile`.
     Compile(CompileResponse),
+    /// Response for `Request::ZeroStats`.
+    ZeroStats,
     /// Response for `Request::GetStats`, containing server statistics.
     Stats(Box<ServerInfo>),
     /// Response for `Request::DistStatus`, containing client info.

--- a/src/server.rs
+++ b/src/server.rs
@@ -805,10 +805,7 @@ where
                 Request::ZeroStats => {
                     debug!("handle_client: zero_stats");
                     me.zero_stats().await;
-                    me.get_info()
-                        .await
-                        .map(|i| Response::Stats(Box::new(i)))
-                        .map(Message::WithoutBody)
+                    Ok(Message::WithoutBody(Response::ZeroStats))
                 }
                 Request::Shutdown => {
                     debug!("handle_client: shutdown");


### PR DESCRIPTION
It's been displaying empty stats, which is useless. Let's make it do the same as the equivalent option in ccache. One can call --show-stats before --zero-stats if they want useful stats (which they had to already if they needed stats).

Fixes #2053