### PR TITLE
WIP: Add option to skip RW mode check

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -19,6 +19,11 @@ cache_dir = "/home/user/.cache/sccache-dist-client"
 type = "token"
 token = "secrettoken"
 
+[cache]
+# If specified, skip the startup check for whether the backend is read-only/writeable;
+# assume it has this mode instead.
+# If unspecified, the server will check the mode at startup.
+assume_rw_mode = "READ_WRITE"
 
 #[cache.azure]
 # does not work as it appears
@@ -135,6 +140,9 @@ configuration variables
 * `SCCACHE_CACHE_MULTIARCH` to disable caching of multi architecture builds.
 
 ### cache configs
+
+* `SCCACHE_ASSUME_RW_MODE` to skip checking whether the cache is correctly configured.
+  Instead, assume it is `READ_ONLY` or `READ_WRITE`- whichever this environment variable specifies.
 
 #### disk (local)
 

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -146,6 +146,7 @@ pub fn sccache_client_cfg(
     };
     sccache::config::FileConfig {
         cache: sccache::config::CacheConfigs {
+            assume_rw_mode: None,
             azure: None,
             disk: Some(disk_cache),
             gcs: None,


### PR DESCRIPTION
WIP: I've not tested this yet.

Adds a config / env option, `cache.assume_rw_mode` or `SCCACHE_ASSUME_RW_MODE`. If present, the server skips the startup check of the cache's mode, and assumes it is the one specified. If not present, the server attempts to read and write from the server, and uses the results to determine the mode.

Fixes #2132 (I think - again, I need to work out how to test this properly before sending forward).