### PR TITLE
Clean up logging

### DIFF
--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -954,6 +954,7 @@ mod server {
                         Ok(HeartbeatServerResult { is_new }) => {
                             trace!(target: "sccache_heartbeat", "Heartbeat success is_new={}", is_new);
                             // TODO: if is_new, terminate all running jobs
+                            if is_new {info!("Server connected to scheduler");}
                             thread::sleep(HEARTBEAT_INTERVAL)
                         }
                         Err(e) => {

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -762,7 +762,7 @@ mod server {
 
             let server = rouille::Server::new(public_addr, move |request| {
                 let req_id = request_count.fetch_add(1, atomic::Ordering::SeqCst);
-                trace!("Req {} ({}): {:?}", req_id, request.remote_addr(), request);
+                trace!(target: "sccache_http", "Req {} ({}): {:?}", req_id, request.remote_addr(), request);
                 let response = (|| router!(request,
                     (POST) (/api/v1/scheduler/alloc_job) => {
                         let bearer_auth = match bearer_http_auth(request) {
@@ -836,7 +836,7 @@ mod server {
                         rouille::Response::empty_404()
                     },
                 ))();
-                trace!("Res {}: {:?}", req_id, response);
+                 trace!(target: "sccache_http", "Res {}: {:?}", req_id, response);
                 response
             }).map_err(|e| anyhow!(format!("Failed to start http server for sccache scheduler: {}", e)))?;
 


### PR DESCRIPTION
Improve logging as discussed in point 1 of #2332.

Splits out heartbeats and raw HTTP as `sccache_heartbeat` and `sccache_http`, respectively.