### PR TITLE
Downgrade CUDA to 12.5 for Windows 2022 CI to fix integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,21 +118,21 @@ jobs:
             rustc: beta
             extra_desc: cuda11.8
           - os: windows-2022
-            cuda: "12.8"
+            cuda: "12.4"
             # Oldest supported version, keep in sync with README.md
             rustc: "1.75.0"
             extra_args: --no-fail-fast
-            extra_desc: cuda12.8
+            extra_desc: cuda12.4
           - os: windows-2022
-            cuda: "12.8"
+            cuda: "12.4"
             rustc: nightly
             allow_failure: true
             extra_args: --features=unstable
-            extra_desc: cuda12.8
+            extra_desc: cuda12.4
           - os: windows-2022
-            cuda: "12.8"
+            cuda: "12.4"
             rustc: beta
-            extra_desc: cuda12.8
+            extra_desc: cuda12.4
             no_coverage: true
     env:
       RUST_BACKTRACE: 1


### PR DESCRIPTION
Based on the following warning and then error, which look related: clang++: warning: CUDA version is newer than the latest partially supported version 12.5 [-Wunknown-cuda-version]
corecrt_wstdio.h:486:24: error: non-const lvalue reference to type '__builtin_va_list' cannot bind to a value of unrelated type 'va_list' (aka 'char *')