### PR TITLE
Don't run tests using Clang as CUDA compiler on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,16 +122,19 @@ jobs:
             # Oldest supported version, keep in sync with README.md
             rustc: "1.75.0"
             extra_args: --no-fail-fast
+            notest_cuda_compilers: clang++
             extra_desc: cuda12.8
           - os: windows-2022
             cuda: "12.8"
             rustc: nightly
             allow_failure: true
             extra_args: --features=unstable
+            notest_cuda_compilers: clang++
             extra_desc: cuda12.8
           - os: windows-2022
             cuda: "12.8"
             rustc: beta
+            notest_cuda_compilers: clang++
             extra_desc: cuda12.8
             no_coverage: true
     env:
@@ -141,6 +144,7 @@ jobs:
       BINARY_DIR: "target/debug"
       GRCOV_IGNORE_OPTION: '--ignore build.rs --ignore "/*" --ignore "[a-zA-Z]:/*"'
       GRCOV_EXCLUDE_OPTION: '--excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"'
+      NOTEST_CUDA_COMPILERS: ${{ matrix.notest_cuda_compilers || '' }}
     steps:
       - uses: ilammy/msvc-dev-cmd@v1
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -59,7 +59,13 @@ const COMPILERS: &[&str] = &["gcc", "clang", "clang++", "nvc", "nvc++"];
 #[cfg(target_os = "macos")]
 const COMPILERS: &[&str] = &["clang", "clang++"];
 
+#[cfg(not(windows))]
 const CUDA_COMPILERS: &[&str] = &["nvcc", "clang++"];
+// Visual Studio 2022 ships clang++ v19 which is too old for recent CUDA versions, and older CUDA
+// versions are too old for recent MSVC versions such as v14 included with Visual Studio 2022...
+// One could perhaps try to accept only clang++ not from under the VS2022 path.
+#[cfg(windows)]
+const CUDA_COMPILERS: &[&str] = &["nvcc"];
 
 fn adv_key_kind(lang: &str, compiler: &str) -> String {
     let language = lang.to_owned();


### PR DESCRIPTION
Visual Studio 2022 actually ships Clang these days. The included Clang v19 is too old to work with CUDA versions new enough to work with the MVSC version 14 also included with VS2022.