### PR TITLE
Set User Agent Header for S3 Requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ memcached = ["opendal/services-memcached"]
 native-zlib = []
 oss = ["opendal/services-oss", "reqsign"]
 redis = ["url", "opendal/services-redis"]
-s3 = ["opendal/services-s3", "reqsign"]
+s3 = ["opendal/services-s3", "reqsign", "reqwest/blocking"]
 webdav = ["opendal/services-webdav"]
 # Enable features that will build a vendored version of openssl and
 # statically linked with it, instead of linking against the system-wide openssl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ memcached = ["opendal/services-memcached"]
 native-zlib = []
 oss = ["opendal/services-oss", "reqsign"]
 redis = ["url", "opendal/services-redis"]
-s3 = ["opendal/services-s3", "reqsign", "reqwest/blocking"]
+s3 = ["opendal/services-s3", "reqsign", "reqwest"]
 webdav = ["opendal/services-webdav"]
 # Enable features that will build a vendored version of openssl and
 # statically linked with it, instead of linking against the system-wide openssl

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -31,11 +31,7 @@ impl S3Cache {
         server_side_encryption: Option<bool>,
     ) -> Result<Operator> {
         let mut builder = S3::default();
-        let user_agent = format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
-        let client_builder = ClientBuilder::new().user_agent(user_agent);
-        let client =
-            HttpClient::build(client_builder).map_err(|err| err.with_operation("S3::build"))?;
-        builder.http_client(client);
+        builder.http_client(build_http_client());
         builder.bucket(bucket);
         builder.root(key_prefix);
 
@@ -68,6 +64,12 @@ impl S3Cache {
             .finish();
         Ok(op)
     }
+}
+
+fn build_http_client() -> HttpClient {
+    let user_agent = format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    let client_builder = ClientBuilder::new().user_agent(user_agent);
+    HttpClient::build(client_builder).unwrap()
 }
 
 /// Resolve given endpoint along with use_ssl settings.

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -11,8 +11,10 @@
 // limitations under the License.
 
 use opendal::layers::LoggingLayer;
+use opendal::raw::HttpClient;
 use opendal::services::S3;
 use opendal::Operator;
+use reqwest::ClientBuilder;
 
 use crate::errors::*;
 
@@ -29,6 +31,11 @@ impl S3Cache {
         server_side_encryption: Option<bool>,
     ) -> Result<Operator> {
         let mut builder = S3::default();
+        let user_agent = format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        let client_builder = ClientBuilder::new().user_agent(user_agent);
+        let client =
+            HttpClient::build(client_builder).map_err(|err| err.with_operation("S3::build"))?;
+        builder.http_client(client);
         builder.bucket(bucket);
         builder.root(key_prefix);
 

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -31,7 +31,7 @@ impl S3Cache {
         server_side_encryption: Option<bool>,
     ) -> Result<Operator> {
         let mut builder = S3::default();
-        builder.http_client(build_http_client());
+        builder.http_client(set_user_agent());
         builder.bucket(bucket);
         builder.root(key_prefix);
 
@@ -66,7 +66,8 @@ impl S3Cache {
     }
 }
 
-fn build_http_client() -> HttpClient {
+/// Set the user agent (helps with monitoring on the server side)
+fn set_user_agent() -> HttpClient {
     let user_agent = format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
     let client_builder = ClientBuilder::new().user_agent(user_agent);
     HttpClient::build(client_builder).unwrap()


### PR DESCRIPTION
Closes #2136.

This PR configures the S3 backend to use a custom HTTP client that has a user agent header set.

The user agent header enables `sccache` users to write AWS policies to accept or reject `sccache` requests to an S3 bucket based on their `sccache` version.

The user agent header value is like `sccache/0.7.7`.