### PR TITLE
 Apply log filtering to syslog with env_filter crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1077,17 @@ dependencies = [
  "libc",
  "match_cfg",
  "winapi",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "windows",
 ]
 
 [[package]]
@@ -2561,12 +2582,14 @@ dependencies = [
  "daemonize",
  "directories",
  "encoding_rs",
+ "env_filter",
  "env_logger",
  "filetime",
  "flate2",
  "fs-err",
  "futures",
  "gzp",
+ "hostname 0.4.0",
  "http 1.1.0",
  "http-body-util",
  "hyper 1.1.0",
@@ -2959,7 +2982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7434e95bcccce1215d30f4bf84fe8c00e8de1b9be4fb736d747ca53d36e7f96f"
 dependencies = [
  "error-chain",
- "hostname",
+ "hostname 0.3.1",
  "libc",
  "log",
  "time",
@@ -3718,6 +3741,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,8 @@ zip = { version = "0.6", default-features = false }
 zstd = "0.13"
 
 # dist-server only
+env_filter = "0.1.3"
+hostname = "0.4.0"
 nix = { version = "0.28.0", optional = true, features = [
   "mount",
   "user",

--- a/docs/Distributed.md
+++ b/docs/Distributed.md
@@ -427,6 +427,30 @@ token = "preshared token"
 type = "DANGEROUSLY_INSECURE"
 ```
 
+# Logging
+
+## stderr
+
+You can set the `SCCACHE_LOG` environment variable to a comma-separated list of directives that specifies the levels and modules desired. 
+
+For example:
+```
+SCCACHE_LOG=info,sccache_dist=trace,sccache=trace,sccache_heartbeat=off
+```
+
+
+For more details, consult the [`env_logger`](https://docs.rs/env_logger/latest/env_logger/#enabling-logging) documentation.
+
+## Syslog
+
+Use the `--syslog` argument to enable logging to a syslog daemon. 
+The presence of the `SCCACHE_LOG` environment variable takes precedence over this argument.
+The same syntax is accepted:
+
+```
+--syslog info,sccache_dist=debug,sccache=debug,sccache_heartbeat=off
+```
+
 
 # Building the Distributed Server Binaries
 


### PR DESCRIPTION
Expands --syslog argument to accept a comma-separated list of directives to control logging in the same manner as SCCACHE_LOG.