### PR TITLE
Non hashable args like fdebug-prefix-map & related

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -25,8 +25,8 @@ use crate::dist;
 use crate::dist::pkg;
 use crate::mock_command::CommandCreatorSync;
 use crate::util::{
-    Digest, HashToDigest, MetadataCtimeExt, TimeMacroFinder, Timestamp, decode_path, encode_path,
-    hash_all,
+    decode_path, encode_path, hash_all, Digest, HashToDigest, MetadataCtimeExt, TimeMacroFinder,
+    Timestamp,
 };
 use async_trait::async_trait;
 use fs_err as fs;
@@ -44,8 +44,8 @@ use std::sync::Arc;
 
 use crate::errors::*;
 
-use super::CacheControl;
 use super::preprocessor_cache::PreprocessorCacheEntry;
+use super::CacheControl;
 
 /// A generic implementation of the `Compiler` trait for C/C++ compilers.
 #[derive(Clone)]


### PR DESCRIPTION
Hello!

I realized that compilers arguments/flags for gcc like the mentioned above are being used in the hash_key function. This means that strategies for handling the absolute paths to relatives regarding debug info or in similar fashion that involves passing a _dynamic value_ into the argument depending of the builder origin will create a different hash key.

From my point of view, these kind of arguments should not affect the computer hash key at all:
- -_fdebug-prefix-map=${PWD}=.
- -fmacro-prefix-map
- ffile-prefix-map
- fdebug-compilation-dir

A naive change could just include a non-hashable list of args that should be skipped or not considered into the hash key.



