### PR TITLE
feat: Add support to Redis cluster mode

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -63,7 +63,17 @@ expiration = 3600
 key_prefix = "/custom/prefix/if/need"
 
 [cache.redis]
+# Deprecated, use `endpoint` instead
 url = "redis://user:passwd@1.2.3.4:6379/?db=1"
+## Refer to the `opendal` documentation for more information about Redis endpoint
+# Single-node endpoint. Mutually exclusive with `cluster_endpoints`
+endpoint = "redis://127.0.0.1:6379"
+# Multiple-node list of endpoints (cluster mode). Mutually exclusive with `endpoint`
+cluster_endpoints = "redis://10.0.0.1:6379,redis://10.0.0.2:6379"
+username = "user"
+password = "passwd"
+# Database number to use. Default is 0
+db = 1
 # Entry expiration time in seconds. Default is 0 (never expire)
 expiration = 3600
 key_prefix = "/custom/prefix/if/need"

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -154,7 +154,7 @@ use self::ArgData::*;
 
 const ARCH_FLAG: &str = "-arch";
 
-// Mostly taken from https://github.com/ccache/ccache/blob/master/src/compopt.c#L32-L84
+// Mostly taken from https://github.com/ccache/ccache/blob/master/src/compopt.cpp#L52-L172
 counted_array!(pub static ARGS: [ArgInfo<ArgData>; _] = [
     flag!("-", TooHardFlag),
     flag!("--coverage", Coverage),


### PR DESCRIPTION
* Add possibility to use Redis in cluster mode
* Store Redis credentials via dedicated fields: for security reasons, as discussed in #2083
* Deprecate `url` usage for Redis config
* Actualize doc