### PR TITLE
make sccache -s always return current cache size

### DIFF
--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -173,7 +173,7 @@ impl Storage for DiskCache {
     }
 
     async fn current_size(&self) -> Result<Option<u64>> {
-        Ok(self.lru.lock().unwrap().get().map(|l| l.size()))
+        Ok(Some(self.lru.lock().unwrap().get_or_init()?.size()))
     }
     async fn max_size(&self) -> Result<Option<u64>> {
         Ok(Some(self.lru.lock().unwrap().capacity()))

--- a/src/cache/disk.rs
+++ b/src/cache/disk.rs
@@ -27,40 +27,40 @@ use crate::errors::*;
 
 use super::{normalize_key, PreprocessorCacheModeConfig};
 
-enum LazyDiskCache {
+enum LazyLruDiskCache {
     Uninit { root: OsString, max_size: u64 },
     Init(LruDiskCache),
 }
 
-impl LazyDiskCache {
+impl LazyLruDiskCache {
     fn get_or_init(&mut self) -> Result<&mut LruDiskCache> {
         match self {
-            LazyDiskCache::Uninit { root, max_size } => {
-                *self = LazyDiskCache::Init(LruDiskCache::new(&root, *max_size)?);
+            LazyLruDiskCache::Uninit { root, max_size } => {
+                *self = LazyLruDiskCache::Init(LruDiskCache::new(&root, *max_size)?);
                 self.get_or_init()
             }
-            LazyDiskCache::Init(d) => Ok(d),
+            LazyLruDiskCache::Init(d) => Ok(d),
         }
     }
 
     fn get(&mut self) -> Option<&mut LruDiskCache> {
         match self {
-            LazyDiskCache::Uninit { .. } => None,
-            LazyDiskCache::Init(d) => Some(d),
+            LazyLruDiskCache::Uninit { .. } => None,
+            LazyLruDiskCache::Init(d) => Some(d),
         }
     }
 
     fn capacity(&self) -> u64 {
         match self {
-            LazyDiskCache::Uninit { max_size, .. } => *max_size,
-            LazyDiskCache::Init(d) => d.capacity(),
+            LazyLruDiskCache::Uninit { max_size, .. } => *max_size,
+            LazyLruDiskCache::Init(d) => d.capacity(),
         }
     }
 
     fn path(&self) -> &Path {
         match self {
-            LazyDiskCache::Uninit { root, .. } => root.as_ref(),
-            LazyDiskCache::Init(d) => d.path(),
+            LazyLruDiskCache::Uninit { root, .. } => root.as_ref(),
+            LazyLruDiskCache::Init(d) => d.path(),
         }
     }
 }
@@ -68,11 +68,11 @@ impl LazyDiskCache {
 /// A cache that stores entries at local disk paths.
 pub struct DiskCache {
     /// `LruDiskCache` does all the real work here.
-    lru: Arc<Mutex<LazyDiskCache>>,
+    lru: Arc<Mutex<LazyLruDiskCache>>,
     /// Thread pool to execute disk I/O
     pool: tokio::runtime::Handle,
     preprocessor_cache_mode_config: PreprocessorCacheModeConfig,
-    preprocessor_cache: Arc<Mutex<LazyDiskCache>>,
+    preprocessor_cache: Arc<Mutex<LazyLruDiskCache>>,
     rw_mode: CacheMode,
 }
 
@@ -86,13 +86,13 @@ impl DiskCache {
         rw_mode: CacheMode,
     ) -> DiskCache {
         DiskCache {
-            lru: Arc::new(Mutex::new(LazyDiskCache::Uninit {
+            lru: Arc::new(Mutex::new(LazyLruDiskCache::Uninit {
                 root: root.as_ref().to_os_string(),
                 max_size,
             })),
             pool: pool.clone(),
             preprocessor_cache_mode_config,
-            preprocessor_cache: Arc::new(Mutex::new(LazyDiskCache::Uninit {
+            preprocessor_cache: Arc::new(Mutex::new(LazyLruDiskCache::Uninit {
                 root: Path::new(root.as_ref())
                     .join("preprocessor")
                     .into_os_string(),


### PR DESCRIPTION
sccache server disk cache is usually initiated by the first compilation request. If `sccache -s` is issued before then, sccache will not return the currently occupied cache size. This PR fixes that by querying the underlying LruDiskCache in `current_size()`. I don't think they are performance implications of this, but I am not sure.

I also renamed LazyDiskCache to LazyLruDiskCache, because I think the name is more clear. Let me know if you want me to revert that change