### PR TITLE
add default ttl of 0 to fix breaking change

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -236,6 +236,7 @@ pub struct RedisCacheConfig {
     /// the ttl time in seconds.
     ///
     /// Default to infinity (0)
+    #[serde(default)]
     pub ttl: u64,
 }
 


### PR DESCRIPTION
closes https://github.com/mozilla/sccache/issues/2057