### PR TITLE
Add support for Xclang '-mrelax-all' and '-mconstructor-aliases' flags.

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -237,6 +237,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     flag!("-gcodeview", PassThroughFlag),
     take_arg!("-include-pch", PathBuf, CanBeSeparated, PreprocessorArgumentPath),
     take_arg!("-load", PathBuf, Separated, ExtraHashFile),
+    flag!("-mconstructor-aliases", PassThroughFlag),
     take_arg!("-mllvm", OsString, Separated, PassThrough),
     flag!("-no-opaque-pointers", PreprocessorArgumentFlag),
     take_arg!("-plugin-arg", OsString, Concatenated('-'), PassThrough),
@@ -895,6 +896,19 @@ mod test {
     fn test_parse_xclang_use_ctor_homing() {
         let a = parses!("-c", "foo.c", "-o", "foo.o", "-Xclang", "-fuse-ctor-homing");
         assert_eq!(ovec!["-Xclang", "-fuse-ctor-homing"], a.common_args);
+    }
+
+    #[test]
+    fn test_parse_xclang_mconstructor_aliases_all() {
+        let a = parses!(
+            "-c",
+            "foo.c",
+            "-o",
+            "foo.o",
+            "-Xclang",
+            "-mconstructor-aliases"
+        );
+        assert_eq!(ovec!["-Xclang", "-mconstructor-aliases"], a.common_args);
     }
 
     #[test]

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -239,6 +239,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("-load", PathBuf, Separated, ExtraHashFile),
     flag!("-mconstructor-aliases", PassThroughFlag),
     take_arg!("-mllvm", OsString, Separated, PassThrough),
+    flag!("-mrelax-all", PassThroughFlag),
     flag!("-no-opaque-pointers", PreprocessorArgumentFlag),
     take_arg!("-plugin-arg", OsString, Concatenated('-'), PassThrough),
     take_arg!("-target", OsString, Separated, PassThrough),
@@ -909,6 +910,12 @@ mod test {
             "-mconstructor-aliases"
         );
         assert_eq!(ovec!["-Xclang", "-mconstructor-aliases"], a.common_args);
+    }
+
+    #[test]
+    fn test_parse_xclang_mrelax_all() {
+        let a = parses!("-c", "foo.c", "-o", "foo.o", "-Xclang", "-mrelax-all");
+        assert_eq!(ovec!["-Xclang", "-mrelax-all"], a.common_args);
     }
 
     #[test]


### PR DESCRIPTION
This is basically the same implementation as https://github.com/mozilla/sccache/pull/1547 and https://github.com/mozilla/sccache/pull/1721.

Closes https://github.com/mozilla/sccache/issues/2370.