### PR TITLE
Remove or replace "Windows 2019" CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,23 +100,6 @@ jobs:
             no_coverage: true
           # # M1 CPU
           - os: macos-14
-          - os: windows-2019
-            cuda: "11.1"
-            # Oldest supported version, keep in sync with README.md
-            rustc: "1.75.0"
-            extra_args: --no-fail-fast
-            extra_desc: cuda11.1
-          - os: windows-2019
-            cuda: "11.8"
-            rustc: nightly
-            allow_failure: true
-            extra_args: --features=unstable
-            extra_desc: cuda11.8
-            no_coverage: true
-          - os: windows-2019
-            cuda: "11.8"
-            rustc: beta
-            extra_desc: cuda11.8
           - os: windows-2022
             cuda: "12.8"
             # Oldest supported version, keep in sync with README.md
@@ -268,10 +251,10 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             macosx_deployment_target: 11.0
-          - os: windows-2019
+          - os: windows-2022
             target: x86_64-pc-windows-msvc
             rustflags: -Ctarget-feature=+crt-static
-          - os: windows-2019
+          - os: windows-2022
             target: aarch64-pc-windows-msvc
             rustflags: -Ctarget-feature=+crt-static
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -452,7 +452,7 @@ jobs:
           ${SCCACHE_PATH} --show-stats | grep -e "Cache hits\s*[1-9]"
 
   test-mock-msvc:
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       TARGET: x86_64-pc-windows-msvc
       SCCACHE_EXE: ${{ github.workspace }}\\target\\x86_64-pc-windows-msvc\\debug\\sccache.exe


### PR DESCRIPTION
Remove where there is a similar config with Windows 2022, raise the version where there isn't one.