### PR TITLE
Add bind_address config field

### DIFF
--- a/src/bin/sccache-dist/main.rs
+++ b/src/bin/sccache-dist/main.rs
@@ -225,6 +225,7 @@ fn run(command: Command) -> Result<i32> {
             builder,
             cache_dir,
             public_addr,
+            bind_address,
             scheduler_url,
             scheduler_auth,
             toolchain_cache_size,
@@ -288,7 +289,7 @@ fn run(command: Command) -> Result<i32> {
             let server = Server::new(builder, &cache_dir, toolchain_cache_size)
                 .context("Failed to create sccache server instance")?;
             let http_server = dist::http::Server::new(
-                public_addr,
+                bind_address.unwrap_or(public_addr),
                 scheduler_url.to_url(),
                 scheduler_auth,
                 server,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1207,6 +1207,7 @@ pub mod server {
         pub builder: BuilderType,
         pub cache_dir: PathBuf,
         pub public_addr: SocketAddr,
+        pub bind_address: Option<SocketAddr>,
         pub scheduler_url: HTTPUrl,
         pub scheduler_auth: SchedulerAuth,
         #[serde(default = "default_toolchain_cache_size")]


### PR DESCRIPTION
Allows binding to local address, uses `public_addr` as default.
Fix for #930, #974.