### PR TITLE
Fix symbolic links to sccache on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,10 +287,6 @@ Known Caveats
 
 [More details on Rust caveats](/docs/Rust.md)
 
-### Symbolic links
-
-* Symbolic links to sccache won't work. Use hardlinks: `ln sccache /usr/local/bin/cc`
-
 ### User Agent
 
 * Requests sent to your storage option of choice will have a user agent header indicating the current sccache version, e.g. `sccache/0.8.2`.

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -197,7 +197,10 @@ pub fn try_parse() -> Result<Command> {
     let mut args: Vec<_> = env::args_os().collect();
 
     if !internal_start_server {
-        if let Ok(exe) = env::current_exe() {
+        if let Ok(exe) = match env::args().next() {
+            Some(s) if !s.is_empty() => Ok(PathBuf::from(s)),
+            _ => env::current_exe(),
+        } {
             match exe
                 .file_stem()
                 .and_then(|s| s.to_str())
@@ -205,7 +208,7 @@ pub fn try_parse() -> Result<Command> {
             {
                 // If the executable has its standard name, do nothing.
                 Some(ref e) if e == env!("CARGO_PKG_NAME") => {}
-                // Otherwise, if it was copied/hardlinked under a different $name, act
+                // Otherwise, if it was copied/linked under a different $name, act
                 // as if it were invoked with `sccache $name`, but avoid $name resolving
                 // to ourselves again if it's in the PATH.
                 _ => {


### PR DESCRIPTION
Whether or not `env::current_exe` follows symlinks is platform dependant. On linux it follows them which made it impossible to do things like `ln -s sccache /usr/bin/cc`. By reading `env::args()` directly we don't have this issue.

Fixes https://github.com/mozilla/sccache/issues/993
Based on https://github.com/rivy/rs.coreutils/commit/ad3852a72d2235ae501a40b4e1f36d406cc53b1b