### PR TITLE
Display a more user-friendly error when compiling on Linux/arm64

### DIFF
--- a/src/bin/sccache-dist/main.rs
+++ b/src/bin/sccache-dist/main.rs
@@ -35,6 +35,14 @@ use cmdline::{AuthSubcommand, Command};
 
 pub const INSECURE_DIST_SERVER_TOKEN: &str = "dangerously_insecure_server";
 
+#[cfg(not(any(
+    all(target_os = "linux", target_arch = "x86_64"),
+    target_os = "freebsd"
+)))]
+fn main() {
+    compile_error!("Distributed compilation is only support on Linux/x86_64 and FreeBSD!");
+}
+
 // Only supported on x86_64 Linux machines and on FreeBSD
 #[cfg(any(
     all(target_os = "linux", target_arch = "x86_64"),


### PR DESCRIPTION
Without this change, users may be greeted with the following confusing
message when trying to build on Linux/arm64

```
error[E0601]: `main` function not found in crate `sccache_dist`
   --> /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sccache-0.10.0/src/bin/sccache-dist/main.rs:835:2
    |
835 | }
    |  ^ consider adding a `main` function to `/home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sccache-0.10.0/src/bin/sccache-dist/main.rs`

For more information about this error, try `rustc --explain E0601`.
```

With this change:

```
error: Distributed compilation is only support on Linux/x86_64 and FreeBSD!
  --> src/bin/sccache-dist/main.rs:43:5
   |
43 |     compile_error!("Distributed compilation is only support on Linux/x86_64 and FreeBSD!");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
