### PR TITLE
Handle -Xarch_<arch> <arg> for Clang

### DIFF
--- a/src/compiler/args.rs
+++ b/src/compiler/args.rs
@@ -93,6 +93,8 @@ pub enum ArgDisposition {
     CanBeSeparated(Delimiter),
     /// As "-arg<delimiter>value"
     Concatenated(Delimiter),
+    /// As "-arg<delimiter>suffix value"
+    ConcatenatedAndSeparated(Delimiter),
 }
 
 pub enum NormalizedDisposition {
@@ -456,6 +458,17 @@ impl<T: ArgumentValue> ArgInfo<T> {
                     a => a?,
                 }
             }
+            ArgInfo::TakeArg(_s, create, ArgDisposition::ConcatenatedAndSeparated(_)) => {
+                if let Some(a) = get_next_arg() {
+                    Argument::WithValue(
+                        arg.to_string().leak(),
+                        create(a)?,
+                        ArgDisposition::Separated,
+                    )
+                } else {
+                    return Err(ArgParseError::UnexpectedEndOfArgs);
+                }
+            }
         })
     }
 
@@ -471,6 +484,7 @@ impl<T: ArgumentValue> ArgInfo<T> {
             }
             &ArgInfo::TakeArg(s, _, ArgDisposition::CanBeSeparated(Some(d)))
             | &ArgInfo::TakeArg(s, _, ArgDisposition::Concatenated(Some(d)))
+            | &ArgInfo::TakeArg(s, _, ArgDisposition::ConcatenatedAndSeparated(Some(d)))
                 if arg.len() > s.len() && arg.starts_with(s) =>
             {
                 arg.as_bytes()[s.len()].cmp(&d)
@@ -854,6 +868,16 @@ mod tests {
         assert_eq!(
             info.process("-foo", || Some("bar".into())).unwrap(),
             arg!(WithValue("-foo", Foo("bar"), CanBeConcatenated('=')))
+        );
+
+        let info = take_arg!("-foo", OsString, ConcatenatedAndSeparated('_'), Foo);
+        assert_eq!(
+            info.clone().process("-foo_bar", || None).unwrap_err(),
+            ArgParseError::UnexpectedEndOfArgs
+        );
+        assert_eq!(
+            info.process("-foo_bar", || Some("baz".into())).unwrap(),
+            arg!(WithValue("-foo_bar", Foo("baz"), Separated))
         );
     }
 

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -176,6 +176,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("-MF", PathBuf, CanBeSeparated, DepArgumentPath),
     take_arg!("-MQ", OsString, CanBeSeparated, DepTarget),
     take_arg!("-MT", OsString, CanBeSeparated, DepTarget),
+    take_arg!("-Xarch", OsString, ConcatenatedAndSeparated('_'), PassThrough),
     take_arg!("-Xclang", OsString, Separated, XClang),
     take_arg!("-add-plugin", OsString, Separated, PassThrough),
     take_arg!("-debug-info-kind", OsString, Concatenated('='), PassThrough),

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -186,7 +186,8 @@ where
         match arg {
             Argument::WithValue(_, ref v, ArgDisposition::Separated)
             | Argument::WithValue(_, ref v, ArgDisposition::CanBeConcatenated(_))
-            | Argument::WithValue(_, ref v, ArgDisposition::CanBeSeparated(_)) => {
+            | Argument::WithValue(_, ref v, ArgDisposition::CanBeSeparated(_))
+            | Argument::WithValue(_, ref v, ArgDisposition::ConcatenatedAndSeparated(_)) => {
                 if v.clone().into_arg_os_string().starts_with("@") {
                     cannot_cache!("@");
                 }

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -304,7 +304,8 @@ where
         match arg {
             Argument::WithValue(_, ref v, ArgDisposition::Separated)
             | Argument::WithValue(_, ref v, ArgDisposition::CanBeConcatenated(_))
-            | Argument::WithValue(_, ref v, ArgDisposition::CanBeSeparated(_)) => {
+            | Argument::WithValue(_, ref v, ArgDisposition::CanBeSeparated(_))
+            | Argument::WithValue(_, ref v, ArgDisposition::ConcatenatedAndSeparated(_)) => {
                 if v.clone().into_arg_os_string().starts_with("@") {
                     cannot_cache!("@");
                 }


### PR DESCRIPTION
A new ArgDisposition is introduces that combines the Concatenated and Separated behaviors, but produces results similar to a plain Separated argument with the full original -Xarch_<arch> argument.

Fixes #2090