### PR TITLE
chore: replace is-terminal with standard library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,7 +2544,6 @@ dependencies = [
  "http-body-util",
  "hyper 1.1.0",
  "hyper-util",
- "is-terminal",
  "itertools",
  "jobserver",
  "jsonwebtoken",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ hyper-util = { version = "0.1.3", optional = true, features = [
   "tokio",
   "server",
 ] }
-is-terminal = "0.4.12"
 itertools = "0.12"
 jobserver = "0.1"
 jwt = { package = "jsonwebtoken", version = "9", optional = true }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -25,11 +25,10 @@ use crate::util::daemonize;
 use byteorder::{BigEndian, ByteOrder};
 use fs::{File, OpenOptions};
 use fs_err as fs;
-use is_terminal::IsTerminal;
 use log::Level::Trace;
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 use std::path::Path;


### PR DESCRIPTION
`std::io::IsTerminal` can be used as it is stabilized at Rust 1.70.