### PR TITLE
feat: Use profile-generate to replace outdated -Zprofile options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
         env:
           CARGO_INCREMENTAL: "0"
           RUSTC_WRAPPER: ""
-          RUSTFLAGS: "-Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
+          RUSTFLAGS: "-Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cprofile-generate=target/debug"
 
       - name: Generate coverage data (via `grcov`)
         id: coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
         env:
           CARGO_INCREMENTAL: "0"
           RUSTC_WRAPPER: ""
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
+          RUSTFLAGS: "-Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
 
       - name: Generate coverage data (via `grcov`)
         id: coverage

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,5 +1,5 @@
 name: integration-tests
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 env:
   RUST_BACKTRACE: full
@@ -812,7 +812,7 @@ jobs:
     env:
       RUSTC_WRAPPER: /home/runner/.cargo/bin/sccache
       CARGO_INCREMENTAL: "0"
-      RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+      RUSTFLAGS: "-Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
       RUSTDOCFLAGS: "-Cpanic=abort"
 
     steps:

--- a/src/compiler/args.rs
+++ b/src/compiler/args.rs
@@ -671,7 +671,7 @@ macro_rules! take_arg {
         ArgInfo::TakeArg(
             $s,
             |arg: OsString| $vtype::process(arg).map($variant),
-            ArgDisposition::$d(Some(b'=')),
+            ArgDisposition::$d(Some($x as u8)),
         )
     };
 }

--- a/src/compiler/args.rs
+++ b/src/compiler/args.rs
@@ -671,7 +671,7 @@ macro_rules! take_arg {
         ArgInfo::TakeArg(
             $s,
             |arg: OsString| $vtype::process(arg).map($variant),
-            ArgDisposition::$d(Some($x as u8)),
+            ArgDisposition::$d(Some(b'=')),
         )
     };
 }

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -1263,7 +1263,7 @@ impl pkg::ToolchainPackager for CToolchainPackager {
         // files by path.
         let named_file = |kind: &str, name: &str| -> Option<PathBuf> {
             let mut output = process::Command::new(&self.executable)
-                .arg(&format!("-print-{}-name={}", kind, name))
+                .arg(format!("-print-{}-name={}", kind, name))
                 .output()
                 .ok()?;
             debug!(

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -3560,7 +3560,7 @@ proc_macro false
             "./src/lib.rs",
             "--emit=dep-info,link",
             "--out-dir",
-            "/out",
+            "/out"
         );
 
         assert_eq!(h.gcno, Some("foo.gcno".into()));
@@ -3575,7 +3575,7 @@ proc_macro false
             "-C",
             "extra-filename=-a1b6419f8321841f",
             "--out-dir",
-            "/out",
+            "/out"
         );
 
         assert_eq!(h.gcno, Some("foo-a1b6419f8321841f.gcno".into()));

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -3561,7 +3561,6 @@ proc_macro false
             "--emit=dep-info,link",
             "--out-dir",
             "/out",
-            "-Zprofile"
         );
 
         assert_eq!(h.gcno, Some("foo.gcno".into()));
@@ -3577,7 +3576,6 @@ proc_macro false
             "extra-filename=-a1b6419f8321841f",
             "--out-dir",
             "/out",
-            "-Zprofile"
         );
 
         assert_eq!(h.gcno, Some("foo-a1b6419f8321841f.gcno".into()));

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -159,8 +159,8 @@ pub struct ParsedArguments {
     crate_types: CrateTypes,
     /// If dependency info is being emitted, the name of the dep info file.
     dep_info: Option<PathBuf>,
-    /// If gcno info is being emitted, the name of the gcno file.
-    gcno: Option<PathBuf>,
+    /// If profile info is being emitted, the name of the profile file.
+    profile: Option<PathBuf>,
     /// rustc says that emits .rlib for --emit=metadata
     /// https://github.com/rust-lang/rust/issues/54852
     emit: HashSet<String>,
@@ -994,7 +994,6 @@ ArgData! {
     CodeGen(ArgCodegen),
     PassThrough(OsString),
     Target(ArgTarget),
-    Unstable(ArgUnstable),
 }
 
 use self::ArgData::*;
@@ -1036,7 +1035,6 @@ counted_array!(static ARGS: [ArgInfo<ArgData>; _] = [
     take_arg!("-L", ArgLinkPath, CanBeSeparated, LinkPath),
     flag!("-V", NotCompilationFlag),
     take_arg!("-W", OsString, CanBeSeparated, PassThrough),
-    take_arg!("-Z", ArgUnstable, CanBeSeparated, Unstable),
     take_arg!("-l", ArgLinkLibrary, CanBeSeparated, LinkLibrary),
     take_arg!("-o", PathBuf, CanBeSeparated, TooHardPath),
 ]);
@@ -1114,6 +1112,7 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
                 match (opt.as_ref(), value) {
                     ("extra-filename", Some(value)) => extra_filename = Some(value.to_owned()),
                     ("extra-filename", None) => cannot_cache!("extra-filename"),
+                    ("profile-generate", Some(_)) => profile = true,
                     // Incremental compilation makes a mess of sccache's entire world
                     // view. It produces additional compiler outputs that we don't cache,
                     // and just letting rustc do its work in incremental mode is likely
@@ -1126,12 +1125,6 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
                     (_, _) => (),
                 }
             }
-            Some(Unstable(ArgUnstable { opt, value })) => match value.as_deref() {
-                Some("y") | Some("yes") | Some("on") | None if opt == "profile" => {
-                    profile = true;
-                }
-                _ => (),
-            },
             Some(Color(value)) => {
                 // We'll just assume the last specified value wins.
                 color_mode = match value.as_ref() {
@@ -1220,14 +1213,15 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
         None
     };
 
-    // Figure out the gcno filename, if producing gcno files with `-Zprofile`.
-    let gcno = if profile && emit.contains("link") {
-        let mut gcno = crate_name.clone();
+    // Figure out the profile filename, if producing profile files with `-C profile-generate`.
+    let profile = if profile && emit.contains("link") {
+        let mut profile = crate_name.clone();
         if let Some(extra_filename) = extra_filename {
-            gcno.push_str(&extra_filename[..]);
+            profile.push_str(&extra_filename[..]);
         }
-        gcno.push_str(".gcno");
-        Some(gcno)
+        // LLVM will append ".profraw" to the filename.
+        profile.push_str(".profraw");
+        Some(profile)
     } else {
         None
     };
@@ -1267,7 +1261,7 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
         staticlibs,
         crate_name,
         dep_info: dep_info.map(|s| s.into()),
-        gcno: gcno.map(|s| s.into()),
+        profile: profile.map(|s| s.into()),
         emit,
         color_mode,
         has_json,
@@ -1311,7 +1305,7 @@ where
                     dep_info,
                     emit,
                     has_json,
-                    gcno,
+                    profile,
                     ..
                 },
         } = *self;
@@ -1535,10 +1529,10 @@ where
         } else {
             None
         };
-        if let Some(gcno) = gcno {
-            let p = output_dir.join(&gcno);
+        if let Some(profile) = profile {
+            let p = output_dir.join(&profile);
             outputs.insert(
-                gcno.to_string_lossy().into_owned(),
+                profile.to_string_lossy().into_owned(),
                 ArtifactDescriptor {
                     path: p,
                     optional: true,
@@ -3213,7 +3207,7 @@ proc_macro false
                 emit,
                 color_mode: ColorMode::Auto,
                 has_json: false,
-                gcno: None,
+                profile: None,
             },
         });
         let creator = new_creator();
@@ -3560,10 +3554,12 @@ proc_macro false
             "./src/lib.rs",
             "--emit=dep-info,link",
             "--out-dir",
-            "/out"
+            "/out",
+            "-C",
+            "profile-generate=."
         );
 
-        assert_eq!(h.gcno, Some("foo.gcno".into()));
+        assert_eq!(h.profile, Some("foo.profraw".into()));
 
         let h = parses!(
             "--crate-name",
@@ -3575,9 +3571,11 @@ proc_macro false
             "-C",
             "extra-filename=-a1b6419f8321841f",
             "--out-dir",
-            "/out"
+            "/out",
+            "-C",
+            "profile-generate=."
         );
 
-        assert_eq!(h.gcno, Some("foo-a1b6419f8321841f.gcno".into()));
+        assert_eq!(h.profile, Some("foo-a1b6419f8321841f.profraw".into()));
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -56,7 +56,6 @@ use std::task::{Context, Poll, Waker};
 use std::time::Duration;
 #[cfg(feature = "dist-client")]
 use std::time::Instant;
-use std::u64;
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 use tokio::{

--- a/tests/sccache_cargo.rs
+++ b/tests/sccache_cargo.rs
@@ -98,7 +98,10 @@ fn test_rust_cargo_check_nightly() -> Result<()> {
 
     test_rust_cargo_cmd(
         "check",
-        SccacheTest::new(Some(&[("RUSTFLAGS", OsString::from("-Zprofile"))]))?,
+        SccacheTest::new(Some(&[(
+            "RUSTFLAGS",
+            OsString::from("-Cprofile-generate=."),
+        )]))?,
     )
 }
 
@@ -110,7 +113,10 @@ fn test_rust_cargo_check_nightly_readonly() -> Result<()> {
 
     test_rust_cargo_cmd_readonly(
         "check",
-        SccacheTest::new(Some(&[("RUSTFLAGS", OsString::from("-Zprofile"))]))?,
+        SccacheTest::new(Some(&[(
+            "RUSTFLAGS",
+            OsString::from("-Cprofile-generate=."),
+        )]))?,
     )
 }
 
@@ -122,7 +128,10 @@ fn test_rust_cargo_build_nightly() -> Result<()> {
 
     test_rust_cargo_cmd(
         "build",
-        SccacheTest::new(Some(&[("RUSTFLAGS", OsString::from("-Zprofile"))]))?,
+        SccacheTest::new(Some(&[(
+            "RUSTFLAGS",
+            OsString::from("-Cprofile-generate=."),
+        )]))?,
     )
 }
 
@@ -134,7 +143,10 @@ fn test_rust_cargo_build_nightly_readonly() -> Result<()> {
 
     test_rust_cargo_cmd_readonly(
         "build",
-        SccacheTest::new(Some(&[("RUSTFLAGS", OsString::from("-Zprofile"))]))?,
+        SccacheTest::new(Some(&[(
+            "RUSTFLAGS",
+            OsString::from("-Cprofile-generate=."),
+        )]))?,
     )
 }
 


### PR DESCRIPTION
Related to https://github.com/mozilla/grcov/issues/1240

I start this PR to fix the main branch's CI failure, but find out that we need to use profile-generate to replace outdated -Zprofile options.

Refer https://doc.rust-lang.org/rustc/profile-guided-optimization.html for more information.