### PR TITLE
github action: run on native m1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
             extra_args: --features=unstable
           - os: ubuntu-22.04
           - os: macOS-11
+          # M1 CPU
+          - os: macos-14
           - os: windows-2019
             # Oldest supported version, keep in sync with README.md
             rustc: "1.70.0"
@@ -147,7 +149,7 @@ jobs:
             macosx_deployment_target: 10.13
             developer_dir: /Applications/Xcode_11.7.app
             sdkroot: /Applications/Xcode_11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
-          - os: macOS-11
+          - os: macos-14
             target: aarch64-apple-darwin
             macosx_deployment_target: 11.0
             developer_dir: /Applications/Xcode_13.2.1.app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,6 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             macosx_deployment_target: 11.0
-            developer_dir: /Applications/Xcode_13.2.1.app
-            sdkroot: /Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk
           - os: windows-2019
             target: x86_64-pc-windows-msvc
             rustflags: -Ctarget-feature=+crt-static


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/