### PR TITLE
feat(GCS): Update `CustomTime` metadata field at cache entry hits

### DIFF
--- a/docs/Gcs.md
+++ b/docs/Gcs.md
@@ -65,6 +65,16 @@ export SCCACHE_GCS_KEY_PATH=secret-gcp-storage.json
 Cache location                  GCS, bucket: Bucket(name=<bucket name in GCP>), key_prefix: (none)
 ```
 
+## Lifecycle management
+
+Sccache updates the `CustomTime` metadata field of cache objects every time
+there was a cache hit.
+This can be used to implement automatic cleanup in GCS using the
+["Custom time before"](https://cloud.google.com/storage/docs/lifecycle#customtimebefore)
+or ["Days since custom time"](https://cloud.google.com/storage/docs/lifecycle#dayssincecustomtime)
+conditions on the bucket in order to remove cache entries which have not been
+actively used for a certain amount of time.
+
 ## Deprecation
 
 `SCCACHE_GCS_OAUTH_URL` have been deprecated and not supported, please use `SCCACHE_GCS_SERVICE_ACCOUNT` instead.

--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -168,6 +168,11 @@ impl Storage for DiskCache {
         Ok(self.rw_mode)
     }
 
+    async fn timestamp_cache_hit(&self, _key: &str) -> Result<Option<Duration>> {
+        // Not supported.
+        Ok(None)
+    }
+
     fn location(&self) -> String {
         format!("Local disk: {:?}", self.lru.lock().unwrap().path())
     }

--- a/src/cache/gcs.rs
+++ b/src/cache/gcs.rs
@@ -13,13 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::cache::CacheMode;
+use crate::cache::{CacheMode, TimestampUpdater, normalize_key};
 use crate::errors::*;
+use async_trait::async_trait;
 use opendal::Operator;
 use opendal::{layers::LoggingLayer, services::Gcs};
-use reqsign::{GoogleToken, GoogleTokenLoad};
+use reqsign::{GoogleCredentialLoader,
+              GoogleToken,
+              GoogleTokenLoad,
+              GoogleTokenLoader,
+              GoogleSigner,
+};
 use reqwest::Client;
 use serde::Deserialize;
+use serde_json::json;
 use url::Url;
 
 use super::http_client::set_user_agent;
@@ -72,6 +79,190 @@ impl GCSCache {
             .layer(LoggingLayer::default())
             .finish();
         Ok(op)
+    }
+
+}
+
+/// An updater that updates entries in Google Cloud Storage with a custom
+/// timestamp.
+pub struct GCSCustomTimeUpdater {
+    bucket: String,
+    key_prefix: String,
+    cred_path: Option<String>,
+    service_account: Option<String>,
+    rw_mode: CacheMode,
+    credential_url: Option<String>,
+
+    client: reqwest::Client,
+    signer: GoogleSigner,
+    token: Option<GoogleToken>,
+    token_last_loaded_at: Option<chrono::DateTime<chrono::Utc>>
+}
+
+impl GCSCustomTimeUpdater {
+    pub fn new (
+        bucket: &str,
+        key_prefix: &str,
+        cred_path: Option<&str>,
+        service_account: Option<&str>,
+        rw_mode: CacheMode,
+        credential_url: Option<&str>,
+    ) -> Self {
+        GCSCustomTimeUpdater {
+            bucket: bucket.to_string(),
+            key_prefix: key_prefix.to_string(),
+            cred_path: cred_path.map(|s| s.to_string()),
+            service_account: service_account.map(|s| s.to_string()),
+            rw_mode,
+            credential_url: credential_url.map(|s| s.to_string()),
+
+            client: reqwest::Client::new(),
+            signer: GoogleSigner::new("storage"),
+            token: None,
+            token_last_loaded_at: None,
+        }
+    }
+
+    /// Initializes the request token that will be used to update the cache
+    /// hits, as the API requires authenticated requests.
+    pub async fn init(&mut self) -> Result<()> {
+        match self.load_token().await {
+            Ok(t) => {
+                self.token = Some(t);
+                self.token_last_loaded_at = Some(chrono::Utc::now());
+            }
+            Err(err) => {
+                error!("failed to load token: {err}");
+                return Err(anyhow!("gcs: failed to load token"));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Loads a new token using the Google Cloud API for the timestamp update
+    /// requests.
+    async fn load_token(&mut self) -> Result<GoogleToken> {
+        if let Some(cred_url) = &self.credential_url {
+            let _ = Url::parse(cred_url)
+                .map_err(|err| anyhow!("gcs credential url is invalid: {err:?}"))?;
+
+            let tc_loader = TaskClusterTokenLoader {
+                scope: rw_to_scope(self.rw_mode).to_string(),
+                url: cred_url.to_string(),
+            };
+
+            if let Ok(Some(tok)) = tc_loader.load(self.client.clone()).await {
+                return Ok(tok)
+            }
+        }
+
+        if let Some(cred_path) = &self.cred_path {
+            let cred_loader = GoogleCredentialLoader::default()
+                .with_disable_env()
+                .with_disable_well_known_location()
+                .with_path(cred_path);
+            let creds = cred_loader.load()?.unwrap();
+
+            let mut token_loader = GoogleTokenLoader::new(
+                    // devstorage.full_control is required to use the metadata PATCH
+                    "https://www.googleapis.com/auth/devstorage.full_control",
+                    Client::new())
+                .with_credentials(creds);
+            if let Some(srv_account) = &self.service_account {
+                token_loader = token_loader.with_service_account(srv_account);
+            }
+
+            if let Some(token_) = token_loader.load().await? {
+                return Ok(token_);
+            }
+        }
+
+        error!("failed to load credential token: no valid cases");
+        Err(anyhow!("gcs: failed to load credential token: no valid cases"))
+    }
+}
+
+/// In raw API requests, `/` in paths must be URL-encoded.
+fn encode_key_to_api_path(key: String) -> String {
+    key.replace("/", "%2F")
+}
+
+#[async_trait]
+impl TimestampUpdater for GCSCustomTimeUpdater {
+    fn can_update(&self) -> bool {
+        // Assume no rights to update metadata if the user may only read the
+        // cache.
+        CacheMode::from(self.rw_mode.clone()) == CacheMode::ReadWrite
+    }
+
+    async fn needs_init(&self) -> Result<bool> {
+        if !self.can_update() {
+            return Ok(false);
+        }
+
+        if self.token.is_none() || self.token_last_loaded_at.is_none() {
+            debug!("needs initialization because a token was never loaded");
+            return Ok(true);
+        }
+
+        if (chrono::Utc::now() - self.token_last_loaded_at.as_ref().unwrap())
+                .num_seconds() > 3600 {
+            // Google Cloud tokens are valid for 3600 seconds by default.
+            // Unfortunately, reqsign explicitly forbids querying the otherwise
+            // available `expires_in` field from the `Token`...
+            debug!("needs reinitialization because the token likely expired");
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    async fn init(&mut self) -> Result<()> {
+        self.init().await
+    }
+
+    // Update the `CustomTime` timestamp for an object in the cache through
+    // [the API](https://cloud.google.com/storage/docs/metadata#custom-time).
+    //
+    // `CustomTime` can only grow incrementally. In case an error is reported
+    // because someone else set a time ahead of us, the error is silently
+    // ignored.
+    async fn update(&self, key: &str) -> Result<()> {
+        if !self.can_update() {
+            return Err(anyhow!("gcs: update timestamp is not supported for a read-only cache"));
+        }
+
+        let url = format!(
+            "https://storage.googleapis.com/storage/v1/b/{}/o/{}",
+            self.bucket,
+            encode_key_to_api_path(self.key_prefix.clone() + &normalize_key(key))
+        );
+        let payload = json!({
+            "customTime": chrono::Utc::now().to_rfc3339(),
+        });
+        let mut request = self.client.patch(&url).json(&payload).build()?;
+        self.signer.sign(&mut request, self.token.as_ref().unwrap())?;
+
+        let resp = self.client.execute(request).await?;
+        if !resp.status().is_success() {
+            let status_code = resp.status();
+            let content = resp.text().await?;
+
+            if status_code == reqwest::StatusCode::BAD_REQUEST &&
+                    content.contains("Custom time cannot be decreased.") {
+                // Do not report custom time changes as an error, the local
+                // clock may be out of sync with another sccache server using
+                // the same cache.
+                return Ok(());
+            }
+
+            return Err(anyhow!(
+                "gcs: failed to update timestamp for {key}: code: {status_code}, {content}"
+            ));
+        }
+
+        Ok(())
     }
 }
 

--- a/src/cache/readonly.rs
+++ b/src/cache/readonly.rs
@@ -44,6 +44,11 @@ impl Storage for ReadOnlyStorage {
         Ok(CacheMode::ReadOnly)
     }
 
+    async fn timestamp_cache_hit(&self, _key: &str) -> Result<Option<Duration>> {
+        // Not supported.
+        Ok(None)
+    }
+
     /// Get the storage location.
     fn location(&self) -> String {
         self.0.location()

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -563,6 +563,25 @@ where
 
         match lookup {
             CacheLookupResult::Success(compile_result, output) => {
+                let out_pretty3 = out_pretty.clone();
+                match storage.timestamp_cache_hit(&key).await {
+                    Ok(None) => {} // Not an error, intentionally left empty.
+                    Ok(Some(duration_timestamp)) => {
+                        debug!(
+                            "[{}]: Updated cache hit timestamp {}",
+                            out_pretty3,
+                            fmt_duration_as_secs(&duration_timestamp)
+                        );
+                    }
+                    Err(e) => {
+                        // `{:#}` prints the error and the causes in a single line.
+                        let errmsg = format!("{:#}", e);
+                        warn!(
+                            "[{}]: Failed to update cache hit timestamp: {}",
+                            out_pretty3, errmsg);
+                    }
+                }
+
                 Ok::<_, Error>((compile_result, output))
             }
             CacheLookupResult::Miss(miss_type) => {

--- a/src/test/mock_storage.rs
+++ b/src/test/mock_storage.rs
@@ -65,6 +65,9 @@ impl Storage for MockStorage {
             Duration::from_secs(0)
         })
     }
+    async fn timestamp_cache_hit(&self, _key: &str) -> Result<Duration> {
+        Ok(Duration::from_secs(0))
+    }
     fn location(&self) -> String {
         "Mock Storage".to_string()
     }


### PR DESCRIPTION
Resolves #2318.

This commit introduces the architectural support for implementing a cache-provider-specific routine that updates an `atime`-like (access time) timestamp every time a cache entry is successfully hit. Several cloud providers implement such semantics under different names and APIs, most commonly for the purpose of providing a better time-out and culling mechanism. The logic in _sccache_ only performs the bookkeeping of this information. With this feature, it is possible to give the necessary inputs to the cloud provider's lifecycle routines to allow keeping cloud costs and size low by culling cache objects that had not been hit for a set amount of time.

Added the support for the aforementioned logic specifically for the GCS cache implementation, where the custom access time medata is available under the `CustomTime` attribute, which can be bumped only ever forward in time. In case a bumping is unsuccessful (due to clocks getting out-of-synch), the error is silently discarded.

![Screenshot of the Google Cloud Console inspecting the metadata of a cache object where _Custom Time_ is set.](https://github.com/user-attachments/assets/4b67a35f-33f9-4e6a-b235-d32bb072f395)
