### PR TITLE
Give the --dist-status user some information about when a retry wil happen

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -258,10 +258,13 @@ impl DistClientContainer {
                     "enabled, auth not configured".to_string(),
                 )
             }
-            DistClientState::RetryCreateAt(cfg, _) => {
+            DistClientState::RetryCreateAt(cfg, time) => {
                 return DistInfo::NotConnected(
                     cfg.scheduler_url.clone(),
-                    "enabled, not connected, will retry".to_string(),
+                    format!(
+                        "enabled, not connected, will retry in {:.1}s",
+                        time.duration_since(Instant::now()).as_secs_f32()
+                    ),
                 )
             }
             DistClientState::Some(cfg, client) => (Arc::clone(client), cfg.scheduler_url.clone()),


### PR DESCRIPTION
The retry timeout is so long that I sometimes wonder during setup debug if it's even going to retry.