### PR TITLE
Fix build on Android (in Termux)

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -13,7 +13,9 @@
 //! The module is used to provide abstraction over TCP socket and UDS.
 
 use std::fmt;
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(target_os = "android")]
+use std::os::android::net::SocketAddrExt;
+#[cfg(target_os = "linux")]
 use std::os::linux::net::SocketAddrExt;
 
 use futures::{Future, TryFutureExt};

--- a/src/server.rs
+++ b/src/server.rs
@@ -46,7 +46,9 @@ use std::io::{self, Write};
 use std::marker::Unpin;
 #[cfg(feature = "dist-client")]
 use std::mem;
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(target_os = "android")]
+use std::os::android::net::SocketAddrExt;
+#[cfg(target_os = "linux")]
 use std::os::linux::net::SocketAddrExt;
 use std::path::PathBuf;
 use std::pin::Pin;


### PR DESCRIPTION
error[E0433]: failed to resolve: could not find `linux` in `os`
  --> src/server.rs:50:14
     |
  50 | use std::os::linux::net::SocketAddrExt;
     |              ^^^^^ could not find `linux` in `os`
     |