### PR TITLE
Add ability to specify server port from cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ sccache supports gcc, clang, MSVC, rustc, [NVCC](https://docs.nvidia.com/cuda/cu
 
 If you don't [specify otherwise](#storage-options), sccache will use a local disk cache.
 
-sccache works using a client-server model, where the server runs locally on the same machine as the client. The client-server model allows the server to be more efficient by keeping some state in memory. The sccache command will spawn a server process if one is not already running, or you can run `sccache --start-server` to start the background server process without performing any compilation.
+sccache works using a client-server model, where the server runs locally on the same machine as the client. The client-server model allows the server to be more efficient by keeping some state in memory. The sccache command will spawn a server process if one is not already running, or you can run `sccache --start-server[=port]` to start the background server process without performing any compilation.
 
-You can run `sccache --stop-server` to terminate the server. It will also terminate after (by default) 10 minutes of inactivity.
+You can run `sccache --stop-server[=port]` to terminate the server. It will also terminate after (by default) 10 minutes of inactivity.
 
 Running `sccache --show-stats` will print a summary of cache statistics.
 

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -62,9 +62,9 @@ pub enum Command {
     /// Run background server.
     InternalStartServer,
     /// Start background server as a subprocess.
-    StartServer,
+    StartServer(Option<u16>),
     /// Stop background server.
-    StopServer,
+    StopServer(Option<u16>),
     /// Zero cache statistics and exit.
     ZeroStats,
     /// Show the status of the distributed client.
@@ -136,13 +136,19 @@ fn get_clap_command() -> clap::Command {
                 .action(ArgAction::SetTrue),
             flag_infer_long("start-server")
                 .help("start background server")
-                .action(ArgAction::SetTrue),
+                .value_name("port")
+                .num_args(0..=1)
+                .default_missing_value("None")
+                .action(ArgAction::Append),
             flag_infer_long("debug-preprocessor-cache")
                 .help("show all preprocessor cache entries")
                 .action(ArgAction::SetTrue),
             flag_infer_long("stop-server")
                 .help("stop background server")
-                .action(ArgAction::SetTrue),
+                .value_name("port")
+                .num_args(0..=1)
+                .default_missing_value("None")
+                .action(ArgAction::Append),
             flag_infer_long_and_short("zero-stats")
                 .help("zero statistics counters")
                 .action(ArgAction::SetTrue),
@@ -268,12 +274,18 @@ pub fn try_parse() -> Result<Command> {
                     .cloned()
                     .expect("There is a default value");
                 Ok(Command::ShowStats(fmt, true))
-            } else if matches.get_flag("start-server") {
-                Ok(Command::StartServer)
+            } else if matches.contains_id("start-server") {
+                let port = matches
+                    .get_one::<String>("start-server")
+                    .and_then(|s| s.parse::<u16>().ok());
+                Ok(Command::StartServer(port))
             } else if matches.get_flag("debug-preprocessor-cache") {
                 Ok(Command::DebugPreprocessorCacheEntries)
-            } else if matches.get_flag("stop-server") {
-                Ok(Command::StopServer)
+            } else if matches.contains_id("stop-server") {
+                let port = matches
+                    .get_one::<String>("stop-server")
+                    .and_then(|s| s.parse::<u16>().ok());
+                Ok(Command::StopServer(port))
             } else if matches.get_flag("zero-stats") {
                 Ok(Command::ZeroStats)
             } else if matches.get_flag("dist-auth") {


### PR DESCRIPTION
It now looks to see if a port number was specified on the command line, and tries to use that before looking at the config file or environment variables
Since --start-server calls InternalStartServer under the hood, I have it starting it with the port number specified as the environment variable, although I can change it to also take it from the cli.
Added tests and updated the readme for usages