### PR TITLE
Expand coverage to sccache-dist tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,10 @@ jobs:
             rustc: nightly
             allow_failure: true
             extra_args: --features=unstable
+          - os: ubuntu-22.04
+            rustc: "1.75.0"
+            extra_desc: dist-server
+            extra_args: --no-default-features --features=dist-tests test_dist_ -- --test-threads 1
           - os: macos-13
             rustc: nightly
     # Disable on Windows for now as it fails with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,12 @@ jobs:
       - name: "`grcov` ~ install"
         run: cargo install grcov
 
+      - name: Create config for testing
+        run: |
+          mkdir -p .cargo
+          echo '[env]
+          LLVM_PROFILE_FILE = { value = "target/debug/coverage/default-%p-%8m.profraw", relative = true }' >> .cargo/config.toml
+
       - name: Execute tests
         run: cargo test --no-fail-fast --locked --all-targets ${{ matrix.extra_args }}
         env:


### PR DESCRIPTION
Add testing matrix option for `dist-tests`.
Configures `LLVM_PROFILE_FILE` environment variable to collect coverage results.