### PR TITLE
fixed --no-default-features --features=gcs warnings

### DIFF
--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -172,6 +172,7 @@ pub struct ParsedArguments {
 
 /// A struct on which to hang a `Compilation` impl.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct RustCompilation {
     /// The path to the rustc executable, not the rustup proxy.
     executable: PathBuf,


### PR DESCRIPTION
closes #2056 and #2100

## Summary
Removed the warnings by adding `#[allow(dead_code)]` attribute.