### PR TITLE
fix: bring "cargo build -Zprofile" support back

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -805,14 +805,15 @@ jobs:
 
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
-  rust-test-coverage:
+  # The test cargo "cargo build -Zprofile"
+  rust-test-Z-profile:
     runs-on: ubuntu-latest
     needs: build
 
     env:
       RUSTC_WRAPPER: /home/runner/.cargo/bin/sccache
       CARGO_INCREMENTAL: "0"
-      RUSTFLAGS: "-Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+      RUSTFLAGS: "-Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort -Zprofile"
       RUSTDOCFLAGS: "-Cpanic=abort"
 
     steps:
@@ -825,21 +826,24 @@ jobs:
 
       - name: Prepare
         run: |
-          rustup toolchain install nightly
+          # The last nightly rust that still support "-Zprofile"
+          #
+          # See https://github.com/rust-lang/rust/pull/131829
+          rustup toolchain install nightly-2024-11-01
           cargo new coverage-test
           cd coverage-test
           echo "serde = { version = \"1.0\", features = [\"derive\"] }" >> Cargo.toml
 
       - name: "Coverage test #1"
         working-directory: ./coverage-test
-        run: cargo clean && cargo +nightly test
+        run: cargo clean && cargo +nightly-2024-11-01 test
 
       - name: Output
         run: ${SCCACHE_PATH} --show-stats
 
       - name: "Coverage test #2"
         working-directory: ./coverage-test
-        run: cargo clean && cargo +nightly test
+        run: cargo clean && cargo +nightly-2024-11-01 test
 
       - name: Output
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -824,30 +824,28 @@ jobs:
       - name: Chmod for binary
         run: chmod +x ${SCCACHE_PATH}
 
-      - name: Prepare
-        run: |
-          # The last nightly rust that still support "-Zprofile"
-          #
-          # See https://github.com/rust-lang/rust/pull/131829
-          rustup toolchain install nightly-2024-11-01
-          cargo new coverage-test
-          cd coverage-test
-          echo "serde = { version = \"1.0\", features = [\"derive\"] }" >> Cargo.toml
+      # The last nightly rust that still support "-Zprofile"
+      #
+      # See https://github.com/rust-lang/rust/pull/131829
+      - name: Install rust
+        uses: ./.github/actions/rust-toolchain
+        with:
+          toolchain: "nightly-2024-11-01"
 
       - name: "Coverage test #1"
-        working-directory: ./coverage-test
-        run: cargo clean && cargo +nightly-2024-11-01 test
-
-      - name: Output
-        run: ${SCCACHE_PATH} --show-stats
-
-      - name: "Coverage test #2"
-        working-directory: ./coverage-test
-        run: cargo clean && cargo +nightly-2024-11-01 test
+        run: cargo +nightly-2024-11-01 clean && cargo +nightly-2024-11-01 build
 
       - name: Output
         run: |
           ${SCCACHE_PATH} --show-stats
+
+      - name: "Coverage test #2"
+        run: cargo +nightly-2024-11-01 clean && cargo +nightly-2024-11-01 build
+
+      - name: Output
+        run: |
+          ${SCCACHE_PATH} --show-stats
+
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
   zstd-compression-level:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -815,6 +815,10 @@ jobs:
       CARGO_INCREMENTAL: "0"
       RUSTFLAGS: "-Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort -Zprofile"
       RUSTDOCFLAGS: "-Cpanic=abort"
+      # The last nightly rust that still support "-Zprofile"
+      #
+      # See https://github.com/rust-lang/rust/pull/131829
+      RUST_TEST_TOOLCHAIN: nightly-2024-11-01
 
     steps:
       - uses: actions/download-artifact@v4
@@ -824,23 +828,20 @@ jobs:
       - name: Chmod for binary
         run: chmod +x ${SCCACHE_PATH}
 
-      # The last nightly rust that still support "-Zprofile"
-      #
-      # See https://github.com/rust-lang/rust/pull/131829
       - name: Install rust
         uses: ./.github/actions/rust-toolchain
         with:
-          toolchain: "nightly-2024-11-01"
+          toolchain: ${{ env.RUST_TEST_TOOLCHAIN }}
 
       - name: "Coverage test #1"
-        run: cargo +nightly-2024-11-01 clean && cargo +nightly-2024-11-01 build
+        run: cargo +${{ env.RUST_TEST_TOOLCHAIN }} clean && cargo +${{ env.RUST_TEST_TOOLCHAIN }} build
 
       - name: Output
         run: |
           ${SCCACHE_PATH} --show-stats
 
       - name: "Coverage test #2"
-        run: cargo +nightly-2024-11-01 clean && cargo +nightly-2024-11-01 build
+        run: cargo +${{ env.RUST_TEST_TOOLCHAIN }} clean && cargo +${{ env.RUST_TEST_TOOLCHAIN }} build
 
       - name: Output
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -821,17 +821,20 @@ jobs:
       RUST_TEST_TOOLCHAIN: nightly-2024-11-01
 
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Install rust
+        uses: ./.github/actions/rust-toolchain
+        with:
+          toolchain: ${{ env.RUST_TEST_TOOLCHAIN }}
+
       - uses: actions/download-artifact@v4
         with:
           name: integration-tests
           path: /home/runner/.cargo/bin/
       - name: Chmod for binary
         run: chmod +x ${SCCACHE_PATH}
-
-      - name: Install rust
-        uses: ./.github/actions/rust-toolchain
-        with:
-          toolchain: ${{ env.RUST_TEST_TOOLCHAIN }}
 
       - name: "Coverage test #1"
         run: cargo +${{ env.RUST_TEST_TOOLCHAIN }} clean && cargo +${{ env.RUST_TEST_TOOLCHAIN }} build

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -163,9 +163,11 @@ pub struct ParsedArguments {
     dep_info: Option<PathBuf>,
     /// If profile info is being emitted, the path of the profile.
     ///
-    /// This could be filled while `-Cprofile-generate` or `-Cprofile-use` been enabled.
+    /// This could be filled while `-Cprofile-use` been enabled.
     ///
     /// We need to add the profile into our outputs to enable distributed compilation.
+    /// We don't need to track `profile-generate` since it's users work to make sure
+    /// the `profdata` been generated from profraw files.
     ///
     /// For more information, see https://doc.rust-lang.org/rustc/profile-guided-optimization.html
     profile: Option<PathBuf>,
@@ -1133,7 +1135,6 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
                 match (opt.as_ref(), value) {
                     ("extra-filename", Some(value)) => extra_filename = Some(value.to_owned()),
                     ("extra-filename", None) => cannot_cache!("extra-filename"),
-                    ("profile-generate", Some(v)) => profile = Some(v.to_string()),
                     ("profile-use", Some(v)) => profile = Some(v.to_string()),
                     // Incremental compilation makes a mess of sccache's entire world
                     // view. It produces additional compiler outputs that we don't cache,

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -3728,11 +3728,10 @@ proc_macro false
             "--emit=dep-info,link",
             "--out-dir",
             "/out",
-            "-C",
-            "profile-generate=."
+            "-Zprofile"
         );
 
-        assert_eq!(h.profile, Some("foo.profraw".into()));
+        assert_eq!(h.gcno, Some("foo.gcno".into()));
 
         let h = parses!(
             "--crate-name",
@@ -3745,10 +3744,9 @@ proc_macro false
             "extra-filename=-a1b6419f8321841f",
             "--out-dir",
             "/out",
-            "-C",
-            "profile-generate=."
+            "-Zprofile"
         );
 
-        assert_eq!(h.profile, Some("foo-a1b6419f8321841f.profraw".into()));
+        assert_eq!(h.gcno, Some("foo-a1b6419f8321841f.gcno".into()));
     }
 }


### PR DESCRIPTION
Close https://github.com/mozilla/sccache/pull/2297.

In https://github.com/mozilla/sccache/pull/2282, I mistakenly removed the `-Zprofile` support, which is still used by many older Rust nightly toolchains. This PR restores this feature.

Additionally, this PR updates the CI to ensure it will not be broken by similar changes in the future.