### PR TITLE
chore: use what we really need from `opendal`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ mime = "0.3"
 num_cpus = "1.16"
 number_prefix = "0.4"
 once_cell = "1.19"
-opendal = { version = "0.45.1", optional = true }
+opendal = { version = "0.45.1", optional = true, default-features = false }
 openssl = { version = "0.10.62", optional = true }
 rand = "0.8.4"
 regex = "1.10.3"
@@ -74,6 +74,7 @@ reqwest = { version = "0.11", features = [
   "blocking",
   "stream",
   "rustls-tls",
+  "rustls-tls-native-roots",
   "trust-dns",
 ], optional = true }
 retry = "2"
@@ -155,16 +156,16 @@ all = [
   "webdav",
   "oss",
 ]
-azure = ["opendal", "reqsign"]
+azure = ["opendal/services-azblob", "reqsign"]
 default = ["all"]
-gcs = ["opendal", "reqsign", "url", "reqwest/blocking"]
-gha = ["opendal"]
+gcs = ["opendal/services-gcs", "reqsign", "url", "reqwest/blocking"]
+gha = ["opendal/services-ghac"]
 memcached = ["opendal/services-memcached"]
 native-zlib = []
-oss = ["opendal", "reqsign"]
+oss = ["opendal/services-oss", "reqsign"]
 redis = ["url", "opendal/services-redis"]
-s3 = ["opendal", "reqsign"]
-webdav = ["opendal"]
+s3 = ["opendal/services-s3", "reqsign"]
+webdav = ["opendal/services-webdav"]
 # Enable features that will build a vendored version of openssl and
 # statically linked with it, instead of linking against the system-wide openssl
 # dynamically or statically.


### PR DESCRIPTION
~This PR must be merged only after #2114, because this code is based on the parent changes~