### PR TITLE
chore: replace retry crate with backon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2343,15 +2343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "retry"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9166d72162de3575f950507683fac47e30f6f2c3836b71b7fbc61aa517c9c5f4"
-dependencies = [
- "rand",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,6 +2560,7 @@ dependencies = [
  "ar",
  "assert_cmd",
  "async-trait",
+ "backon",
  "base64 0.21.7",
  "bincode",
  "blake3",
@@ -2611,7 +2603,6 @@ dependencies = [
  "regex",
  "reqsign",
  "reqwest 0.12.5",
- "retry",
  "rouille",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ strip = true
 anyhow = { version = "1.0", features = ["backtrace"] }
 ar = "0.9"
 async-trait = "0.1"
+backon = { version = "1", default-features = false, features = [
+  "std-blocking-sleep",
+] }
 base64 = "0.21"
 bincode = "1"
 blake3 = "1"
@@ -78,7 +81,6 @@ reqwest = { version = "0.12", features = [
   "rustls-tls-native-roots",
   "trust-dns",
 ], optional = true }
-retry = "2"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Replaces `retry` crate with `backon`. Since `backon` is used in the dependency `opendal` as well, this could reduces dependencies.