### PR TITLE
Always decompose nvcc compilations

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -32,5 +32,6 @@ mod tasking_vx;
 #[macro_use]
 mod counted_array;
 
+pub use crate::compiler::c::CCompilerKind;
 pub use crate::compiler::compiler::*;
 pub use crate::compiler::preprocessor_cache::PreprocessorCacheEntry;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1305,8 +1305,22 @@ where
 
         let out_pretty = hasher.output_pretty().into_owned();
         let color_mode = hasher.color_mode();
-        let kind = compiler.kind();
-        let lang = hasher.language();
+
+        let (kind, lang) = {
+            // HACK: See note in src/compiler/nvcc.rs
+            if env_vars
+                .iter()
+                .any(|(k, _)| k == "__SCCACHE_THIS_IS_A_CUDA_COMPILATION__")
+            {
+                (
+                    CompilerKind::C(crate::compiler::CCompilerKind::Nvcc),
+                    Language::Cuda,
+                )
+            } else {
+                (compiler.kind(), hasher.language())
+            }
+        };
+
         let me = self.clone();
 
         self.rt

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -703,12 +703,12 @@ fn test_nvcc_cuda_compiles(compiler: &Compiler, tempdir: &Path) {
     trace!("compile A request stats");
     get_stats(|info| {
         assert_eq!(2, info.stats.compile_requests);
-        assert_eq!(5, info.stats.requests_executed);
-        assert_eq!(1, info.stats.cache_hits.all());
+        assert_eq!(8, info.stats.requests_executed);
+        assert_eq!(3, info.stats.cache_hits.all());
         assert_eq!(3, info.stats.cache_misses.all());
         assert_eq!(&1, info.stats.cache_hits.get("CUDA").unwrap());
-        assert!(info.stats.cache_hits.get("PTX").is_none());
-        assert!(info.stats.cache_hits.get("CUBIN").is_none());
+        assert_eq!(&1, info.stats.cache_hits.get("PTX").unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get("CUBIN").unwrap());
         assert_eq!(&1, info.stats.cache_misses.get("CUDA").unwrap());
         assert_eq!(&1, info.stats.cache_misses.get("PTX").unwrap());
         assert_eq!(&1, info.stats.cache_misses.get("CUBIN").unwrap());
@@ -717,8 +717,8 @@ fn test_nvcc_cuda_compiles(compiler: &Compiler, tempdir: &Path) {
         let adv_ptx_key = adv_key_kind("ptx", compiler.name);
         let adv_cubin_key = adv_key_kind("cubin", compiler.name);
         assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cuda_key).unwrap());
-        assert!(info.stats.cache_hits.get_adv(&adv_ptx_key).is_none());
-        assert!(info.stats.cache_hits.get_adv(&adv_cubin_key).is_none());
+        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cubin_key).unwrap());
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_cuda_key).unwrap());
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_cubin_key).unwrap());
@@ -747,12 +747,12 @@ fn test_nvcc_cuda_compiles(compiler: &Compiler, tempdir: &Path) {
     trace!("compile B request stats");
     get_stats(|info| {
         assert_eq!(3, info.stats.compile_requests);
-        assert_eq!(9, info.stats.requests_executed);
-        assert_eq!(2, info.stats.cache_hits.all());
+        assert_eq!(12, info.stats.requests_executed);
+        assert_eq!(4, info.stats.cache_hits.all());
         assert_eq!(5, info.stats.cache_misses.all());
         assert_eq!(&1, info.stats.cache_hits.get("CUDA").unwrap());
-        assert!(info.stats.cache_hits.get("PTX").is_none());
-        assert_eq!(&1, info.stats.cache_hits.get("CUBIN").unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get("PTX").unwrap());
+        assert_eq!(&2, info.stats.cache_hits.get("CUBIN").unwrap());
         assert_eq!(&2, info.stats.cache_misses.get("CUDA").unwrap());
         assert_eq!(&2, info.stats.cache_misses.get("PTX").unwrap());
         assert_eq!(&1, info.stats.cache_misses.get("CUBIN").unwrap());
@@ -761,8 +761,8 @@ fn test_nvcc_cuda_compiles(compiler: &Compiler, tempdir: &Path) {
         let adv_ptx_key = adv_key_kind("ptx", compiler.name);
         let adv_cubin_key = adv_key_kind("cubin", compiler.name);
         assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cuda_key).unwrap());
-        assert!(info.stats.cache_hits.get_adv(&adv_ptx_key).is_none());
-        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cubin_key).unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
+        assert_eq!(&2, info.stats.cache_hits.get_adv(&adv_cubin_key).unwrap());
         assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_cuda_key).unwrap());
         assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_cubin_key).unwrap());
@@ -789,13 +789,13 @@ fn test_nvcc_cuda_compiles(compiler: &Compiler, tempdir: &Path) {
     trace!("compile ptx request stats");
     get_stats(|info| {
         assert_eq!(4, info.stats.compile_requests);
-        assert_eq!(11, info.stats.requests_executed);
-        assert_eq!(3, info.stats.cache_hits.all());
-        assert_eq!(6, info.stats.cache_misses.all());
+        assert_eq!(14, info.stats.requests_executed);
+        assert_eq!(5, info.stats.cache_hits.all());
+        assert_eq!(5, info.stats.cache_misses.all());
         assert_eq!(&1, info.stats.cache_hits.get("CUDA").unwrap());
-        assert_eq!(&1, info.stats.cache_hits.get("PTX").unwrap());
-        assert_eq!(&1, info.stats.cache_hits.get("CUBIN").unwrap());
-        assert_eq!(&3, info.stats.cache_misses.get("CUDA").unwrap());
+        assert_eq!(&2, info.stats.cache_hits.get("PTX").unwrap());
+        assert_eq!(&2, info.stats.cache_hits.get("CUBIN").unwrap());
+        assert_eq!(&2, info.stats.cache_misses.get("CUDA").unwrap());
         assert_eq!(&2, info.stats.cache_misses.get("PTX").unwrap());
         assert_eq!(&1, info.stats.cache_misses.get("CUBIN").unwrap());
         assert!(info.stats.cache_misses.get("C/C++").is_none());
@@ -803,9 +803,9 @@ fn test_nvcc_cuda_compiles(compiler: &Compiler, tempdir: &Path) {
         let adv_ptx_key = adv_key_kind("ptx", compiler.name);
         let adv_cubin_key = adv_key_kind("cubin", compiler.name);
         assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cuda_key).unwrap());
-        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
-        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cubin_key).unwrap());
-        assert_eq!(&3, info.stats.cache_misses.get_adv(&adv_cuda_key).unwrap());
+        assert_eq!(&2, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
+        assert_eq!(&2, info.stats.cache_hits.get_adv(&adv_cubin_key).unwrap());
+        assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_cuda_key).unwrap());
         assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_cubin_key).unwrap());
     });
@@ -831,13 +831,13 @@ fn test_nvcc_cuda_compiles(compiler: &Compiler, tempdir: &Path) {
     trace!("compile cubin request stats");
     get_stats(|info| {
         assert_eq!(5, info.stats.compile_requests);
-        assert_eq!(14, info.stats.requests_executed);
-        assert_eq!(5, info.stats.cache_hits.all());
-        assert_eq!(7, info.stats.cache_misses.all());
+        assert_eq!(17, info.stats.requests_executed);
+        assert_eq!(7, info.stats.cache_hits.all());
+        assert_eq!(5, info.stats.cache_misses.all());
         assert_eq!(&1, info.stats.cache_hits.get("CUDA").unwrap());
-        assert_eq!(&2, info.stats.cache_hits.get("PTX").unwrap());
-        assert_eq!(&2, info.stats.cache_hits.get("CUBIN").unwrap());
-        assert_eq!(&4, info.stats.cache_misses.get("CUDA").unwrap());
+        assert_eq!(&3, info.stats.cache_hits.get("PTX").unwrap());
+        assert_eq!(&3, info.stats.cache_hits.get("CUBIN").unwrap());
+        assert_eq!(&2, info.stats.cache_misses.get("CUDA").unwrap());
         assert_eq!(&2, info.stats.cache_misses.get("PTX").unwrap());
         assert_eq!(&1, info.stats.cache_misses.get("CUBIN").unwrap());
         assert!(info.stats.cache_misses.get("C/C++").is_none());
@@ -845,9 +845,9 @@ fn test_nvcc_cuda_compiles(compiler: &Compiler, tempdir: &Path) {
         let adv_ptx_key = adv_key_kind("ptx", compiler.name);
         let adv_cubin_key = adv_key_kind("cubin", compiler.name);
         assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cuda_key).unwrap());
-        assert_eq!(&2, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
-        assert_eq!(&2, info.stats.cache_hits.get_adv(&adv_cubin_key).unwrap());
-        assert_eq!(&4, info.stats.cache_misses.get_adv(&adv_cuda_key).unwrap());
+        assert_eq!(&3, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
+        assert_eq!(&3, info.stats.cache_hits.get_adv(&adv_cubin_key).unwrap());
+        assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_cuda_key).unwrap());
         assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_cubin_key).unwrap());
     });
@@ -914,14 +914,14 @@ fn test_nvcc_proper_lang_stat_tracking(compiler: Compiler, tempdir: &Path) {
     trace!("request stats");
     get_stats(|info| {
         assert_eq!(4, info.stats.compile_requests);
-        assert_eq!(8, info.stats.requests_executed);
-        assert_eq!(3, info.stats.cache_hits.all());
+        assert_eq!(12, info.stats.requests_executed);
+        assert_eq!(5, info.stats.cache_hits.all());
         assert_eq!(3, info.stats.cache_misses.all());
-        assert_eq!(&1, info.stats.cache_hits.get("C/C++").unwrap());
-        assert_eq!(&1, info.stats.cache_hits.get("CUDA").unwrap());
-        assert_eq!(&1, info.stats.cache_hits.get("CUBIN").unwrap());
-        assert_eq!(&1, info.stats.cache_misses.get("C/C++").unwrap());
-        assert_eq!(&1, info.stats.cache_misses.get("CUDA").unwrap());
+        assert!(info.stats.cache_hits.get("C/C++").is_none());
+        assert_eq!(&2, info.stats.cache_hits.get("CUDA").unwrap());
+        assert_eq!(&2, info.stats.cache_hits.get("CUBIN").unwrap());
+        assert!(info.stats.cache_misses.get("C/C++").is_none());
+        assert_eq!(&2, info.stats.cache_misses.get("CUDA").unwrap());
         assert_eq!(&1, info.stats.cache_misses.get("PTX").unwrap());
     });
 }


### PR DESCRIPTION
Never cache the outer CUDA compilation (because `nvcc -E` can't be trusted).

Always decompose via `nvcc --dryrun`, then cache and report the host compiler call as a CUDA compilation.

Fixes https://github.com/mozilla/sccache/issues/2299.