### PR TITLE
refactor: Bump MSRV to 1.75 for async in trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: ci
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   lint:
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
-        component: [clippy]
+        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+        component: [ clippy ]
         include:
           - component: rustfmt
             cargo_cmd: fmt -- --check
@@ -26,7 +26,7 @@ jobs:
         with:
           components: ${{ matrix.component }}
           # Oldest supported version, keep in sync with README.md
-          toolchain: "1.70.0"
+          toolchain: "1.75.0"
 
       - name: clippy version
         run: cargo clippy --version
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        feature: [azure, gcs, gha, memcached, redis, s3, webdav]
+        feature: [ azure, gcs, gha, memcached, redis, s3, webdav ]
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -67,10 +67,10 @@ jobs:
         include:
           - os: ubuntu-20.04
             # Oldest supported version, keep in sync with README.md
-            rustc: "1.70.0"
+            rustc: "1.75.0"
           - os: ubuntu-22.04
             # Oldest supported version, keep in sync with README.md
-            rustc: "1.70.0"
+            rustc: "1.75.0"
             extra_desc: dist-server
             extra_args: --no-default-features --features=dist-tests test_dist_ -- --test-threads 1
           - os: ubuntu-20.04
@@ -91,7 +91,7 @@ jobs:
           - os: macos-14
           - os: windows-2019
             # Oldest supported version, keep in sync with README.md
-            rustc: "1.70.0"
+            rustc: "1.75.0"
           - os: windows-2019
             rustc: nightly
             allow_failure: true
@@ -330,7 +330,7 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
-    needs: [build, lint, test]
+    needs: [ build, lint, test ]
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
       - name: Clone repository

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "sccache"
-rust-version = "1.70.0"
+rust-version = "1.75.0"
 version = "0.8.1"
 
 categories = ["command-line-utilities", "development-tools::build-utils"]

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ And you can build code as usual without any additional flags in the command line
 Build Requirements
 ------------------
 
-sccache is a [Rust](https://www.rust-lang.org/) program. Building it requires `cargo` (and thus`rustc`). sccache currently requires **Rust 1.70.0**. We recommend you install Rust via [Rustup](https://rustup.rs/).
+sccache is a [Rust](https://www.rust-lang.org/) program. Building it requires `cargo` (and thus`rustc`). sccache currently requires **Rust 1.75.0**. We recommend you install Rust via [Rustup](https://rustup.rs/).
 
 Build
 -----

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,22 +4,22 @@ adopt-info: sccache
 
 summary: sccache is ccache with cloud storage
 description: |
-    sccache is a ccache-like compiler caching tool. It is used as a compiler
-    wrapper and avoids compilation when possible, storing cached results either
-    on local disk or in one of several cloud storage backends.
-
-    sccache includes support for caching the compilation of C/C++ code, Rust, as
-    well as NVIDIA's CUDA using nvcc.
-
-    sccache also provides icecream-style distributed compilation (automatic
-    packaging of local toolchains) for all supported compilers (including Rust).
-    The distributed compilation system includes several security features that
-    icecream lacks such as authentication, transport layer encryption, and
-    sandboxed compiler execution on build servers. See the distributed quickstart
-    guide for more information.
-
-    sccache is also available as a GitHub Actions to facilitate the deployment
-    using GitHub Actions cache.
+  sccache is a ccache-like compiler caching tool. It is used as a compiler
+  wrapper and avoids compilation when possible, storing cached results either
+  on local disk or in one of several cloud storage backends.
+  
+  sccache includes support for caching the compilation of C/C++ code, Rust, as
+  well as NVIDIA's CUDA using nvcc.
+  
+  sccache also provides icecream-style distributed compilation (automatic
+  packaging of local toolchains) for all supported compilers (including Rust).
+  The distributed compilation system includes several security features that
+  icecream lacks such as authentication, transport layer encryption, and
+  sandboxed compiler execution on build servers. See the distributed quickstart
+  guide for more information.
+  
+  sccache is also available as a GitHub Actions to facilitate the deployment
+  using GitHub Actions cache.
 website: https://github.com/mozilla/sccache
 contact: https://github.com/mozilla/sccache/issues
 license: "Apache-2.0"
@@ -27,26 +27,26 @@ grade: stable
 confinement: classic
 
 apps:
-    sccache:
-        command: bin/sccache
-    sccache-dist:
-        command: bin/sccache-dist
+  sccache:
+    command: bin/sccache
+  sccache-dist:
+    command: bin/sccache-dist
 
 parts:
-    sccache:
-        plugin: rust
-        rust-channel: 1.70.0
-        rust-use-global-lto: true
-        source: .
-        override-pull: |
-          craftctl default
-          craftctl set version="$( git -C "${CRAFT_PART_SRC}" describe --tags )"
-        build-packages:
-        - libssl-dev
-        - make
-        - pkg-config
-        rust-features:
-        - all
-        - dist-server
-        build-attributes:
-        - enable-patchelf
+  sccache:
+    plugin: rust
+    rust-channel: 1.75.0
+    rust-use-global-lto: true
+    source: .
+    override-pull: |
+      craftctl default
+      craftctl set version="$( git -C "${CRAFT_PART_SRC}" describe --tags )"
+    build-packages:
+      - libssl-dev
+      - make
+      - pkg-config
+    rust-features:
+      - all
+      - dist-server
+    build-attributes:
+      - enable-patchelf

--- a/src/bin/sccache-dist/cmdline/parse.rs
+++ b/src/bin/sccache-dist/cmdline/parse.rs
@@ -131,7 +131,7 @@ fn get_clap_command() -> ClapCommand {
                         ])
                         .group(
                             ArgGroup::new("key_source_mutual_exclusion")
-                                .args(&["config", "secret-key"])
+                                .args(["config", "secret-key"])
                                 .required(true),
                         ),
                 )

--- a/src/bin/sccache-dist/main.rs
+++ b/src/bin/sccache-dist/main.rs
@@ -145,7 +145,7 @@ fn run(command: Command) -> Result<i32> {
             server_id,
         }) => {
             let header = jwt::Header::new(jwt::Algorithm::HS256);
-            let secret_key = BASE64_URL_SAFE_ENGINE.decode(&secret_key)?;
+            let secret_key = BASE64_URL_SAFE_ENGINE.decode(secret_key)?;
             let token = create_jwt_server_token(server_id, &header, &secret_key)
                 .context("Failed to create server token")?;
             println!("{}", token);
@@ -191,7 +191,7 @@ fn run(command: Command) -> Result<i32> {
                 }
                 scheduler_config::ServerAuth::JwtHS256 { secret_key } => {
                     let secret_key = BASE64_URL_SAFE_ENGINE
-                        .decode(&secret_key)
+                        .decode(secret_key)
                         .context("Secret key base64 invalid")?;
                     if secret_key.len() != 256 / 8 {
                         bail!("Size of secret key incorrect")

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -31,7 +31,7 @@ use crate::dist::pkg;
 #[cfg(feature = "dist-client")]
 use crate::lru_disk_cache;
 use crate::mock_command::{exit_status, CommandChild, CommandCreatorSync, RunCommand};
-use crate::util::{fmt_duration_as_secs, ref_env, run_input_output};
+use crate::util::{fmt_duration_as_secs, run_input_output};
 use crate::{counted_array, dist};
 use async_trait::async_trait;
 use filetime::FileTime;
@@ -1100,7 +1100,7 @@ where
         child.arg(&rustc_executable);
     }
 
-    child.env_clear().envs(ref_env(env)).args(&["-vV"]);
+    child.env_clear().envs(env.to_vec()).args(&["-vV"]);
 
     let rustc_vv = run_input_output(child, None).await.map(|output| {
         if let Ok(stdout) = String::from_utf8(output.stdout.clone()) {

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -323,7 +323,7 @@ where
         .args(&parsed_args.preprocessor_args)
         .args(&parsed_args.common_args)
         .env_clear()
-        .envs(env_vars.iter().map(|(k, v)| (k, v)))
+        .envs(env_vars.to_vec())
         .current_dir(cwd);
 
     if log_enabled!(Trace) {

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -726,7 +726,7 @@ fn preprocess_cmd<T>(
     }
     cmd.arg(&parsed_args.input)
         .env_clear()
-        .envs(env_vars.iter().map(|(k, v)| (k, v)))
+        .envs(env_vars.to_vec())
         .current_dir(cwd);
     debug!("cmd after -arch rewrite: {:?}", cmd);
 }

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -891,7 +891,7 @@ pub fn preprocess_cmd<T>(
         .args(&parsed_args.dependency_args)
         .args(&parsed_args.common_args)
         .env_clear()
-        .envs(env_vars.iter().map(|(k, v)| (k, v)))
+        .envs(env_vars.to_vec())
         .current_dir(cwd);
 
     if is_clang {

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -143,7 +143,7 @@ impl CCompilerImpl for Nvcc {
             dep_cmd
                 .args(&transformed_deps)
                 .env_clear()
-                .envs(env_vars.iter().map(|(k, v)| (k, v)))
+                .envs(env_vars.to_vec())
                 .current_dir(cwd);
 
             if log_enabled!(Trace) {
@@ -169,7 +169,7 @@ impl CCompilerImpl for Nvcc {
         cmd.arg("-E")
             .arg(no_line_num_flag)
             .env_clear()
-            .envs(env_vars.iter().map(|(k, v)| (k, v)))
+            .envs(env_vars.to_vec())
             .current_dir(cwd);
         if log_enabled!(Trace) {
             trace!("preprocess: {:?}", cmd);

--- a/src/compiler/nvhpc.rs
+++ b/src/compiler/nvhpc.rs
@@ -120,7 +120,7 @@ impl CCompilerImpl for Nvhpc {
             dep_cmd
                 .args(&transformed_deps)
                 .env_clear()
-                .envs(env_vars.iter().map(|(k, v)| (k, v)))
+                .envs(env_vars.to_vec())
                 .current_dir(cwd);
 
             if log_enabled!(Trace) {
@@ -135,7 +135,7 @@ impl CCompilerImpl for Nvhpc {
         //NVHPC doesn't support disabling line info when outputting to console
         cmd.arg("-E")
             .env_clear()
-            .envs(env_vars.iter().map(|(k, v)| (k, v)))
+            .envs(env_vars.to_vec())
             .current_dir(cwd);
         if log_enabled!(Trace) {
             trace!("preprocess: {:?}", cmd);

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -26,7 +26,7 @@ use crate::dist::pkg;
 use crate::lru_disk_cache::{LruCache, Meter};
 use crate::mock_command::{CommandCreatorSync, RunCommand};
 use crate::util::{fmt_duration_as_secs, hash_all, hash_all_archives, run_input_output, Digest};
-use crate::util::{ref_env, HashToDigest, OsStrExt};
+use crate::util::{HashToDigest, OsStrExt};
 use crate::{counted_array, dist};
 use async_trait::async_trait;
 use filetime::FileTime;
@@ -242,7 +242,7 @@ where
         .arg("-o")
         .arg(&dep_file)
         .env_clear()
-        .envs(ref_env(env_vars))
+        .envs(env_vars.to_vec())
         .current_dir(cwd);
     trace!("[{}]: get dep-info: {:?}", crate_name, cmd);
     // Output of command is in file under dep_file, so we ignore stdout&stderr
@@ -364,7 +364,7 @@ where
     cmd.args(&arguments)
         .args(&["--print", "file-names"])
         .env_clear()
-        .envs(ref_env(env_vars))
+        .envs(env_vars.to_vec())
         .current_dir(cwd);
     if log_enabled!(Trace) {
         trace!("get_compiler_outputs: {:?}", cmd);
@@ -406,7 +406,7 @@ impl Rust {
             .stderr(process::Stdio::null())
             .arg("--print=sysroot")
             .env_clear()
-            .envs(ref_env(env_vars));
+            .envs(env_vars.to_vec());
         let sysroot_and_libs = async move {
             let output = run_input_output(cmd, None).await?;
             //debug!("output.and_then: {}", output);
@@ -549,7 +549,7 @@ where
         child
             .current_dir(&cwd)
             .env_clear()
-            .envs(ref_env(env))
+            .envs(env.to_vec())
             .args(&["which", "rustc"]);
 
         Box::pin(async move {
@@ -632,7 +632,7 @@ impl RustupProxy {
 
         // verify rustc is proxy
         let mut child = creator.new_command_sync(compiler_executable);
-        child.env_clear().envs(ref_env(env)).args(&["+stable"]);
+        child.env_clear().envs(env.to_vec()).args(&["+stable"]);
         let state = run_input_output(child, None).await.map(move |output| {
             if output.status.success() {
                 trace!("proxy: Found a compiler proxy managed by rustup");
@@ -695,7 +695,7 @@ impl RustupProxy {
             Ok(ProxyPath::Candidate(proxy_executable)) => {
                 // verify the candidate is a rustup
                 let mut child = creator.new_command_sync(&proxy_executable);
-                child.env_clear().envs(ref_env(env)).args(&["--version"]);
+                child.env_clear().envs(env.to_vec()).args(&["--version"]);
                 let rustup_candidate_check = run_input_output(child, None).await?;
 
                 let stdout = String::from_utf8(rustup_candidate_check.stdout)
@@ -2305,7 +2305,7 @@ impl RlibDepReader {
             .arg(&temp_rlib)
             .arg("-")
             .env_clear()
-            .envs(ref_env(env_vars));
+            .envs(env_vars.to_vec());
 
         let process::Output {
             status,
@@ -2377,7 +2377,7 @@ impl RlibDepReader {
         cmd.args(["-Z", "ls"])
             .arg(rlib)
             .env_clear()
-            .envs(ref_env(env_vars))
+            .envs(env_vars.to_vec())
             .env("RUSTC_BOOTSTRAP", "1"); // TODO: this is fairly naughty
 
         let process::Output {

--- a/src/compiler/tasking_vx.rs
+++ b/src/compiler/tasking_vx.rs
@@ -304,7 +304,7 @@ where
         .args(&parsed_args.preprocessor_args)
         .args(&parsed_args.common_args)
         .env_clear()
-        .envs(env_vars.iter().map(|(k, v)| (k, v)))
+        .envs(env_vars.to_vec())
         .current_dir(cwd);
 
     if log_enabled!(Trace) {
@@ -334,7 +334,7 @@ where
             .args(&parsed_args.preprocessor_args)
             .args(&parsed_args.common_args)
             .env_clear()
-            .envs(env_vars.iter().map(|(k, v)| (k, v)))
+            .envs(env_vars.to_vec())
             .current_dir(cwd);
 
         if log_enabled!(Trace) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -833,11 +833,6 @@ impl<'a> Hasher for HashToDigest<'a> {
     }
 }
 
-/// Turns a slice of environment var tuples into the type expected by Command::envs.
-pub fn ref_env(env: &[(OsString, OsString)]) -> impl Iterator<Item = (&OsString, &OsString)> {
-    env.iter().map(|(k, v)| (k, v))
-}
-
 /// Pipe `cmd`'s stdio to `/dev/null`, unless a specific env var is set.
 #[cfg(not(windows))]
 pub fn daemonize() -> Result<()> {

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -33,7 +33,7 @@ fn basic_compile(tmpdir: &Path, sccache_cfg_path: &Path, sccache_cached_cfg_path
     let obj_file = "x.o";
     write_source(tmpdir, source_file, "#if !defined(SCCACHE_TEST_DEFINE)\n#error SCCACHE_TEST_DEFINE is not defined\n#endif\nint x() { return 5; }");
     sccache_command()
-        .args(&[
+        .args([
             std::env::var("CC")
                 .unwrap_or_else(|_| "gcc".to_string())
                 .as_str(),

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -231,7 +231,7 @@ impl DistSystem {
     pub fn new(sccache_dist: &Path, tmpdir: &Path) -> Self {
         // Make sure the docker image is available, building it if necessary
         let mut child = Command::new("docker")
-            .args(&["build", "-q", "-t", DIST_IMAGE, "-"])
+            .args(["build", "-q", "-t", DIST_IMAGE, "-"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -265,7 +265,7 @@ impl DistSystem {
         let scheduler_cfg_container_path =
             Path::new(CONFIGS_CONTAINER_PATH).join(scheduler_cfg_relpath);
         let scheduler_cfg = sccache_scheduler_cfg();
-        fs::File::create(&scheduler_cfg_path)
+        fs::File::create(scheduler_cfg_path)
             .unwrap()
             .write_all(&serde_json::to_vec(&scheduler_cfg).unwrap())
             .unwrap();
@@ -273,7 +273,7 @@ impl DistSystem {
         // Create the scheduler
         let scheduler_name = make_container_name("scheduler");
         let output = Command::new("docker")
-            .args(&[
+            .args([
                 "run",
                 "--name",
                 &scheduler_name,
@@ -341,7 +341,7 @@ impl DistSystem {
 
         let server_name = make_container_name("server");
         let output = Command::new("docker")
-            .args(&[
+            .args([
                 "run",
                 // Important for the bubblewrap builder
                 "--privileged",
@@ -436,7 +436,7 @@ impl DistSystem {
         match handle {
             ServerHandle::Container { cid, url: _ } => {
                 let output = Command::new("docker")
-                    .args(&["restart", cid])
+                    .args(["restart", cid])
                     .output()
                     .unwrap();
                 check_output(&output);
@@ -519,29 +519,29 @@ impl Drop for DistSystem {
 
         if let Some(scheduler_name) = self.scheduler_name.as_ref() {
             droperr!(Command::new("docker")
-                .args(&["logs", scheduler_name])
+                .args(["logs", scheduler_name])
                 .output()
                 .map(|o| logs.push((scheduler_name, o))));
             droperr!(Command::new("docker")
-                .args(&["kill", scheduler_name])
+                .args(["kill", scheduler_name])
                 .output()
                 .map(|o| outputs.push((scheduler_name, o))));
             droperr!(Command::new("docker")
-                .args(&["rm", "-f", scheduler_name])
+                .args(["rm", "-f", scheduler_name])
                 .output()
                 .map(|o| outputs.push((scheduler_name, o))));
         }
         for server_name in self.server_names.iter() {
             droperr!(Command::new("docker")
-                .args(&["logs", server_name])
+                .args(["logs", server_name])
                 .output()
                 .map(|o| logs.push((server_name, o))));
             droperr!(Command::new("docker")
-                .args(&["kill", server_name])
+                .args(["kill", server_name])
                 .output()
                 .map(|o| outputs.push((server_name, o))));
             droperr!(Command::new("docker")
-                .args(&["rm", "-f", server_name])
+                .args(["rm", "-f", server_name])
                 .output()
                 .map(|o| outputs.push((server_name, o))));
         }


### PR DESCRIPTION
Rust 1.75 was released six months ago and introduced great features such as `async in trait`. Many of our dependencies, including https://github.com/mozilla/sccache/pull/2202, are adopting this feature. Let's update our MSRV to 1.75.