### PR TITLE
Allow using S3 virtual host style endpoints

### DIFF
--- a/docs/S3.md
+++ b/docs/S3.md
@@ -5,6 +5,7 @@ If you want to use S3 storage for the sccache cache, you need to set the followi
 - `SCCACHE_BUCKET` with the name of the S3 bucket to use;
 - `SCCACHE_REGION` with the S3 region. If you have set `SCCACHE_ENDPOINT`, you can set `SCCACHE_REGION` to `auto`;
 - Optionally, `SCCACHE_ENDPOINT=<ip>:<port>` with a custom URL of a server you want a use, such as MinIO or DigitalOcean storage.
+- `SCCACHE_S3_ENABLE_VIRTUAL_HOST_STYLE` to `true` if you are using a custom endpoint that supports virtual host style addressing. This is required for S3 transfer acceleration and some S3-compatible storage services. If you are using AWS S3, you can leave this unset.
 
 If your endpoint requires HTTPS/TLS, set `SCCACHE_S3_USE_SSL=true`. If you don't need a secure network layer, HTTP (`SCCACHE_S3_USE_SSL=false`) might be better for performance.
 

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -689,6 +689,7 @@ pub fn storage_from_config(
                     c.endpoint.as_deref(),
                     c.use_ssl,
                     c.server_side_encryption,
+                    c.enable_virtual_host_style,
                 )
                 .map_err(|err| anyhow!("create s3 cache failed: {err:?}"))?;
 

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -680,18 +680,16 @@ pub fn storage_from_config(
                     "Init s3 cache with bucket {}, endpoint {:?}",
                     c.bucket, c.endpoint
                 );
-
-                let storage = S3Cache::build(
-                    &c.bucket,
-                    c.region.as_deref(),
-                    &c.key_prefix,
-                    c.no_credentials,
-                    c.endpoint.as_deref(),
-                    c.use_ssl,
-                    c.server_side_encryption,
-                    c.enable_virtual_host_style,
-                )
-                .map_err(|err| anyhow!("create s3 cache failed: {err:?}"))?;
+                let storage_builder =
+                    S3Cache::new(c.bucket.clone(), c.key_prefix.clone(), c.no_credentials);
+                let storage = storage_builder
+                    .with_region(c.region.clone())
+                    .with_endpoint(c.endpoint.clone())
+                    .with_use_ssl(c.use_ssl)
+                    .with_server_side_encryption(c.server_side_encryption)
+                    .with_enable_virtual_host_style(c.enable_virtual_host_style)
+                    .build()
+                    .map_err(|err| anyhow!("create s3 cache failed: {err:?}"))?;
 
                 return Ok(Arc::new(storage));
             }

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -29,6 +29,7 @@ impl S3Cache {
         endpoint: Option<&str>,
         use_ssl: Option<bool>,
         server_side_encryption: Option<bool>,
+        enable_virtual_host_style: Option<bool>,
     ) -> Result<Operator> {
         let mut builder = S3::default()
             .http_client(set_user_agent())
@@ -37,6 +38,10 @@ impl S3Cache {
 
         if let Some(region) = region {
             builder = builder.region(region);
+        }
+
+        if let Some(true) = enable_virtual_host_style {
+            builder = builder.enable_virtual_host_style();
         }
 
         if no_credentials {

--- a/src/config.rs
+++ b/src/config.rs
@@ -315,6 +315,7 @@ pub struct S3CacheConfig {
     pub endpoint: Option<String>,
     pub use_ssl: Option<bool>,
     pub server_side_encryption: Option<bool>,
+    pub enable_virtual_host_style: Option<bool>,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -640,6 +641,7 @@ fn config_from_env() -> Result<EnvConfig> {
         let server_side_encryption = bool_from_env_var("SCCACHE_S3_SERVER_SIDE_ENCRYPTION")?;
         let endpoint = env::var("SCCACHE_ENDPOINT").ok();
         let key_prefix = key_prefix_from_env_var("SCCACHE_S3_KEY_PREFIX");
+        let enable_virtual_host_style = bool_from_env_var("SCCACHE_S3_ENABLE_VIRTUAL_HOST_STYLE")?;
 
         Some(S3CacheConfig {
             bucket,
@@ -649,6 +651,7 @@ fn config_from_env() -> Result<EnvConfig> {
             endpoint,
             use_ssl,
             server_side_encryption,
+            enable_virtual_host_style,
         })
     } else {
         None
@@ -1558,7 +1561,8 @@ no_credentials = true
                     use_ssl: Some(true),
                     key_prefix: "s3prefix".into(),
                     no_credentials: true,
-                    server_side_encryption: Some(false)
+                    server_side_encryption: Some(false),
+                    enable_virtual_host_style: None,
                 }),
                 webdav: Some(WebdavCacheConfig {
                     endpoint: "http://127.0.0.1:8080".to_string(),


### PR DESCRIPTION
sccache currently breaks on S3 endpoints that use virtual host style URLs. This is because [opendal strips the bucket name from URLs](https://opendal.apache.org/docs/rust/src/opendal/services/s3/backend.rs.html#504-505).

This PR provides a config option to force opendal to keep the bucket name in the URL, which unbreaks sccache for such buckets.