### PR TITLE
chore: update S3 docs on region

### DIFF
--- a/docs/S3.md
+++ b/docs/S3.md
@@ -1,12 +1,14 @@
 # S3
 
-If you want to use S3 storage for the sccache cache, you need to set the `SCCACHE_BUCKET` environment variable to the name of the S3 bucket to use.
+If you want to use S3 storage for the sccache cache, you need to set the following environment variables:
 
-If using the default endpoint, you **must** configure the region using the `SCCACHE_REGION` environment variable, or specify the `region` key in `~/.aws/credentials`. Alternatively you can specify the endpoint URL using the `SCCACHE_ENDPOINT` environment variable. To connect to a minio storage for example you can set `SCCACHE_ENDPOINT=<ip>:<port>`.
+- `SCCACHE_BUCKET` with the name of the S3 bucket to use;
+- `SCCACHE_REGION` with the S3 region. If you have set `SCCACHE_ENDPOINT`, you can set `SCCACHE_REGION` to `auto`;
+- Optionally, `SCCACHE_ENDPOINT=<ip>:<port>` with a custom URL of a server you want a use, such as MinIO or DigitalOcean storage.
 
 If your endpoint requires HTTPS/TLS, set `SCCACHE_S3_USE_SSL=true`. If you don't need a secure network layer, HTTP (`SCCACHE_S3_USE_SSL=false`) might be better for performance.
 
-Enable server side encryption with s3 managed key (SSE-S3), set `SCCACHE_S3_SERVER_SIDE_ENCRYPTION=true` .  
+Enable server-side encryption with s3 managed key (SSE-S3), set `SCCACHE_S3_SERVER_SIDE_ENCRYPTION=true`.  
 More details about encryption [here](https://opendal.apache.org/docs/services/s3/#server-side-encryption) and documentation [here](https://docs.rs/opendal/latest/opendal/services/struct.S3.html#method.server_side_encryption_with_s3_key).
 
 You can also define a prefix that will be prepended to the keys of all cache objects created and read within the S3 bucket, effectively creating a scope. To do that use the `SCCACHE_S3_KEY_PREFIX` environment variable. This can be useful when sharing a bucket with another application.


### PR DESCRIPTION
OpenDAL now expects SCCACHE_REGION to always be set when using S3.
apache/opendal#2812