### PR TITLE
Fix: fix sccache bug for dwo file generate

### DIFF
--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -575,6 +575,9 @@ where
     };
     if split_dwarf {
         let dwo = output.with_extension("dwo");
+        common_args.push(OsString::from(
+            "-D_gsplit_dwarf_path=".to_owned() + dwo.to_str().unwrap(),
+        ));
         // -gsplit-dwarf doesn't guarantee .dwo file if no -g is specified
         outputs.insert(
             "dwo",
@@ -1075,6 +1078,9 @@ mod test {
             CompilerArguments::Ok(args) => args,
             o => panic!("Got unexpected parse result: {:?}", o),
         };
+        let mut common_and_arch_args = common_args.clone();
+        common_and_arch_args.extend(common_args.to_vec());
+        debug!("common_and_arch_args: {:?}", common_and_arch_args);
         assert_eq!(Some("foo.cpp"), input.to_str());
         assert_eq!(Language::Cxx, language);
         assert_map_contains!(
@@ -1095,7 +1101,10 @@ mod test {
             )
         );
         assert!(preprocessor_args.is_empty());
-        assert_eq!(ovec!["-gsplit-dwarf"], common_args);
+        assert!(
+            common_args.contains(&"-gsplit-dwarf".into())
+                && common_args.contains(&"-D_gsplit_dwarf_path=foo.dwo".into())
+        );
         assert!(!msvc_show_includes);
     }
 


### PR DESCRIPTION
When output dir changed, and -g -gsplit-dwarf is enabled, 
because the object file have link to the dwo file (include directories),
the new object file should be gererated, but not old cached object.
In this patch, we add a new precompile macro, for example, "-D_gsplit_dwarf_path=foo.dwo", to force sccache to generate new object file depend on the output directories.

we can check if it work by this case:
case:
```bash
echo "int test(){}" > test.cc
mkdir o1 o2
sccache g++ -c -g -gsplit-dwarf test.cc -o o1/test.o
sccache g++ -c -g -gsplit-dwarf test.cc -o o2/test.o
strings o2/test.o |grep o2/test.dwo
```
The new o2/test.o should contains new link to o2/test.dwo, but not cached o1/test.dwo
