### PR TITLE
Add required winapi features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,14 @@ optional = true
 version = "0.1.15"
 
 [target.'cfg(windows)'.dependencies.winapi]
-features = ["fileapi", "handleapi", "stringapiset", "winnls"]
+features = [
+  "fileapi",
+  "handleapi",
+  "stringapiset",
+  "winnls",
+  "processenv",
+  "std",
+]
 version = "0.3"
 
 [features]


### PR DESCRIPTION
Currently `cargo install sccache` fails due to missing `winapi` features:

```
error[E0432]: unresolved import `winapi::um::processenv`
   --> C:\Users\x\.cargo\registry\src\index.crates.io-6f17d22bba15001f\sccache-0.8.0\src\commands.rs:136:21
    |
136 |     use winapi::um::processenv::SetStdHandle;
    |                     ^^^^^^^^^^ could not find `processenv` in `um`
```

This is due to the recent `winapi-utils` update removing its `winapi` depencency, which before, through feature-unification, made them available to `sccache`: https://github.com/BurntSushi/winapi-util/commit/732de05aa8e75489864e57896e58ab987802fc50

Both `"processenv"` and `"std`" are required to compile.
