### PR TITLE
Fix and update sccache for CUDA 12.8

### DIFF
--- a/.github/actions/nvcc-toolchain/install-cuda.ps1
+++ b/.github/actions/nvcc-toolchain/install-cuda.ps1
@@ -1,7 +1,7 @@
 Param(
     [Parameter(Mandatory=$false)]
     [string]
-    $cudaVersion="12.6.0"
+    $cudaVersion="12.8.0"
 )
 
 # Use System.Version to tokenize version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,10 +93,10 @@ jobs:
             cuda: "11.8"
             extra_desc: cuda11.8
           - os: ubuntu-24.04
-            cuda: "12.6"
+            cuda: "12.8"
             # Oldest supported version, keep in sync with README.md
             rustc: "1.75.0"
-            extra_desc: cuda12.6
+            extra_desc: cuda12.8
           - os: macos-13
           # # M1 CPU
           - os: macos-14
@@ -117,21 +117,21 @@ jobs:
             rustc: beta
             extra_desc: cuda11.8
           - os: windows-2022
-            cuda: "12.6"
+            cuda: "12.8"
             # Oldest supported version, keep in sync with README.md
             rustc: "1.75.0"
             extra_args: --no-fail-fast
-            extra_desc: cuda12.6
+            extra_desc: cuda12.8
           - os: windows-2022
-            cuda: "12.6"
+            cuda: "12.8"
             rustc: nightly
             allow_failure: true
             extra_args: --features=unstable
-            extra_desc: cuda12.6
+            extra_desc: cuda12.8
           - os: windows-2022
-            cuda: "12.6"
+            cuda: "12.8"
             rustc: beta
-            extra_desc: cuda12.6
+            extra_desc: cuda12.8
     env:
       RUST_BACKTRACE: 1
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
           path: ./target/debug/sccache
 
   redis-deprecated:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     services:
@@ -76,7 +76,7 @@ jobs:
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
   redis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     services:
@@ -124,7 +124,7 @@ jobs:
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
   s3_minio:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     # Setup minio server
@@ -184,7 +184,7 @@ jobs:
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
   azblob_azurite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     # Setup azurite server
@@ -240,7 +240,7 @@ jobs:
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
   gha:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     env:
@@ -289,7 +289,7 @@ jobs:
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
   memcached-deprecated:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     # Setup memcached server
@@ -344,7 +344,7 @@ jobs:
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
   memcached:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     # Setup memcached server
@@ -399,7 +399,7 @@ jobs:
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
   webdav:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     env:
@@ -455,7 +455,7 @@ jobs:
     env:
       TARGET: x86_64-pc-windows-msvc
       SCCACHE_EXE: ${{ github.workspace }}\\target\\x86_64-pc-windows-msvc\\debug\\sccache.exe
-      SCCACHE_LOG: "trace"
+      SCCACHE_LOG: "debug"
       SCCACHE_ERROR_LOG: "${{ github.workspace }}\\server_log.txt"
 
     steps:
@@ -471,7 +471,7 @@ jobs:
           target: $TARGET
 
       - name: Build
-        run: cargo build --bin sccache --target $env:TARGET --features=openssl/vendored
+        run: cargo build --bin sccache --target $env:TARGET --features=vendored-openssl
 
       - name: Compile MSVC (no cache)
         shell: bash
@@ -524,7 +524,7 @@ jobs:
         run: cat "$SCCACHE_ERROR_LOG"
 
   clang:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     env:
@@ -578,10 +578,10 @@ jobs:
   hip:
     # Probably wouldn't matter anyway since we run in a container, but staying
     # close to the version is better than not.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build
     container:
-      image: rocm/dev-ubuntu-22.04:6.0
+      image: rocm/dev-ubuntu-24.04:6.3
 
     env:
       # SCCACHE_GHA_ENABLED: "on"
@@ -647,7 +647,7 @@ jobs:
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
   gcc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     env:
@@ -692,7 +692,7 @@ jobs:
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
   autotools:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     env:
@@ -748,7 +748,7 @@ jobs:
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
   cmake:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     env:
@@ -807,7 +807,7 @@ jobs:
 
   # The test cargo "cargo build -Zprofile"
   rust-test-Z-profile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     env:
@@ -853,7 +853,7 @@ jobs:
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
   zstd-compression-level:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
 
     env:

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -155,6 +155,8 @@ pub enum CCompilerKind {
     Msvc,
     /// NVIDIA CUDA compiler
     Nvcc,
+    /// NVIDIA CUDA front-end
+    CudaFE,
     /// NVIDIA CUDA optimizer and PTX generator
     Cicc,
     /// NVIDIA CUDA PTX assembler
@@ -1385,18 +1387,10 @@ impl pkg::ToolchainPackager for CToolchainPackager {
                 add_named_file(&mut package_builder, "liblto_plugin.so")?;
             }
 
-            CCompilerKind::Cicc => {}
-
-            CCompilerKind::Ptxas => {}
-
-            CCompilerKind::Nvcc => {
-                // Various programs called by the nvcc front end.
-                // presumes the underlying host compiler is consistent
-                add_named_file(&mut package_builder, "cudafe++")?;
-                add_named_file(&mut package_builder, "fatbinary")?;
-                add_named_prog(&mut package_builder, "nvlink")?;
-                add_named_prog(&mut package_builder, "ptxas")?;
-            }
+            CCompilerKind::Cicc
+            | CCompilerKind::CudaFE
+            | CCompilerKind::Ptxas
+            | CCompilerKind::Nvcc => {}
 
             CCompilerKind::Nvhpc => {
                 // Various programs called by the nvc nvc++ front end.

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -188,6 +188,7 @@ pub fn language_to_clang_arg(lang: Language) -> Option<&'static str> {
         Language::ObjectiveCxx => Some("objective-c++"),
         Language::ObjectiveCxxHeader => Some("objective-c++-header"),
         Language::Cuda => Some("cuda"),
+        Language::CudaFE => None,
         Language::Ptx => None,
         Language::Cubin => None,
         Language::Rust => None, // Let the compiler decide

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -18,6 +18,7 @@ use crate::compiler::args::*;
 use crate::compiler::c::{CCompiler, CCompilerKind};
 use crate::compiler::cicc::Cicc;
 use crate::compiler::clang::Clang;
+use crate::compiler::cudafe::CudaFE;
 use crate::compiler::diab::Diab;
 use crate::compiler::gcc::Gcc;
 use crate::compiler::msvc;
@@ -222,6 +223,7 @@ pub enum Language {
     ObjectiveCxx,
     ObjectiveCxxHeader,
     Cuda,
+    CudaFE,
     Ptx,
     Cubin,
     Rust,
@@ -268,6 +270,7 @@ impl Language {
             Language::ObjectiveC => "objc",
             Language::ObjectiveCxx | Language::ObjectiveCxxHeader => "objc++",
             Language::Cuda => "cuda",
+            Language::CudaFE => "cuda",
             Language::Ptx => "ptx",
             Language::Cubin => "cubin",
             Language::Rust => "rust",
@@ -288,6 +291,7 @@ impl CompilerKind {
             | Language::ObjectiveCxx
             | Language::ObjectiveCxxHeader => "C/C++",
             Language::Cuda => "CUDA",
+            Language::CudaFE => "CUDA (Device code)",
             Language::Ptx => "PTX",
             Language::Cubin => "CUBIN",
             Language::Rust => "Rust",
@@ -303,6 +307,7 @@ impl CompilerKind {
             CompilerKind::C(CCompilerKind::Gcc) => textual_lang + " [gcc]",
             CompilerKind::C(CCompilerKind::Msvc) => textual_lang + " [msvc]",
             CompilerKind::C(CCompilerKind::Nvcc) => textual_lang + " [nvcc]",
+            CompilerKind::C(CCompilerKind::CudaFE) => textual_lang + " [cudafe++]",
             CompilerKind::C(CCompilerKind::Cicc) => textual_lang + " [cicc]",
             CompilerKind::C(CCompilerKind::Ptxas) => textual_lang + " [ptxas]",
             CompilerKind::C(CCompilerKind::Nvhpc) => textual_lang + " [nvhpc]",
@@ -1165,6 +1170,17 @@ fn is_rustc_like<P: AsRef<Path>>(p: P) -> bool {
     )
 }
 
+/// Returns true if the given path looks like cudafe++
+fn is_nvidia_cudafe<P: AsRef<Path>>(p: P) -> bool {
+    matches!(
+        p.as_ref()
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_lowercase())
+            .as_deref(),
+        Some("cudafe++")
+    )
+}
+
 /// Returns true if the given path looks like cicc
 fn is_nvidia_cicc<P: AsRef<Path>>(p: P) -> bool {
     matches!(
@@ -1248,6 +1264,18 @@ where
 
     let rustc_executable = if let Some(ref rustc_executable) = maybe_rustc_executable {
         rustc_executable
+    } else if is_nvidia_cudafe(executable) {
+        debug!("Found cudafe++");
+        return CCompiler::new(
+            CudaFE {
+                // TODO: Use nvcc --version
+                version: Some(String::new()),
+            },
+            executable.to_owned(),
+            &pool,
+        )
+        .await
+        .map(|c| (Box::new(c) as Box<dyn Compiler<T>>, None));
     } else if is_nvidia_cicc(executable) {
         debug!("Found cicc");
         return CCompiler::new(

--- a/src/compiler/cudafe.rs
+++ b/src/compiler/cudafe.rs
@@ -1,0 +1,189 @@
+// Copyright 2016 Mozilla Foundation
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(unused_imports, dead_code, unused_variables)]
+
+use crate::compiler::args::*;
+use crate::compiler::c::{ArtifactDescriptor, CCompilerImpl, CCompilerKind, ParsedArguments};
+use crate::compiler::cicc;
+use crate::compiler::{
+    CCompileCommand, Cacheable, ColorMode, CompileCommand, CompilerArguments, Language,
+    SingleCompileCommand,
+};
+use crate::{counted_array, dist};
+
+use crate::mock_command::{CommandCreator, CommandCreatorSync, RunCommand};
+
+use async_trait::async_trait;
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process;
+
+use crate::errors::*;
+
+/// A unit struct on which to implement `CCompilerImpl`.
+#[derive(Clone, Debug)]
+pub struct CudaFE {
+    pub version: Option<String>,
+}
+
+#[async_trait]
+impl CCompilerImpl for CudaFE {
+    fn kind(&self) -> CCompilerKind {
+        CCompilerKind::CudaFE
+    }
+    fn plusplus(&self) -> bool {
+        true
+    }
+    fn version(&self) -> Option<String> {
+        self.version.clone()
+    }
+    fn parse_arguments(
+        &self,
+        arguments: &[OsString],
+        cwd: &Path,
+        _env_vars: &[(OsString, OsString)],
+    ) -> CompilerArguments<ParsedArguments> {
+        cicc::parse_arguments(arguments, cwd, Language::CudaFE, &ARGS[..], 1)
+    }
+    #[allow(clippy::too_many_arguments)]
+    async fn preprocess<T>(
+        &self,
+        _creator: &T,
+        _executable: &Path,
+        parsed_args: &ParsedArguments,
+        cwd: &Path,
+        _env_vars: &[(OsString, OsString)],
+        _may_dist: bool,
+        _rewrite_includes_only: bool,
+        _preprocessor_cache_mode: bool,
+    ) -> Result<process::Output>
+    where
+        T: CommandCreatorSync,
+    {
+        cicc::preprocess(cwd, parsed_args).await
+    }
+    fn generate_compile_commands<T>(
+        &self,
+        path_transformer: &mut dist::PathTransformer,
+        executable: &Path,
+        parsed_args: &ParsedArguments,
+        cwd: &Path,
+        env_vars: &[(OsString, OsString)],
+        _rewrite_includes_only: bool,
+    ) -> Result<(
+        Box<dyn CompileCommand<T>>,
+        Option<dist::CompileCommand>,
+        Cacheable,
+    )>
+    where
+        T: CommandCreatorSync,
+    {
+        generate_compile_commands(path_transformer, executable, parsed_args, cwd, env_vars).map(
+            |(command, dist_command, cacheable)| {
+                (CCompileCommand::new(command), dist_command, cacheable)
+            },
+        )
+    }
+}
+
+pub fn generate_compile_commands(
+    path_transformer: &mut dist::PathTransformer,
+    executable: &Path,
+    parsed_args: &ParsedArguments,
+    cwd: &Path,
+    env_vars: &[(OsString, OsString)],
+) -> Result<(
+    SingleCompileCommand,
+    Option<dist::CompileCommand>,
+    Cacheable,
+)> {
+    // Unused arguments
+    #[cfg(not(feature = "dist-client"))]
+    {
+        let _ = path_transformer;
+    }
+
+    let lang_str = &parsed_args.language.as_str();
+    let out_file = match parsed_args.outputs.get("obj") {
+        Some(obj) => &obj.path,
+        None => return Err(anyhow!("Missing {:?} file output", lang_str)),
+    };
+
+    let mut arguments: Vec<OsString> = vec![];
+    arguments.extend_from_slice(&parsed_args.common_args);
+    arguments.extend_from_slice(&parsed_args.unhashed_args);
+    arguments.extend(vec![
+        "--module_id_file_name".into(),
+        out_file.into(),
+        (&parsed_args.input).into(),
+    ]);
+
+    if log_enabled!(log::Level::Trace) {
+        trace!(
+            "[{}]: {} command: {:?}",
+            out_file.file_name().unwrap().to_string_lossy(),
+            executable.file_name().unwrap().to_string_lossy(),
+            [
+                &[format!("cd {} &&", cwd.to_string_lossy()).to_string()],
+                &[executable.to_str().unwrap_or_default().to_string()][..],
+                &dist::osstrings_to_strings(&arguments).unwrap_or_default()[..]
+            ]
+            .concat()
+            .join(" ")
+        );
+    }
+
+    let command = SingleCompileCommand {
+        executable: executable.to_owned(),
+        arguments,
+        env_vars: env_vars.to_owned(),
+        cwd: cwd.to_owned(),
+    };
+
+    #[cfg(not(feature = "dist-client"))]
+    let dist_command = None;
+    #[cfg(feature = "dist-client")]
+    let dist_command = (|| {
+        let mut arguments: Vec<String> = vec![];
+        arguments.extend(dist::osstrings_to_strings(&parsed_args.common_args)?);
+        arguments.extend(dist::osstrings_to_strings(&parsed_args.unhashed_args)?);
+        arguments.extend(vec![
+            "--module_id_file_name".into(),
+            path_transformer.as_dist(out_file)?,
+            path_transformer.as_dist(&parsed_args.input)?,
+        ]);
+        Some(dist::CompileCommand {
+            executable: path_transformer.as_dist(executable.canonicalize().unwrap().as_path())?,
+            arguments,
+            env_vars: dist::osstring_tuples_to_strings(env_vars)?,
+            cwd: path_transformer.as_dist_abs(cwd)?,
+        })
+    })();
+
+    Ok((command, dist_command, Cacheable::Yes))
+}
+
+use cicc::ArgData::*;
+
+counted_array!(pub static ARGS: [ArgInfo<cicc::ArgData>; _] = [
+    take_arg!("--gen_c_file_name", PathBuf, Separated, UnhashedOutput),
+    flag!("--gen_module_id_file", GenModuleIdFileFlag),
+    take_arg!("--module_id_file_name", PathBuf, Separated, Output),
+    take_arg!("--stub_file_name", OsString, Separated, UnhashedPassThrough),
+]);

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -704,6 +704,7 @@ pub fn language_to_gcc_arg(lang: Language) -> Option<&'static str> {
         Language::ObjectiveCxx => Some("objective-c++"),
         Language::ObjectiveCxxHeader => Some("objective-c++-header"),
         Language::Cuda => Some("cu"),
+        Language::CudaFE => None,
         Language::Ptx => None,
         Language::Cubin => None,
         Language::Rust => None, // Let the compiler decide

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -20,6 +20,7 @@ mod clang;
 #[macro_use]
 #[allow(clippy::module_inception)]
 mod compiler;
+mod cudafe;
 mod diab;
 mod gcc;
 mod msvc;

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -454,6 +454,7 @@ pub fn generate_compile_commands(
         num_parallel,
         executable: executable.to_owned(),
         arguments,
+        compilation_flag: parsed_args.compilation_flag.clone(),
         env_vars,
         cwd: cwd.to_owned(),
         host_compiler: host_compiler.clone(),
@@ -484,6 +485,7 @@ pub struct NvccCompileCommand {
     pub num_parallel: usize,
     pub executable: PathBuf,
     pub arguments: Vec<OsString>,
+    pub compilation_flag: OsString,
     pub env_vars: Vec<(OsString, OsString)>,
     pub cwd: PathBuf,
     pub host_compiler: NvccHostCompiler,
@@ -519,6 +521,7 @@ impl CompileCommandImpl for NvccCompileCommand {
             num_parallel,
             executable,
             arguments,
+            compilation_flag,
             env_vars,
             cwd,
             host_compiler,
@@ -529,6 +532,7 @@ impl CompileCommandImpl for NvccCompileCommand {
             creator,
             executable,
             arguments,
+            compilation_flag,
             cwd,
             temp_dir.as_path(),
             keep_dir.clone(),
@@ -625,6 +629,7 @@ async fn group_nvcc_subcommands_by_compilation_stage<T>(
     creator: &T,
     executable: &Path,
     arguments: &[OsString],
+    compilation_flag: &OsStr,
     cwd: &Path,
     tmp: &Path,
     keep_dir: Option<PathBuf>,
@@ -738,6 +743,19 @@ where
             ),
             // cicc and ptxas are cacheable
             Some("cicc") => {
+                match compilation_flag.to_str() {
+                    // Fix for CTK < 12.8:
+                    // If `nvcc` is invoked with `-c` (or any of its variants), remove the
+                    // `--gen_module_id_file` flag. In this mode, we instruct `cudafe++`
+                    // to generate this file, so cicc shouldn't generate it again.
+                    Some("-c") | Some("--compile") | Some("-dc") | Some("--device-c")
+                    | Some("-dw") | Some("--device-w") => {
+                        if let Some(idx) = args.iter().position(|x| x == &gen_module_id_file_flag) {
+                            args.splice(idx..(idx + 1), []);
+                        }
+                    }
+                    _ => {}
+                }
                 let group = device_compile_groups.get_mut(&args[args.len() - 3]);
                 (env_vars.clone(), Cacheable::Yes, group)
             }
@@ -752,7 +770,7 @@ where
                 });
                 (env_vars.clone(), Cacheable::Yes, group)
             }
-            // cudafe++ is not cacheable
+            // cudafe++ _must be_ cached, because the `.module_id` file is unique to each invocation (new in CTK 12.8)
             Some("cudafe++") => {
                 // Fix for CTK < 12.0:
                 // Add `--gen_module_id_file` if the cudafe++ args include `--module_id_file_name`
@@ -764,7 +782,7 @@ where
                 }
                 (
                     env_vars.clone(),
-                    Cacheable::No,
+                    Cacheable::Yes,
                     Some(&mut cuda_front_end_group),
                 )
             }

--- a/src/compiler/ptxas.rs
+++ b/src/compiler/ptxas.rs
@@ -59,7 +59,7 @@ impl CCompilerImpl for Ptxas {
         cwd: &Path,
         _env_vars: &[(OsString, OsString)],
     ) -> CompilerArguments<ParsedArguments> {
-        cicc::parse_arguments(arguments, cwd, Language::Cubin, &ARGS[..])
+        cicc::parse_arguments(arguments, cwd, Language::Cubin, &ARGS[..], 3)
     }
     #[allow(clippy::too_many_arguments)]
     async fn preprocess<T>(

--- a/tests/harness/Dockerfile.sccache-dist
+++ b/tests/harness/Dockerfile.sccache-dist
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:latest
 RUN apt-get update && \
     apt-get install -y libcap2 bubblewrap && \
     apt-get clean

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -46,7 +46,8 @@ pub fn start_local_daemon(cfg_path: &Path, cached_cfg_path: &Path) {
     if !sccache_command()
         .arg("--start-server")
         // Uncomment following lines to debug locally.
-        // .env("SCCACHE_LOG", "debug")
+        // .env("SCCACHE_LOG", "sccache=trace")
+        // .env("RUST_LOG_STYLE", "never")
         // .env(
         //     "SCCACHE_ERROR_LOG",
         //     env::temp_dir().join("sccache_local_daemon.txt"),

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -69,6 +69,7 @@ fn adv_key_kind(lang: &str, compiler: &str) -> String {
         "cl.exe" => language + " [msvc]",
         "nvc" | "nvc++" => language + " [nvhpc]",
         "nvcc" => match lang {
+            "cudafe++" => "cuda [cudafe++]".to_owned(),
             "ptx" => language + " [cicc]",
             "cubin" => language + " [ptxas]",
             _ => language + " [nvcc]",
@@ -667,17 +668,26 @@ fn test_nvcc_cuda_compiles(compiler: &Compiler, tempdir: &Path) {
     trace!("compile A request stats");
     get_stats(|info| {
         assert_eq!(1, info.stats.compile_requests);
-        assert_eq!(4, info.stats.requests_executed);
+        assert_eq!(5, info.stats.requests_executed);
         assert_eq!(0, info.stats.cache_hits.all());
-        assert_eq!(3, info.stats.cache_misses.all());
+        assert_eq!(4, info.stats.cache_misses.all());
         assert_eq!(&1, info.stats.cache_misses.get("CUDA").unwrap());
+        assert_eq!(
+            &1,
+            info.stats.cache_misses.get("CUDA (Device code)").unwrap()
+        );
         assert_eq!(&1, info.stats.cache_misses.get("PTX").unwrap());
         assert_eq!(&1, info.stats.cache_misses.get("CUBIN").unwrap());
         assert!(info.stats.cache_misses.get("C/C++").is_none());
         let adv_cuda_key = adv_key_kind("cuda", compiler.name);
+        let adv_cudafe_key = adv_key_kind("cudafe++", compiler.name);
         let adv_ptx_key = adv_key_kind("ptx", compiler.name);
         let adv_cubin_key = adv_key_kind("cubin", compiler.name);
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_cuda_key).unwrap());
+        assert_eq!(
+            &1,
+            info.stats.cache_misses.get_adv(&adv_cudafe_key).unwrap()
+        );
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_cubin_key).unwrap());
     });
@@ -703,23 +713,34 @@ fn test_nvcc_cuda_compiles(compiler: &Compiler, tempdir: &Path) {
     trace!("compile A request stats");
     get_stats(|info| {
         assert_eq!(2, info.stats.compile_requests);
-        assert_eq!(8, info.stats.requests_executed);
-        assert_eq!(3, info.stats.cache_hits.all());
-        assert_eq!(3, info.stats.cache_misses.all());
+        assert_eq!(10, info.stats.requests_executed);
+        assert_eq!(4, info.stats.cache_hits.all());
+        assert_eq!(4, info.stats.cache_misses.all());
         assert_eq!(&1, info.stats.cache_hits.get("CUDA").unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get("CUDA (Device code)").unwrap());
         assert_eq!(&1, info.stats.cache_hits.get("PTX").unwrap());
         assert_eq!(&1, info.stats.cache_hits.get("CUBIN").unwrap());
         assert_eq!(&1, info.stats.cache_misses.get("CUDA").unwrap());
+        assert_eq!(
+            &1,
+            info.stats.cache_misses.get("CUDA (Device code)").unwrap()
+        );
         assert_eq!(&1, info.stats.cache_misses.get("PTX").unwrap());
         assert_eq!(&1, info.stats.cache_misses.get("CUBIN").unwrap());
         assert!(info.stats.cache_misses.get("C/C++").is_none());
         let adv_cuda_key = adv_key_kind("cuda", compiler.name);
+        let adv_cudafe_key = adv_key_kind("cudafe++", compiler.name);
         let adv_ptx_key = adv_key_kind("ptx", compiler.name);
         let adv_cubin_key = adv_key_kind("cubin", compiler.name);
         assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cuda_key).unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cudafe_key).unwrap());
         assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cubin_key).unwrap());
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_cuda_key).unwrap());
+        assert_eq!(
+            &1,
+            info.stats.cache_misses.get_adv(&adv_cudafe_key).unwrap()
+        );
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_cubin_key).unwrap());
     });
@@ -747,23 +768,34 @@ fn test_nvcc_cuda_compiles(compiler: &Compiler, tempdir: &Path) {
     trace!("compile B request stats");
     get_stats(|info| {
         assert_eq!(3, info.stats.compile_requests);
-        assert_eq!(12, info.stats.requests_executed);
-        assert_eq!(4, info.stats.cache_hits.all());
-        assert_eq!(5, info.stats.cache_misses.all());
+        assert_eq!(15, info.stats.requests_executed);
+        assert_eq!(5, info.stats.cache_hits.all());
+        assert_eq!(7, info.stats.cache_misses.all());
         assert_eq!(&1, info.stats.cache_hits.get("CUDA").unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get("CUDA (Device code)").unwrap());
         assert_eq!(&1, info.stats.cache_hits.get("PTX").unwrap());
         assert_eq!(&2, info.stats.cache_hits.get("CUBIN").unwrap());
         assert_eq!(&2, info.stats.cache_misses.get("CUDA").unwrap());
+        assert_eq!(
+            &2,
+            info.stats.cache_misses.get("CUDA (Device code)").unwrap()
+        );
         assert_eq!(&2, info.stats.cache_misses.get("PTX").unwrap());
         assert_eq!(&1, info.stats.cache_misses.get("CUBIN").unwrap());
         assert!(info.stats.cache_misses.get("C/C++").is_none());
         let adv_cuda_key = adv_key_kind("cuda", compiler.name);
+        let adv_cudafe_key = adv_key_kind("cudafe++", compiler.name);
         let adv_ptx_key = adv_key_kind("ptx", compiler.name);
         let adv_cubin_key = adv_key_kind("cubin", compiler.name);
         assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cuda_key).unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cudafe_key).unwrap());
         assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&2, info.stats.cache_hits.get_adv(&adv_cubin_key).unwrap());
         assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_cuda_key).unwrap());
+        assert_eq!(
+            &2,
+            info.stats.cache_misses.get_adv(&adv_cudafe_key).unwrap()
+        );
         assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_cubin_key).unwrap());
     });
@@ -789,24 +821,35 @@ fn test_nvcc_cuda_compiles(compiler: &Compiler, tempdir: &Path) {
     trace!("compile ptx request stats");
     get_stats(|info| {
         assert_eq!(4, info.stats.compile_requests);
-        assert_eq!(14, info.stats.requests_executed);
+        assert_eq!(17, info.stats.requests_executed);
         assert_eq!(5, info.stats.cache_hits.all());
-        assert_eq!(5, info.stats.cache_misses.all());
+        assert_eq!(8, info.stats.cache_misses.all());
         assert_eq!(&1, info.stats.cache_hits.get("CUDA").unwrap());
-        assert_eq!(&2, info.stats.cache_hits.get("PTX").unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get("CUDA (Device code)").unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get("PTX").unwrap());
         assert_eq!(&2, info.stats.cache_hits.get("CUBIN").unwrap());
         assert_eq!(&2, info.stats.cache_misses.get("CUDA").unwrap());
-        assert_eq!(&2, info.stats.cache_misses.get("PTX").unwrap());
+        assert_eq!(
+            &2,
+            info.stats.cache_misses.get("CUDA (Device code)").unwrap()
+        );
+        assert_eq!(&3, info.stats.cache_misses.get("PTX").unwrap());
         assert_eq!(&1, info.stats.cache_misses.get("CUBIN").unwrap());
         assert!(info.stats.cache_misses.get("C/C++").is_none());
         let adv_cuda_key = adv_key_kind("cuda", compiler.name);
+        let adv_cudafe_key = adv_key_kind("cudafe++", compiler.name);
         let adv_ptx_key = adv_key_kind("ptx", compiler.name);
         let adv_cubin_key = adv_key_kind("cubin", compiler.name);
         assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cuda_key).unwrap());
-        assert_eq!(&2, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cudafe_key).unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&2, info.stats.cache_hits.get_adv(&adv_cubin_key).unwrap());
         assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_cuda_key).unwrap());
-        assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
+        assert_eq!(
+            &2,
+            info.stats.cache_misses.get_adv(&adv_cudafe_key).unwrap()
+        );
+        assert_eq!(&3, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_cubin_key).unwrap());
     });
 
@@ -831,24 +874,35 @@ fn test_nvcc_cuda_compiles(compiler: &Compiler, tempdir: &Path) {
     trace!("compile cubin request stats");
     get_stats(|info| {
         assert_eq!(5, info.stats.compile_requests);
-        assert_eq!(17, info.stats.requests_executed);
-        assert_eq!(7, info.stats.cache_hits.all());
-        assert_eq!(5, info.stats.cache_misses.all());
+        assert_eq!(20, info.stats.requests_executed);
+        assert_eq!(6, info.stats.cache_hits.all());
+        assert_eq!(9, info.stats.cache_misses.all());
         assert_eq!(&1, info.stats.cache_hits.get("CUDA").unwrap());
-        assert_eq!(&3, info.stats.cache_hits.get("PTX").unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get("CUDA (Device code)").unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get("PTX").unwrap());
         assert_eq!(&3, info.stats.cache_hits.get("CUBIN").unwrap());
         assert_eq!(&2, info.stats.cache_misses.get("CUDA").unwrap());
-        assert_eq!(&2, info.stats.cache_misses.get("PTX").unwrap());
+        assert_eq!(
+            &2,
+            info.stats.cache_misses.get("CUDA (Device code)").unwrap()
+        );
+        assert_eq!(&4, info.stats.cache_misses.get("PTX").unwrap());
         assert_eq!(&1, info.stats.cache_misses.get("CUBIN").unwrap());
         assert!(info.stats.cache_misses.get("C/C++").is_none());
         let adv_cuda_key = adv_key_kind("cuda", compiler.name);
+        let adv_cudafe_key = adv_key_kind("cudafe++", compiler.name);
         let adv_ptx_key = adv_key_kind("ptx", compiler.name);
         let adv_cubin_key = adv_key_kind("cubin", compiler.name);
         assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cuda_key).unwrap());
-        assert_eq!(&3, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cudafe_key).unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&3, info.stats.cache_hits.get_adv(&adv_cubin_key).unwrap());
         assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_cuda_key).unwrap());
-        assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
+        assert_eq!(
+            &2,
+            info.stats.cache_misses.get_adv(&adv_cudafe_key).unwrap()
+        );
+        assert_eq!(&4, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&1, info.stats.cache_misses.get_adv(&adv_cubin_key).unwrap());
     });
 
@@ -900,24 +954,35 @@ int main(int argc, char** argv) {
     trace!("compile test_2299.cu request stats (1)");
     get_stats(|info| {
         assert_eq!(6, info.stats.compile_requests);
-        assert_eq!(21, info.stats.requests_executed);
-        assert_eq!(7, info.stats.cache_hits.all());
-        assert_eq!(8, info.stats.cache_misses.all());
+        assert_eq!(25, info.stats.requests_executed);
+        assert_eq!(6, info.stats.cache_hits.all());
+        assert_eq!(13, info.stats.cache_misses.all());
         assert_eq!(&1, info.stats.cache_hits.get("CUDA").unwrap());
-        assert_eq!(&3, info.stats.cache_hits.get("PTX").unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get("CUDA (Device code)").unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get("PTX").unwrap());
         assert_eq!(&3, info.stats.cache_hits.get("CUBIN").unwrap());
         assert_eq!(&3, info.stats.cache_misses.get("CUDA").unwrap());
-        assert_eq!(&3, info.stats.cache_misses.get("PTX").unwrap());
+        assert_eq!(
+            &3,
+            info.stats.cache_misses.get("CUDA (Device code)").unwrap()
+        );
+        assert_eq!(&5, info.stats.cache_misses.get("PTX").unwrap());
         assert_eq!(&2, info.stats.cache_misses.get("CUBIN").unwrap());
         assert!(info.stats.cache_misses.get("C/C++").is_none());
         let adv_cuda_key = adv_key_kind("cuda", compiler.name);
+        let adv_cudafe_key = adv_key_kind("cudafe++", compiler.name);
         let adv_ptx_key = adv_key_kind("ptx", compiler.name);
         let adv_cubin_key = adv_key_kind("cubin", compiler.name);
         assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cuda_key).unwrap());
-        assert_eq!(&3, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cudafe_key).unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&3, info.stats.cache_hits.get_adv(&adv_cubin_key).unwrap());
         assert_eq!(&3, info.stats.cache_misses.get_adv(&adv_cuda_key).unwrap());
-        assert_eq!(&3, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
+        assert_eq!(
+            &3,
+            info.stats.cache_misses.get_adv(&adv_cudafe_key).unwrap()
+        );
+        assert_eq!(&5, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_cubin_key).unwrap());
     });
 
@@ -949,24 +1014,35 @@ int main(int argc, char** argv) {
     trace!("compile test_2299.cu request stats (2)");
     get_stats(|info| {
         assert_eq!(7, info.stats.compile_requests);
-        assert_eq!(25, info.stats.requests_executed);
-        assert_eq!(9, info.stats.cache_hits.all());
-        assert_eq!(9, info.stats.cache_misses.all());
+        assert_eq!(30, info.stats.requests_executed);
+        assert_eq!(8, info.stats.cache_hits.all());
+        assert_eq!(15, info.stats.cache_misses.all());
         assert_eq!(&1, info.stats.cache_hits.get("CUDA").unwrap());
-        assert_eq!(&4, info.stats.cache_hits.get("PTX").unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get("CUDA (Device code)").unwrap());
+        assert_eq!(&2, info.stats.cache_hits.get("PTX").unwrap());
         assert_eq!(&4, info.stats.cache_hits.get("CUBIN").unwrap());
         assert_eq!(&4, info.stats.cache_misses.get("CUDA").unwrap());
-        assert_eq!(&3, info.stats.cache_misses.get("PTX").unwrap());
+        assert_eq!(
+            &4,
+            info.stats.cache_misses.get("CUDA (Device code)").unwrap()
+        );
+        assert_eq!(&5, info.stats.cache_misses.get("PTX").unwrap());
         assert_eq!(&2, info.stats.cache_misses.get("CUBIN").unwrap());
         assert!(info.stats.cache_misses.get("C/C++").is_none());
         let adv_cuda_key = adv_key_kind("cuda", compiler.name);
+        let adv_cudafe_key = adv_key_kind("cudafe++", compiler.name);
         let adv_ptx_key = adv_key_kind("ptx", compiler.name);
         let adv_cubin_key = adv_key_kind("cubin", compiler.name);
         assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cuda_key).unwrap());
-        assert_eq!(&4, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get_adv(&adv_cudafe_key).unwrap());
+        assert_eq!(&2, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&4, info.stats.cache_hits.get_adv(&adv_cubin_key).unwrap());
         assert_eq!(&4, info.stats.cache_misses.get_adv(&adv_cuda_key).unwrap());
-        assert_eq!(&3, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
+        assert_eq!(
+            &4,
+            info.stats.cache_misses.get_adv(&adv_cudafe_key).unwrap()
+        );
+        assert_eq!(&5, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_cubin_key).unwrap());
     });
 
@@ -999,24 +1075,35 @@ int main(int argc, char** argv) {
     trace!("compile test_2299.cu request stats (3)");
     get_stats(|info| {
         assert_eq!(8, info.stats.compile_requests);
-        assert_eq!(29, info.stats.requests_executed);
+        assert_eq!(35, info.stats.requests_executed);
         assert_eq!(12, info.stats.cache_hits.all());
-        assert_eq!(9, info.stats.cache_misses.all());
+        assert_eq!(15, info.stats.cache_misses.all());
         assert_eq!(&2, info.stats.cache_hits.get("CUDA").unwrap());
-        assert_eq!(&5, info.stats.cache_hits.get("PTX").unwrap());
+        assert_eq!(&2, info.stats.cache_hits.get("CUDA (Device code)").unwrap());
+        assert_eq!(&3, info.stats.cache_hits.get("PTX").unwrap());
         assert_eq!(&5, info.stats.cache_hits.get("CUBIN").unwrap());
         assert_eq!(&4, info.stats.cache_misses.get("CUDA").unwrap());
-        assert_eq!(&3, info.stats.cache_misses.get("PTX").unwrap());
+        assert_eq!(
+            &4,
+            info.stats.cache_misses.get("CUDA (Device code)").unwrap()
+        );
+        assert_eq!(&5, info.stats.cache_misses.get("PTX").unwrap());
         assert_eq!(&2, info.stats.cache_misses.get("CUBIN").unwrap());
         assert!(info.stats.cache_misses.get("C/C++").is_none());
         let adv_cuda_key = adv_key_kind("cuda", compiler.name);
+        let adv_cudafe_key = adv_key_kind("cudafe++", compiler.name);
         let adv_ptx_key = adv_key_kind("ptx", compiler.name);
         let adv_cubin_key = adv_key_kind("cubin", compiler.name);
         assert_eq!(&2, info.stats.cache_hits.get_adv(&adv_cuda_key).unwrap());
-        assert_eq!(&5, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
+        assert_eq!(&2, info.stats.cache_hits.get_adv(&adv_cudafe_key).unwrap());
+        assert_eq!(&3, info.stats.cache_hits.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&5, info.stats.cache_hits.get_adv(&adv_cubin_key).unwrap());
         assert_eq!(&4, info.stats.cache_misses.get_adv(&adv_cuda_key).unwrap());
-        assert_eq!(&3, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
+        assert_eq!(
+            &4,
+            info.stats.cache_misses.get_adv(&adv_cudafe_key).unwrap()
+        );
+        assert_eq!(&5, info.stats.cache_misses.get_adv(&adv_ptx_key).unwrap());
         assert_eq!(&2, info.stats.cache_misses.get_adv(&adv_cubin_key).unwrap());
     });
 }
@@ -1082,14 +1169,19 @@ fn test_nvcc_proper_lang_stat_tracking(compiler: Compiler, tempdir: &Path) {
     trace!("request stats");
     get_stats(|info| {
         assert_eq!(4, info.stats.compile_requests);
-        assert_eq!(12, info.stats.requests_executed);
-        assert_eq!(5, info.stats.cache_hits.all());
-        assert_eq!(3, info.stats.cache_misses.all());
+        assert_eq!(14, info.stats.requests_executed);
+        assert_eq!(6, info.stats.cache_hits.all());
+        assert_eq!(4, info.stats.cache_misses.all());
         assert!(info.stats.cache_hits.get("C/C++").is_none());
         assert_eq!(&2, info.stats.cache_hits.get("CUDA").unwrap());
+        assert_eq!(&1, info.stats.cache_hits.get("CUDA (Device code)").unwrap());
         assert_eq!(&2, info.stats.cache_hits.get("CUBIN").unwrap());
         assert!(info.stats.cache_misses.get("C/C++").is_none());
         assert_eq!(&2, info.stats.cache_misses.get("CUDA").unwrap());
+        assert_eq!(
+            &1,
+            info.stats.cache_misses.get("CUDA (Device code)").unwrap()
+        );
         assert_eq!(&1, info.stats.cache_misses.get("PTX").unwrap());
     });
 }


### PR DESCRIPTION
This PR updates sccache, tests, and CI for CUDA Toolkit 12.8.

This PR fixes a bug related to the `.module_id` file generated by `cudafe++`. This file is now unique (in CTK 12.8) across `cudafe++` invocations, is important for device symbol visibility, and must be consistent between `cudafe++` and all `cicc` calls.

The bug arises when building a `.cu.o` that includes cached PTX. When the `cudafe++` command is re-run it generates a new unique `.module_id` file. This version has a different id than the cached `.ptx` files, leading to a mismatch in the device symbol names in the PTX/cubins vs. the symbols used by the final host-compilation step.

Luckily the fix is straightforward -- cache `cudafe++` invocations. This is safe to do since the `cudafe++` input is the output from the host preprocessor, so any changes that affect device code will yield different hashes.