### PR TITLE
fix: Force disable "warnings as errors" flag for CL preprocessing

### DIFF
--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -908,7 +908,8 @@ pub fn preprocess_cmd<T>(
         }
         // Windows SDK generates C4668 during preprocessing, but compiles fine.
         // Read for more info: https://github.com/mozilla/sccache/issues/1725
-        cmd.arg("/wd4668");
+        // And here: https://github.com/mozilla/sccache/issues/2250
+        cmd.arg("/WX-");
     }
 
     if rewrite_includes_only && is_clang {

--- a/tests/msvc-preprocessing/foo.cpp
+++ b/tests/msvc-preprocessing/foo.cpp
@@ -10,6 +10,14 @@ __pragma(warning(disable: 4668))
 #endif
 __pragma(warning(pop))
 
+// Minimal reproducible example for errors from user code
+// More information: https://github.com/mozilla/sccache/issues/2250
+#pragma warning(disable : 4002)
+
+#define F(x, y)
+
 int main() {
+  F(2, , , , , , 3, , , , , , ) // C4002
+
   return 0;
 }


### PR DESCRIPTION
Fix #2250