### PR TITLE
Reword and correct the preprocessor cache mode documentation

### DIFF
--- a/docs/Local.md
+++ b/docs/Local.md
@@ -8,13 +8,13 @@ The local storage only supports a single sccache server at a time. Multiple conc
 
 ## Preprocessor cache mode
 
-This is inspired by [ccache's direct mode](https://ccache.dev/manual/3.7.9.html#_the_direct_mode) and works roughly the same.
+This is inspired by [ccache's direct mode](https://ccache.dev/manual/3.7.9.html#_the_direct_mode) and works roughly the same. It allows to skip the preprocessor for cached results when compiling C/C++.
 
 [preprocessor cache] mode is controlled by a configuration option which is true by default, as well as additional conditions described below.
 
-In preprocessor cache mode, sccache caches the preprocessor step for C/C++ whenever possible. This can make the compilation much faster, since the preprocessor step takes a non-negligible amount of the entire compile time.
+In non-preprocessor cache mode, sccache's compilation pipeline for one C/C++ source file is inputs → preprocessing → cache lookup → (return outputs if cached / compilation otherwise). In preprocessor cache mode, the compilation pipeline is inputs → cache lookup → (return outputs if cached / preprocessing → compilation otherwise). This can make it much faster to return compilation outputs from cache.
 
-In order to cache the preprocessor step, [sccache] needs to remember, among other things, all files included by a given input file. To quote ccache's documentation:
+To ensure that the cached outputs for a source file correspond to the un-preprocessed inputs, [sccache] needs to remember, among other things, all files included by that source file (i.e. the complete set of inputs). To quote ccache's documentation:
 
 > There is a catch with the [preprocessor cache] mode: header files that were used by the compiler are recorded, but header files that were not used, but would have been used if they existed, are not. So, when [sccache] checks if a result can be taken from the cache, it currently can’t check if the existence of a new header file should invalidate the result. In practice, the [preprocessor cache] mode is safe to use in the vast majority of cases.
 

--- a/docs/Local.md
+++ b/docs/Local.md
@@ -10,27 +10,25 @@ The local storage only supports a single sccache server at a time. Multiple conc
 
 This is inspired by [ccache's direct mode](https://ccache.dev/manual/3.7.9.html#_the_direct_mode) and works roughly the same.
 
-It can be set with by setting the variable:
-```
-SCCACHE_DIRECT=true
-```
+[preprocessor cache] mode is controlled by a configuration option which is true by default, as well as additional conditions described below.
 
-In preprocessor cache mode, sccache caches the preprocessor step for C/C++ whenever possible. This can make the compilation a lot faster, since the preprocessor accounts for a non-negligible amount of time in the entire compile chain.
+In preprocessor cache mode, sccache caches the preprocessor step for C/C++ whenever possible. This can make the compilation much faster, since the preprocessor step takes a non-negligible amount of the entire compile time.
 
-In order to cache the preprocessor step sccache needs to remember, among other things, all files included by the given input file. To quote ccache's documentation:
+In order to cache the preprocessor step, [sccache] needs to remember, among other things, all files included by a given input file. To quote ccache's documentation:
 
-> There is a catch with the [preprocessor cache] mode: header files that were used by the compiler are recorded, but header files that were not used, but would have been used if they existed, are not. So, when [sccache] checks if a result can be taken from the cache, it currently can’t check if the existence of a new header file should invalidate the result. In practice, the [preprocessor cache] mode is safe to use in the absolute majority of cases.
+> There is a catch with the [preprocessor cache] mode: header files that were used by the compiler are recorded, but header files that were not used, but would have been used if they existed, are not. So, when [sccache] checks if a result can be taken from the cache, it currently can’t check if the existence of a new header file should invalidate the result. In practice, the [preprocessor cache] mode is safe to use in the vast majority of cases.
 
 Preprocessor cache mode will be disabled if any of the following holds:
 
-- the configuration setting `use_preprocessor_cache_mode` is false
-- a modification time of one of the include files is too new (needed to avoid a race condition)
-- a compiler option not supported by the preprocessor cache mode is used. Currently, this is only `-Xpreprocessor` and `-Wp,*`, but if/when sccache grows to handle options then more could be added to this list.
+- the configuration option is false
+- not using GCC or Clang with local storage (only implemented for these)
+- the modification time of one of the include files is too new (this avoids a race condition)
+- a compiler option not supported by [preprocessor cache] mode is used; this is usually because the compilation has inputs or outputs which [sccache] does not model well enough
 - the string `__TIME__` is present in the source code
 
 Configuration options and their default values:
 
-- `use_preprocessor_cache_mode`: `true`. Whether to use preprocessor cache mode entirely.
+- `use_preprocessor_cache_mode`: `true`. Whether to use [preprocessor cache] mode. This can be overridden for an sccache invocation by setting the environment variable `SCCACHE_DIRECT` to `true`/`on`/`1` or `false`/`off`/`0`).
 - `file_stat_matches`: `false`. If false, only compare header files by hashing their contents. If true, will use size + ctime + mtime to check whether a file has changed. See other flags below for more control over this behavior.
 - `use_ctime_for_stat`: `true`. If true, uses the ctime (file status change on UNIX, creation time on Windows) to check that a file has/hasn't changed. Can be useful to disable when backdating modification times in a controlled manner.
 
@@ -41,8 +39,6 @@ Configuration options and their default values:
 - `hash_working_directory`: `true`. If true, will add the current working directory in the hash to distinguish two compilations from different directories.
 
 See where to write the config in [the configuration doc](Configuration.md).
-
-*Note that preprocessor caching is currently only implemented for GCC and Clang and when using local storage.*
 
 ## Read-only cache mode
 

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -410,6 +410,7 @@ where
         }
 
         let use_preprocessor_cache_mode = {
+            // Disable preprocessor cache when doing distributed compilation (+ other conditions)
             let can_use_preprocessor_cache_mode = !may_dist
                 && preprocessor_cache_mode_config.use_preprocessor_cache_mode
                 && !too_hard_for_preprocessor_cache_mode;
@@ -438,7 +439,6 @@ where
             use_preprocessor_cache_mode
         };
 
-        // Disable preprocessor cache when doing distributed compilation
         let mut preprocessor_key = if use_preprocessor_cache_mode {
             preprocessor_cache_entry_hash_key(
                 &executable_digest,


### PR DESCRIPTION
The correction is that there is a *long* list of compiler options that disable preprocessor cache mode.