### PR TITLE
Add generic read-only storage mode for a storage that fails the write check

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -25,12 +25,12 @@ pub mod gha;
 pub mod memcached;
 #[cfg(feature = "oss")]
 pub mod oss;
+pub mod readonly;
 #[cfg(feature = "redis")]
 pub mod redis;
 #[cfg(feature = "s3")]
 pub mod s3;
 #[cfg(feature = "webdav")]
 pub mod webdav;
-pub mod readonly;
 
 pub use crate::cache::cache::*;

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -31,5 +31,6 @@ pub mod redis;
 pub mod s3;
 #[cfg(feature = "webdav")]
 pub mod webdav;
+pub mod readonly;
 
 pub use crate::cache::cache::*;

--- a/src/cache/readonly.rs
+++ b/src/cache/readonly.rs
@@ -20,17 +20,6 @@ use async_trait::async_trait;
 use crate::cache::{Cache, CacheMode, CacheWrite, Storage};
 use crate::errors::*;
 
-#[derive(Debug)]
-pub struct ReadOnlyError;
-
-impl std::error::Error for ReadOnlyError {}
-
-impl std::fmt::Display for ReadOnlyError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Cannot write to read-only storage")
-    }
-}
-
 pub struct ReadOnlyStorage(pub Arc<dyn Storage>);
 
 #[async_trait]
@@ -47,7 +36,7 @@ impl Storage for ReadOnlyStorage
     /// finished.
     async fn put(&self, _key: &str, _entry: CacheWrite) -> Result<Duration>
     {
-        Err(ReadOnlyError{}.into())
+        Err(anyhow!("Cannot write to read-only storage"))
     }
 
     /// Check the cache capability.

--- a/src/cache/readonly.rs
+++ b/src/cache/readonly.rs
@@ -18,7 +18,10 @@ use std::time::Duration;
 use async_trait::async_trait;
 
 use crate::cache::{Cache, CacheMode, CacheWrite, Storage};
+use crate::compiler::PreprocessorCacheEntry;
 use crate::errors::*;
+
+use super::PreprocessorCacheModeConfig;
 
 pub struct ReadOnlyStorage(pub Arc<dyn Storage>);
 
@@ -62,5 +65,82 @@ impl Storage for ReadOnlyStorage
     async fn max_size(&self) -> Result<Option<u64>>
     {
         self.0.max_size().await
+    }
+
+    /// Return the config for preprocessor cache mode if applicable
+    fn preprocessor_cache_mode_config(&self) -> PreprocessorCacheModeConfig {
+        self.0.preprocessor_cache_mode_config()
+    }
+
+    /// Return the preprocessor cache entry for a given preprocessor key,
+    /// if it exists.
+    /// Only applicable when using preprocessor cache mode.
+    fn get_preprocessor_cache_entry(
+        &self,
+        _key: &str,
+    ) -> Result<Option<Box<dyn crate::lru_disk_cache::ReadSeek>>> {
+        self.0.get_preprocessor_cache_entry(_key)
+    }
+
+    /// Insert a preprocessor cache entry at the given preprocessor key,
+    /// overwriting the entry if it exists.
+    /// Only applicable when using preprocessor cache mode.
+    fn put_preprocessor_cache_entry(
+        &self,
+        _key: &str,
+        _preprocessor_cache_entry: PreprocessorCacheEntry,
+    ) -> Result<()> {
+        Err(anyhow!("Cannot write to read-only storage"))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use futures::FutureExt;
+
+    use super::*;
+    use crate::test::mock_storage::MockStorage;
+
+    #[test]
+    fn readonly_storage_is_readonly() {
+        let storage = ReadOnlyStorage(Arc::new(MockStorage::new(None, false)));
+        assert_eq!(storage.check().now_or_never().unwrap().unwrap(), CacheMode::ReadOnly);
+    }
+
+    #[test]
+    fn readonly_storage_forwards_preprocessor_cache_mode_config() {
+        let storage_no_preprocessor_cache = ReadOnlyStorage(Arc::new(MockStorage::new(None, false)));
+        assert_eq!(storage_no_preprocessor_cache.preprocessor_cache_mode_config().use_preprocessor_cache_mode, false);
+
+        let storage_with_preprocessor_cache = ReadOnlyStorage(Arc::new(MockStorage::new(None, true)));
+        assert_eq!(storage_with_preprocessor_cache.preprocessor_cache_mode_config().use_preprocessor_cache_mode, true);
+    }
+
+    #[test]
+    fn readonly_storage_put_err() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .worker_threads(1)
+            .build()
+            .unwrap();
+
+        let storage = ReadOnlyStorage(Arc::new(MockStorage::new(None, true)));
+        runtime.block_on(async move {
+            assert_eq!(
+                storage
+                    .put("test1", CacheWrite::default())
+                    .await
+                    .unwrap_err()
+                    .to_string(),
+                "Cannot write to read-only storage"
+            );
+            assert_eq!(
+                storage
+                    .put_preprocessor_cache_entry("test1", PreprocessorCacheEntry::default())
+                    .unwrap_err()
+                    .to_string(),
+                "Cannot write to read-only storage"
+            );
+        });
     }
 }

--- a/src/cache/readonly.rs
+++ b/src/cache/readonly.rs
@@ -52,16 +52,7 @@ impl Storage for ReadOnlyStorage
 
     /// Check the cache capability.
     ///
-    /// - `Ok(CacheMode::ReadOnly)` means cache can only be used to `get`
-    ///   cache.
-    /// - `Ok(CacheMode::ReadWrite)` means cache can do both `get` and `put`.
-    /// - `Err(err)` means cache is not setup correctly or not match with
-    ///   users input (for example, user try to use `ReadWrite` but cache
-    ///   is `ReadOnly`).
-    ///
-    /// We will provide a default implementation which returns
-    /// `Ok(CacheMode::ReadWrite)` for service that doesn't
-    /// support check yet.
+    /// The ReadOnlyStorage cache is always read-only.
     async fn check(&self) -> Result<CacheMode> {
         Ok(CacheMode::ReadOnly)
     }

--- a/src/cache/readonly.rs
+++ b/src/cache/readonly.rs
@@ -110,10 +110,10 @@ mod test {
     #[test]
     fn readonly_storage_forwards_preprocessor_cache_mode_config() {
         let storage_no_preprocessor_cache = ReadOnlyStorage(Arc::new(MockStorage::new(None, false)));
-        assert_eq!(storage_no_preprocessor_cache.preprocessor_cache_mode_config().use_preprocessor_cache_mode, false);
+        assert!(!storage_no_preprocessor_cache.preprocessor_cache_mode_config().use_preprocessor_cache_mode);
 
         let storage_with_preprocessor_cache = ReadOnlyStorage(Arc::new(MockStorage::new(None, true)));
-        assert_eq!(storage_with_preprocessor_cache.preprocessor_cache_mode_config().use_preprocessor_cache_mode, true);
+        assert!(storage_with_preprocessor_cache.preprocessor_cache_mode_config().use_preprocessor_cache_mode);
     }
 
     #[test]

--- a/src/cache/readonly.rs
+++ b/src/cache/readonly.rs
@@ -1,5 +1,3 @@
-// Copyright 2016 Mozilla Foundation
-//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -26,10 +24,8 @@ use super::PreprocessorCacheModeConfig;
 pub struct ReadOnlyStorage(pub Arc<dyn Storage>);
 
 #[async_trait]
-impl Storage for ReadOnlyStorage
-{
-    async fn get(&self, key: &str) -> Result<Cache>
-    {
+impl Storage for ReadOnlyStorage {
+    async fn get(&self, key: &str) -> Result<Cache> {
         self.0.get(key).await
     }
 
@@ -37,8 +33,7 @@ impl Storage for ReadOnlyStorage
     ///
     /// Returns a `Future` that will provide the result or error when the put is
     /// finished.
-    async fn put(&self, _key: &str, _entry: CacheWrite) -> Result<Duration>
-    {
+    async fn put(&self, _key: &str, _entry: CacheWrite) -> Result<Duration> {
         Err(anyhow!("Cannot write to read-only storage"))
     }
 
@@ -50,20 +45,17 @@ impl Storage for ReadOnlyStorage
     }
 
     /// Get the storage location.
-    fn location(&self) -> String
-    {
+    fn location(&self) -> String {
         self.0.location()
     }
 
     /// Get the current storage usage, if applicable.
-    async fn current_size(&self) -> Result<Option<u64>>
-    {
+    async fn current_size(&self) -> Result<Option<u64>> {
         self.0.current_size().await
     }
 
     /// Get the maximum storage size, if applicable.
-    async fn max_size(&self) -> Result<Option<u64>>
-    {
+    async fn max_size(&self) -> Result<Option<u64>> {
         self.0.max_size().await
     }
 
@@ -104,16 +96,29 @@ mod test {
     #[test]
     fn readonly_storage_is_readonly() {
         let storage = ReadOnlyStorage(Arc::new(MockStorage::new(None, false)));
-        assert_eq!(storage.check().now_or_never().unwrap().unwrap(), CacheMode::ReadOnly);
+        assert_eq!(
+            storage.check().now_or_never().unwrap().unwrap(),
+            CacheMode::ReadOnly
+        );
     }
 
     #[test]
     fn readonly_storage_forwards_preprocessor_cache_mode_config() {
-        let storage_no_preprocessor_cache = ReadOnlyStorage(Arc::new(MockStorage::new(None, false)));
-        assert!(!storage_no_preprocessor_cache.preprocessor_cache_mode_config().use_preprocessor_cache_mode);
+        let storage_no_preprocessor_cache =
+            ReadOnlyStorage(Arc::new(MockStorage::new(None, false)));
+        assert!(
+            !storage_no_preprocessor_cache
+                .preprocessor_cache_mode_config()
+                .use_preprocessor_cache_mode
+        );
 
-        let storage_with_preprocessor_cache = ReadOnlyStorage(Arc::new(MockStorage::new(None, true)));
-        assert!(storage_with_preprocessor_cache.preprocessor_cache_mode_config().use_preprocessor_cache_mode);
+        let storage_with_preprocessor_cache =
+            ReadOnlyStorage(Arc::new(MockStorage::new(None, true)));
+        assert!(
+            storage_with_preprocessor_cache
+                .preprocessor_cache_mode_config()
+                .use_preprocessor_cache_mode
+        );
     }
 
     #[test]

--- a/src/cache/readonly.rs
+++ b/src/cache/readonly.rs
@@ -1,0 +1,86 @@
+// Copyright 2016 Mozilla Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::cache::{Cache, CacheMode, CacheWrite, Storage};
+use crate::errors::*;
+
+#[derive(Debug)]
+pub struct ReadOnlyError;
+
+impl std::error::Error for ReadOnlyError {}
+
+impl std::fmt::Display for ReadOnlyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Cannot write to read-only storage")
+    }
+}
+
+pub struct ReadOnlyStorage(pub Arc<dyn Storage>);
+
+#[async_trait]
+impl Storage for ReadOnlyStorage
+{
+    async fn get(&self, key: &str) -> Result<Cache>
+    {
+        self.0.get(key).await
+    }
+
+    /// Put `entry` in the cache under `key`.
+    ///
+    /// Returns a `Future` that will provide the result or error when the put is
+    /// finished.
+    async fn put(&self, _key: &str, _entry: CacheWrite) -> Result<Duration>
+    {
+        Err(ReadOnlyError{}.into())
+    }
+
+    /// Check the cache capability.
+    ///
+    /// - `Ok(CacheMode::ReadOnly)` means cache can only be used to `get`
+    ///   cache.
+    /// - `Ok(CacheMode::ReadWrite)` means cache can do both `get` and `put`.
+    /// - `Err(err)` means cache is not setup correctly or not match with
+    ///   users input (for example, user try to use `ReadWrite` but cache
+    ///   is `ReadOnly`).
+    ///
+    /// We will provide a default implementation which returns
+    /// `Ok(CacheMode::ReadWrite)` for service that doesn't
+    /// support check yet.
+    async fn check(&self) -> Result<CacheMode> {
+        Ok(CacheMode::ReadOnly)
+    }
+
+    /// Get the storage location.
+    fn location(&self) -> String
+    {
+        self.0.location()
+    }
+
+    /// Get the current storage usage, if applicable.
+    async fn current_size(&self) -> Result<Option<u64>>
+    {
+        self.0.current_size().await
+    }
+
+    /// Get the maximum storage size, if applicable.
+    async fn max_size(&self) -> Result<Option<u64>>
+    {
+        self.0.max_size().await
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -427,7 +427,7 @@ pub fn start_server(config: &Config, port: u16) -> Result<()> {
 
     let notify = env::var_os("SCCACHE_STARTUP_NOTIFY");
 
-    let rawStorage = match storage_from_config(config, &pool) {
+    let raw_storage = match storage_from_config(config, &pool) {
         Ok(storage) => storage,
         Err(err) => {
             error!("storage init failed for: {err:?}");
@@ -444,7 +444,7 @@ pub fn start_server(config: &Config, port: u16) -> Result<()> {
     };
 
     let cache_mode = runtime.block_on(async {
-        match rawStorage.check().await {
+        match raw_storage.check().await {
             Ok(mode) => Ok(mode),
             Err(err) => {
                 error!("storage check failed for: {err:?}");
@@ -463,8 +463,8 @@ pub fn start_server(config: &Config, port: u16) -> Result<()> {
     info!("server has setup with {cache_mode:?}");
 
     let storage = match cache_mode {
-        CacheMode::ReadOnly => Arc::new(ReadOnlyStorage(rawStorage)),
-        _ => rawStorage
+        CacheMode::ReadOnly => Arc::new(ReadOnlyStorage(raw_storage)),
+        _ => raw_storage
     };
 
     let res =

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,7 +13,7 @@
 // limitations under the License.SCCACHE_MAX_FRAME_LENGTH
 
 use crate::cache::readonly::ReadOnlyStorage;
-use crate::cache::{storage_from_config, Storage, CacheMode};
+use crate::cache::{storage_from_config, CacheMode, Storage};
 use crate::compiler::{
     get_compiler_info, CacheControl, CompileResult, Compiler, CompilerArguments, CompilerHasher,
     CompilerKind, CompilerProxy, DistType, Language, MissType,
@@ -464,7 +464,7 @@ pub fn start_server(config: &Config, port: u16) -> Result<()> {
 
     let storage = match cache_mode {
         CacheMode::ReadOnly => Arc::new(ReadOnlyStorage(raw_storage)),
-        _ => raw_storage
+        _ => raw_storage,
     };
 
     let res =

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.SCCACHE_MAX_FRAME_LENGTH
 
-use crate::cache::{storage_from_config, Storage};
+use crate::cache::readonly::ReadOnlyStorage;
+use crate::cache::{storage_from_config, Storage, CacheMode};
 use crate::compiler::{
     get_compiler_info, CacheControl, CompileResult, Compiler, CompilerArguments, CompilerHasher,
     CompilerKind, CompilerProxy, DistType, Language, MissType,
@@ -426,7 +427,7 @@ pub fn start_server(config: &Config, port: u16) -> Result<()> {
 
     let notify = env::var_os("SCCACHE_STARTUP_NOTIFY");
 
-    let storage = match storage_from_config(config, &pool) {
+    let rawStorage = match storage_from_config(config, &pool) {
         Ok(storage) => storage,
         Err(err) => {
             error!("storage init failed for: {err:?}");
@@ -443,7 +444,7 @@ pub fn start_server(config: &Config, port: u16) -> Result<()> {
     };
 
     let cache_mode = runtime.block_on(async {
-        match storage.check().await {
+        match rawStorage.check().await {
             Ok(mode) => Ok(mode),
             Err(err) => {
                 error!("storage check failed for: {err:?}");
@@ -460,6 +461,11 @@ pub fn start_server(config: &Config, port: u16) -> Result<()> {
         }
     })?;
     info!("server has setup with {cache_mode:?}");
+
+    let storage = match cache_mode {
+        CacheMode::ReadOnly => Arc::new(ReadOnlyStorage(rawStorage)),
+        _ => rawStorage
+    };
 
     let res =
         SccacheServer::<ProcessCommandCreator>::new(port, runtime, client, dist_client, storage);


### PR DESCRIPTION
Today, sccache can detect that a storage medium is read-only or read-write even if this capability was not specified by the config. However, it doesn't do anything with this information other than log it for diagnostics.

This PR changes sccache to use this information to avoid writing to a read-only storage. This is useful for cases where one might want to use sccache in a read-only configuration in some cases (e.g. public PR builds) while only updating the cache from a separate pipeline (that has write access) without using a separate configuration file.

Additionally, this change reduces the number of "access denied" errors that would be logged on the storage side when sccache detects that it only has read-only access (instead of continuing to attempt to write to the storage).

Fixes #1853
