### PR TITLE
Improve the CARGO_INCREMENTAL checking

### DIFF
--- a/src/bin/sccache-dist/main.rs
+++ b/src/bin/sccache-dist/main.rs
@@ -48,7 +48,10 @@ fn main() {
         .iter()
         .for_each(|incr_str| match env::var(incr_str) {
             Ok(incr_val) if incr_val == "1" => {
-                println!("sccache: increment compilation is  prohibited.");
+                println!(
+                    "sccache: incremental compilation is prohibited: Unset {} to continue.",
+                    incr_str
+                );
                 std::process::exit(1);
             }
             _ => (),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -787,6 +787,21 @@ pub fn run_command(cmd: Command) -> Result<i32> {
             env_vars,
         } => {
             trace!("Command::Compile {{ {:?}, {:?}, {:?} }}", exe, cmdline, cwd);
+
+            let incr_env_strs = ["CARGO_BUILD_INCREMENTAL", "CARGO_INCREMENTAL"];
+            incr_env_strs
+                .iter()
+                .for_each(|incr_str| match env::var(incr_str) {
+                    Ok(incr_val) if incr_val == "1" => {
+                        println!(
+                            "sccache: incremental compilation is prohibited: Unset {} to continue.",
+                            incr_str
+                        );
+                        std::process::exit(1);
+                    }
+                    _ => (),
+                });
+
             let jobserver = Client::new();
             let conn = connect_or_start_server(&get_addr(), startup_timeout)?;
             let mut runtime = Runtime::new()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,20 +64,6 @@ pub const LOGGING_ENV: &str = "SCCACHE_LOG";
 pub fn main() {
     init_logging();
 
-    let incr_env_strs = ["CARGO_BUILD_INCREMENTAL", "CARGO_INCREMENTAL"];
-    incr_env_strs
-        .iter()
-        .for_each(|incr_str| match env::var(incr_str) {
-            Ok(incr_val) if incr_val == "1" => {
-                println!(
-                    "sccache: incremental compilation is prohibited: Unset {} to continue.",
-                    incr_str
-                );
-                std::process::exit(1);
-            }
-            _ => (),
-        });
-
     let command = match cmdline::try_parse() {
         Ok(cmd) => cmd,
         Err(e) => match e.downcast::<clap::error::Error>() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,10 @@ pub fn main() {
         .iter()
         .for_each(|incr_str| match env::var(incr_str) {
             Ok(incr_val) if incr_val == "1" => {
-                println!("sccache: increment compilation is  prohibited.");
+                println!(
+                    "sccache: incremental compilation is prohibited: Unset {} to continue.",
+                    incr_str
+                );
                 std::process::exit(1);
             }
             _ => (),


### PR DESCRIPTION
Improve the error message to give the user a better hint of what to do in response, and make it so you can sccache --help without throwing the error.