### PR TITLE
Avoid keeping lock while writing to disk cache

### DIFF
--- a/src/compiler/preprocessor_cache.rs
+++ b/src/compiler/preprocessor_cache.rs
@@ -77,7 +77,7 @@ impl PreprocessorCacheEntry {
     }
 
     /// Serialize the preprocessor cache entry to `buf`
-    pub fn serialize_to(&self, buf: &mut impl Write) -> Result<(), Error> {
+    pub fn serialize_to(&self, mut buf: impl Write) -> Result<(), Error> {
         // Add the starting byte for version check since `bincode` doesn't
         // support it.
         buf.write_all(&[FORMAT_VERSION])?;


### PR DESCRIPTION
This splits the insertion operation into two separate operations, so that the lock can be released while performing I/O.