### PR TITLE
Don't use CARGO_BUILD_JOBS in hash keys

### DIFF
--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1507,7 +1507,11 @@ where
             // CARGO_REGISTRIES_*_TOKEN contains non-cacheable secrets.
             // Registry override config doesn't need to be hashed, because deps' package IDs
             // already uniquely identify the relevant registries.
-            if var == "CARGO_MAKEFLAGS" || var.starts_with("CARGO_REGISTRIES_") {
+            // CARGO_BUILD_JOBS only affects Cargo's parallelism, not rustc output.
+            if var == "CARGO_MAKEFLAGS"
+                || var.starts_with("CARGO_REGISTRIES_")
+                || var == "CARGO_BUILD_JOBS"
+            {
                 continue;
             }
 
@@ -3442,6 +3446,10 @@ proc_macro false
                     (OsString::from("CARGO_BLAH"), OsString::from("abc")),
                     (
                         OsString::from("CARGO_REGISTRIES_A_TOKEN"),
+                        OsString::from("ignored"),
+                    ),
+                    (
+                        OsString::from("CARGO_BUILD_JOBS"),
                         OsString::from("ignored"),
                     ),
                 ]


### PR DESCRIPTION
`CARGO_BUILD_JOBS` only affects Cargo's parallelism, not rustc's outputs, so it can be safely excluded from the cache key.

This enables better cache reutilization when building from environments with different number of CPUs.

I ran into this while experimenting with sccache on a containerized system where a library can be shared/compiled between different job sizes, and was surprised that I was getting cache misses for those libraries.

Given how small the change is, I figured opening the PR wouldn't hurt, but please let me know if you prefer me to move this to an issue for further discussion before actually having the PR reviewed.