### PR TITLE
Remove Rust jobserver fd reference

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -310,6 +310,7 @@ pub fn try_parse() -> Result<Command> {
                         && k != "MINICOM"
                         && k != "DESTDIR"
                         && k != "RPM_PACKAGE_VERSION"
+                        && k != "CARGO_MAKEFLAGS"
                 });
 
                 let cmd = matches


### PR DESCRIPTION
Strip `CARGO_MAKEFLAGS` environment variable. Under a distributed environment, the file descriptors referenced by the client are not present on a build server.

Resolves #2333.