### PR TITLE
[do not merge] Ensure client and scheduler are resilient to server autoscaling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ hyper-util = { version = "0.1.3", optional = true, features = [
   "server",
 ] }
 is-terminal = "0.4.12"
+itertools = "0.12"
 jobserver = "0.1"
 jwt = { package = "jsonwebtoken", version = "9", optional = true }
 libc = "0.2.153"
@@ -126,7 +127,6 @@ assert_cmd = "2.0.13"
 cc = "1.0"
 chrono = "0.4.33"
 filetime = "0.2"
-itertools = "0.12"
 predicates = "=3.1.0"
 serial_test = "3.1"
 temp-env = "0.3.6"

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -124,6 +124,8 @@ Whatever is set by a file based configuration, it is overruled by the env
 configuration variables
 
 ### dist
+* `SCCACHE_DIST_CONNECT_TIMEOUT` Timeout in seconds for connections to an sccache-dist server. Default is `5`.
+* `SCCACHE_DIST_REQUEST_TIMEOUT` Timeout in seconds for compile requests to an sccache-dist server. Default is `600`.
 * `SCCACHE_DIST_RETRY_LIMIT` Number of times the client should retry failed distributed compilations. The default is `0` (no retries).
 
 ### misc

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -123,6 +123,9 @@ The latest `cache.XXX` entries may be found here: https://github.com/mozilla/scc
 Whatever is set by a file based configuration, it is overruled by the env
 configuration variables
 
+### dist
+* `SCCACHE_DIST_RETRY_LIMIT` Number of times the client should retry failed distributed compilations. The default is `0` (no retries).
+
 ### misc
 
 * `SCCACHE_ALLOW_CORE_DUMPS` to enable core dumps by the server

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -130,6 +130,7 @@ impl ParsedArguments {
 }
 
 /// A generic implementation of the `Compilation` trait for C/C++ compilers.
+#[derive(Debug, Clone)]
 struct CCompilation<I: CCompilerImpl> {
     parsed_args: ParsedArguments,
     #[cfg(feature = "dist-client")]
@@ -1172,6 +1173,10 @@ impl<I: CCompilerImpl> Compilation for CCompilation<I> {
                     optional: output.optional,
                 }),
         )
+    }
+
+    fn box_clone(&self) -> Box<dyn Compilation> {
+        Box::new((*self).clone())
     }
 }
 

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1787,6 +1787,10 @@ impl Compilation for RustCompilation {
             optional: v.optional,
         }))
     }
+
+    fn box_clone(&self) -> Box<dyn Compilation> {
+        Box::new((*self).clone())
+    }
 }
 
 // TODO: we do end up with slashes facing the wrong way, but Windows is agnostic so it's

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -24,10 +24,10 @@ use std::env;
 use std::time::Duration;
 
 /// Default timeout for connections to an sccache-dist server
-const DEFAULT_DIST_CONNECT_TIMEOUT: u64 = 5;
+const DEFAULT_DIST_CONNECT_TIMEOUT: u64 = 30;
 
 /// Timeout for connections to an sccache-dist server
-pub fn get_connect_timeout() -> Duration {
+pub fn get_dist_connect_timeout() -> Duration {
     Duration::new(
         env::var("SCCACHE_DIST_CONNECT_TIMEOUT")
             .ok()
@@ -41,7 +41,7 @@ pub fn get_connect_timeout() -> Duration {
 const DEFAULT_DIST_REQUEST_TIMEOUT: u64 = 600;
 
 /// Timeout for compile requests to an sccache-dist server
-pub fn get_request_timeout() -> Duration {
+pub fn get_dist_request_timeout() -> Duration {
     Duration::new(
         env::var("SCCACHE_DIST_REQUEST_TIMEOUT")
             .ok()
@@ -295,7 +295,7 @@ mod server {
         AllocJobHttpResponse, HeartbeatServerHttpRequest, JobJwt, ReqwestRequestBuilderExt,
         RunJobHttpRequest, ServerCertificateHttpResponse,
     };
-    use super::{get_connect_timeout, get_request_timeout, urls};
+    use super::{get_dist_connect_timeout, get_dist_request_timeout, urls};
     use crate::dist::{
         self, AllocJobResult, AssignJobResult, HeartbeatServerResult, InputsReader, JobAuthorizer,
         JobId, JobState, RunJobResult, SchedulerStatusResult, ServerId, ServerNonce,
@@ -776,8 +776,8 @@ mod server {
                 }
                 // Finish the client
                 let new_client = client_builder
-                    .timeout(get_request_timeout())
-                    .connect_timeout(get_connect_timeout())
+                    .timeout(get_dist_request_timeout())
+                    .connect_timeout(get_dist_connect_timeout())
                     // Disable connection pool to avoid broken connection
                     // between runtime
                     .pool_max_idle_per_host(0)
@@ -1130,7 +1130,7 @@ mod client {
         bincode_req_fut, AllocJobHttpResponse, ReqwestRequestBuilderExt, RunJobHttpRequest,
         ServerCertificateHttpResponse,
     };
-    use super::{get_connect_timeout, get_request_timeout, urls};
+    use super::{get_dist_connect_timeout, get_dist_request_timeout, urls};
     use crate::errors::*;
 
     pub struct Client {
@@ -1155,8 +1155,8 @@ mod client {
             rewrite_includes_only: bool,
         ) -> Result<Self> {
             let client = reqwest::ClientBuilder::new()
-                .timeout(get_request_timeout())
-                .connect_timeout(get_connect_timeout())
+                .timeout(get_dist_request_timeout())
+                .connect_timeout(get_dist_connect_timeout())
                 // Disable connection pool to avoid broken connection
                 // between runtime
                 .pool_max_idle_per_host(0)
@@ -1198,8 +1198,8 @@ mod client {
             }
             // Finish the client
             let new_client_async = client_async_builder
-                .timeout(get_request_timeout())
-                .connect_timeout(get_connect_timeout())
+                .timeout(get_dist_request_timeout())
+                .connect_timeout(get_dist_connect_timeout())
                 // Disable keep-alive
                 .pool_max_idle_per_host(0)
                 .build()

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -706,6 +706,7 @@ pub trait BuilderIncoming: Send + Sync {
     // From Server
     fn run_build(
         &self,
+        job_id: JobId,
         toolchain: Toolchain,
         command: CompileCommand,
         outputs: Vec<String>,

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -92,7 +92,7 @@ mod path_transform {
         }
     }
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub struct PathTransformer {
         dist_to_local_path: HashMap<String, PathBuf>,
     }
@@ -269,7 +269,7 @@ mod path_transform {
     use std::iter;
     use std::path::{Path, PathBuf};
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub struct PathTransformer;
 
     impl PathTransformer {

--- a/src/server.rs
+++ b/src/server.rs
@@ -843,14 +843,14 @@ where
                     me.handle_compile(compile).await
                 }
                 Request::GetStats => {
-                    debug!("handle_client: get_stats");
+                    trace!("handle_client: get_stats");
                     me.get_info()
                         .await
                         .map(|i| Response::Stats(Box::new(i)))
                         .map(Message::WithoutBody)
                 }
                 Request::DistStatus => {
-                    debug!("handle_client: dist_status");
+                    trace!("handle_client: dist_status");
                     me.get_dist_status()
                         .await
                         .map(Response::DistStatus)

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #[cfg(any(feature = "dist-server", feature = "dist-client"))]
-use crate::dist::http::{get_connect_timeout, get_request_timeout};
+use crate::dist::http::{get_dist_connect_timeout, get_dist_request_timeout};
 use crate::mock_command::{CommandChild, RunCommand};
 use blake3::Hasher as blake3_Hasher;
 use byteorder::{BigEndian, ByteOrder};
@@ -943,8 +943,8 @@ pub fn daemonize() -> Result<()> {
 pub fn new_reqwest_blocking_client() -> reqwest::blocking::Client {
     reqwest::blocking::Client::builder()
         .pool_max_idle_per_host(0)
-        .timeout(get_request_timeout())
-        .connect_timeout(get_connect_timeout())
+        .timeout(get_dist_request_timeout())
+        .connect_timeout(get_dist_connect_timeout())
         .build()
         .expect("http client must build with success")
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(any(feature = "dist-server", feature = "dist-client"))]
+use crate::dist::http::{get_connect_timeout, get_request_timeout};
 use crate::mock_command::{CommandChild, RunCommand};
 use blake3::Hasher as blake3_Hasher;
 use byteorder::{BigEndian, ByteOrder};
@@ -941,6 +943,8 @@ pub fn daemonize() -> Result<()> {
 pub fn new_reqwest_blocking_client() -> reqwest::blocking::Client {
     reqwest::blocking::Client::builder()
         .pool_max_idle_per_host(0)
+        .timeout(get_request_timeout())
+        .connect_timeout(get_connect_timeout())
         .build()
         .expect("http client must build with success")
 }


### PR DESCRIPTION
While profiling distributed build cluster performance, forcing the client to fallback to local compilation is the largest contributor to overall build time. Presently this happens due to at least one bug, but also sub-optimal error handling in the client and scheduler.

These issues are amplified when autoscaling sccache-dist servers, as the errors happen more frequently, can lead to sub-optimal autoscaling behavior, leading to more errors, etc.

So this PR is a collection of fixes for the sccache client, scheduler, and server to better support dist-server autoscaling, as well as general improvements for tracing and debugging distributed compilation across clients, schedulers, and workers.

* https://github.com/mozilla/sccache/commit/3c4547b66603995c15234e02cd550c4464af55fb Adds the output file, `job_id`, and `server_id` to client logs, and adds `job_id` to scheduler and server logs. This makes it significantly easier to trace build cluster failures across client and server logs.
    Nit: Searching through unstructured/ad-hoc log lines is difficult, using something like [`structured_logger`](https://docs.rs/structured-logger/latest/structured_logger/) instead of `env_logger` would also improve this experience.
* https://github.com/mozilla/sccache/commit/df2e4a1e7a4619db14fc23c5e85b36c7058d9fdd Ensures the client and scheduler use the latest certificates for each server. This is necessary for resiliency when the servers scale in or out (more on this below).
* https://github.com/mozilla/sccache/commit/fe83892a493565e7bb732d049cf8defb25bf9c6c Ensures the scheduler is resilient to server errors, and attempts to allocate jobs to the next-best server candidate (more on this below).
* https://github.com/mozilla/sccache/commit/4657454dd3481b4461e394bc2df97d4892ba7c1d Adds the ability for clients to retry distributed compilations. In conjunction with the two prior commits, this ensures clients with jobs assigned to servers that are scaled in can ask the scheduler to allocate the job to a new server (more on this below).
*  https://github.com/mozilla/sccache/commit/6cd9ff37faafba4e592c08f0ac5bffcd29b1f2bc Adds envvar-configurable connection and request timeouts. Fixes #2276

### Build cluster configuration

Before diving into these changes, I should describe the architecture of the cluster for which these changes are necessary.

1. A [Traefik](https://doc.traefik.io/traefik/) API Gateway to terminate SSL and expose a single endpoint for clients. This could be any API Gateway/LB/router, I just like Traefik.
2. An `sccache-dist` scheduler instance, which receives forwarded connections from Traefik.
3. An autoscaling group of `sccache-dist` servers, which scale in and out based on load, and are associated with one of a fixed pool of ports on the Traefik instance. For example, if the ASG includes up to 10 instances, Traefik will open 10 ports (e.g. 10500-10509) and associate each port with a worker.

Workers are associated with and forwarded traffic from one of Traefik's open ports when they start up, and un-associated with that port when they shut down. When a new worker starts up, it could be associated with any free port, even ports previously associated with a different worker.

Note: While this PR isn't related, this description assumes sccache has been compiled with the changes in https://github.com/mozilla/sccache/pull/1922, as that's necessary for the workers to report the `public_url` of the API Gateway instead of their private VPC address.

### Certificate handling for server scale in and out

When the server cluster goes through a cycle of scaling out, in, then out again, the new servers may be available at addresses that were previously associated with an old server. This presents a challenge for certificate handling, because the client and scheduler may have cached certificates for the initial instance, and those certs are not valid for communicating with the new instance:

```
# scale out to two instances:
127.0.0.1:10500 - server A
127.0.0.1:10501 - server B

# scale in to one instance:
127.0.0.1:10501 - server B

# scale out to three instances:
127.0.0.1:10500 - server C
127.0.0.1:10501 - server B
127.0.0.1:10502 - server D
```

In the initial state, the client and scheduler cached certificates for servers A and B. After scaling in and out again, the client and scheduler attempt and fail to use the certificates generated by server A to communicate with server C. I believe this is because the certificates for A and C both [embed](https://github.com/mozilla/sccache/blob/877746cd784e29536cdee1a18e18b8d38044b730/src/dist/http.rs#L348-L350) `127.0.0.1:10500` as their [`SubjectAlternativeName`](https://www.ssl.com/article/the-essential-guide-to-san-certificates/), and this confuses `reqwest`.

https://github.com/mozilla/sccache/commit/df2e4a1e7a4619db14fc23c5e85b36c7058d9fdd updates the client to track certificates by `server_id` like the server does, and updates both the [client](https://github.com/mozilla/sccache/commit/df2e4a1e7a4619db14fc23c5e85b36c7058d9fdd#diff-6d63828d1891ff3303de7191b656bc451d27703548c42bd9786fcd1c157aa459R1165-R1166) and [scheduler](https://github.com/mozilla/sccache/commit/df2e4a1e7a4619db14fc23c5e85b36c7058d9fdd#diff-6d63828d1891ff3303de7191b656bc451d27703548c42bd9786fcd1c157aa459R739) to remove the old certificate from the certs map before adding the existing certs to the `reqwest` client builder.

### Scheduler job allocation resiliency

There's a delay between when servers scale in and when the scheduler prunes them from the list of active servers. In this time, the scheduler may attempt to allocate jobs to these servers. When this fails, and the current behavior is to return an error to the client to run a local compile.

This is sub-optimal for an autoscaling strategy, since by rejecting the jobs, the additional work sent back to the client to do isn't captured by the autoscaler.

For example, if the autoscaler scales in from 64 to 32 CPUs, and in the meantime the scheduler rejects the next 32 jobs to compile locally, the autoscaler believes it is in a steady-state rather than recognizing there are 64 units of work to handle.

At best, this leads to delays in scaling up, and at worst it can cause the autoscaler to believe it can continue to scale down.

The best solution is for the scheduler to handle the `alloc_job` failure and attempt to allocate to the next-best server candidate, until either the job is allocated or the candidate list is exhausted. This ensures the autoscaler will see the existing instances get busier, and stop scaling in/start scaling out again.

<details><summary><b>Example of starting a cluster with 3 initial workers, scaling down to 1, then running a distributed compile before the scheduler has pruned the dead servers:</b></summary><pre class="notranslate">$ docker compose up -d --scale worker=3
# ... wait till cluster is up
$ docker compose up -d --scale worker=1
$ sccache ...
[INFO  sccache::dist::http::server] Scheduler listening for clients on 0.0.0.0:80
[INFO  sccache::dist::http::server] Adding new certificate for 172.18.0.2:10500 to scheduler
[INFO  sccache_dist] Registered new server ServerId(172.18.0.2:10500)
[INFO  sccache::dist::http::server] Adding new certificate for 172.18.0.2:10501 to scheduler
[INFO  sccache_dist] Registered new server ServerId(172.18.0.2:10501)
[INFO  sccache::dist::http::server] Adding new certificate for 172.18.0.2:10502 to scheduler
[INFO  sccache_dist] Registered new server ServerId(172.18.0.2:10502)
[WARN  sccache_dist] [alloc_job(0)]: POST to scheduler assign_job failed, caused by: error sending request for url (https://172.18.0.2:10502/api/v1/distserver/assign_job/0), caused by: client error (Connect), caused by: error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:2091: (self-signed certificate), caused by: error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:2091:
[INFO  sccache_dist] [alloc_job(0)]: Job created and assigned to server 172.18.0.2:10501 with state Ready
[WARN  sccache_dist] [alloc_job(1)]: POST to scheduler assign_job failed, caused by: error sending request for url (https://172.18.0.2:10500/api/v1/distserver/assign_job/1), caused by: client error (Connect), caused by: error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:2091: (self-signed certificate), caused by: error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:2091:
[INFO  sccache_dist] [alloc_job(2)]: Job created and assigned to server 172.18.0.2:10501 with state Ready
[INFO  sccache_dist] [alloc_job(1)]: Job created and assigned to server 172.18.0.2:10501 with state Ready
[INFO  sccache_dist] [alloc_job(3)]: Job created and assigned to server 172.18.0.2:10501 with state Ready
[INFO  sccache_dist] [update_job_state(0, 172.18.0.2:10501)]: Job state updated from Ready to Started
[INFO  sccache_dist] [update_job_state(2, 172.18.0.2:10501)]: Job state updated from Ready to Started
[INFO  sccache_dist] [update_job_state(1, 172.18.0.2:10501)]: Job state updated from Ready to Started
[INFO  sccache_dist] [update_job_state(3, 172.18.0.2:10501)]: Job state updated from Ready to Started
[INFO  sccache_dist] [update_job_state(0, 172.18.0.2:10501)]: Job state updated from Started to Complete
[INFO  sccache_dist] [update_job_state(2, 172.18.0.2:10501)]: Job state updated from Started to Complete
[INFO  sccache_dist] [update_job_state(1, 172.18.0.2:10501)]: Job state updated from Started to Complete
[INFO  sccache_dist] [update_job_state(3, 172.18.0.2:10501)]: Job state updated from Started to Complete
[WARN  sccache_dist] Server 172.18.0.2:10500 appears to be dead, pruning it in the scheduler
[WARN  sccache_dist] Server 172.18.0.2:10502 appears to be dead, pruning it in the scheduler</pre></details>

### Client job execution resiliency

It's also possible for a server to be taken offline while it's running jobs for clients. In this scenario the scheduler `alloc_job` succeeds when the worker is still alive, but the worker is destroyed while the client is waiting on the `run_job` response.

To avoid the expensive local compilation, the client should handle the failure and allow retrying the job on a new server assigned by the scheduler. When combined with the feature described in the previous section, the scheduler should reallocate the job on an alive server.

<details><summary><b>Example client logs when worker shuts down during run_job, and client retries:</b></summary><pre class="notranslate">$ docker compose up -d --scale worker=10
# ... wait till cluster is up
$ SCCACHE_DIST_RETRY_LIMIT=5 sccache ...
$ docker compose up -d --scale worker=1
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Run distributed compilation (attempt 1 of 6)
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Creating distributed compile request
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Identifying dist toolchain for "/usr/local/cuda/bin/../nvvm/bin/cicc"
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Requesting allocation
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Successfully allocated job 2
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Running job 2 on server 172.18.0.2:10504
[WARN  sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Error running distributed compilation (attempt 1 of 6), retrying. Could not run distributed compilation job on 172.18.0.2:10504: error sending request for url (https://172.18.0.2:10504/api/v1/distserver/run_job/2): client error (SendRequest): connection closed before message completed
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Run distributed compilation (attempt 2 of 6)
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Creating distributed compile request
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Identifying dist toolchain for "/usr/local/cuda/bin/../nvvm/bin/cicc"
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Requesting allocation
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Successfully allocated job 21
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Running job 21 on server 172.18.0.2:10500
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Fetched [("/tmp/sccache_nvcc5K0cEY/0.cudafe1.c", "Size: 209->174"), ("/tmp/sccache_nvcc5K0cEY/1.cudafe1.stub.c", "Size: 1429->635"), ("/tmp/sccache_nvcc5K0cEY/simpleP2P.compute_50.cudafe1.gpu", "Size: 25849->3584"), ("/tmp/sccache_nvcc5K0cEY/simpleP2P.compute_50.ptx", "Size: 874->445")]
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Compiled in 3.963 s, storing in cache
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Created cache artifact in 0.006 s
[DEBUG sccache::server] [simpleP2P.compute_50.ptx]: compile result: cache miss
[DEBUG sccache::server] [simpleP2P.compute_50.ptx]: CompileFinished retcode: exit status: 0
[DEBUG sccache::compiler::compiler] [simpleP2P.compute_50.ptx]: Stored in cache successfully!
</pre></details>
