### PR TITLE
feat: handle human size prefixes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -25,13 +25,13 @@ use serde::{
 };
 #[cfg(test)]
 use serial_test::serial;
-use std::{collections::HashMap, fmt};
 use std::env;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::result::Result as StdResult;
 use std::str::FromStr;
 use std::sync::Mutex;
+use std::{collections::HashMap, fmt};
 
 pub use crate::cache::PreprocessorCacheModeConfig;
 use crate::errors::*;
@@ -103,7 +103,6 @@ impl<'de> de::Visitor<'de> for StringOrU64Visitor {
         }
     }
 }
-
 
 fn deserialize_size_from_str<'de, D>(deserializer: D) -> StdResult<u64, D::Error>
 where

--- a/src/config.rs
+++ b/src/config.rs
@@ -1688,3 +1688,36 @@ fn server_toml_parse() {
         }
     )
 }
+
+#[test]
+fn human_units_parse() {
+    const CONFIG_STR: &str = r#"
+[dist]
+toolchain_cache_size = "5g"
+
+[cache.disk]
+size = "7g"
+"#;
+
+    let file_config: FileConfig = toml::from_str(CONFIG_STR).expect("Is valid toml.");
+    assert_eq!(
+        file_config,
+        FileConfig {
+            cache: CacheConfigs {
+                disk: Some(DiskCacheConfig {
+                    dir: default_disk_cache_dir(),
+                    size: 7 * 1024 * 1024 * 1024,
+                    preprocessor_cache_mode: PreprocessorCacheModeConfig::activated(),
+                    rw_mode: CacheModeConfig::ReadWrite,
+                }),
+                ..Default::default()
+            },
+            dist: DistConfig {
+                toolchain_cache_size: 5 * 1024 * 1024 * 1024,
+                ..Default::default()
+            },
+            server_startup_timeout_ms: None,
+        }
+    );
+
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1717,5 +1717,4 @@ size = "7g"
             server_startup_timeout_ms: None,
         }
     );
-
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,7 +70,7 @@ fn default_toolchain_cache_size() -> u64 {
 }
 
 pub fn parse_size(val: &str) -> Option<u64> {
-    let multiplier = match val.chars().last() {
+    let multiplier = match val.chars().last().map(|v| v.to_ascii_uppercase()) {
         Some('K') => 1024,
         Some('M') => 1024 * 1024,
         Some('G') => 1024 * 1024 * 1024,
@@ -1211,6 +1211,7 @@ fn test_parse_size() {
     assert_eq!(None, parse_size("bogus value"));
     assert_eq!(Some(100), parse_size("100"));
     assert_eq!(Some(2048), parse_size("2K"));
+    assert_eq!(Some(2048), parse_size("2k"));
     assert_eq!(Some(10 * 1024 * 1024), parse_size("10M"));
     assert_eq!(Some(TEN_GIGS), parse_size("10G"));
     assert_eq!(Some(1024 * TEN_GIGS), parse_size("10T"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -1705,10 +1705,8 @@ size = "7g"
         FileConfig {
             cache: CacheConfigs {
                 disk: Some(DiskCacheConfig {
-                    dir: default_disk_cache_dir(),
                     size: 7 * 1024 * 1024 * 1024,
-                    preprocessor_cache_mode: PreprocessorCacheModeConfig::activated(),
-                    rw_mode: CacheModeConfig::ReadWrite,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },


### PR DESCRIPTION
this PR allows you to specify human sizes in the configuration. For example:
```
[dist]
toolchain_cache_size = "5G"

[cache.disk]
size = "20G"
```

As a bonus, I also added for lowercase sizes, e.g. "2k"
