### PR TITLE
update windows-sys dependency and adapt to breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2397,7 +2397,7 @@ dependencies = [
  "percent-encoding",
  "sha1",
  "sha2",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2823,7 +2823,7 @@ dependencies = [
  "version-compare",
  "walkdir",
  "which",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
  "zip",
  "zstd",
 ]
@@ -4009,9 +4009,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
@@ -4072,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,14 +143,8 @@ optional = true
 version = "0.1.15"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-features = [
-  "Win32_Foundation",
-  "Win32_Globalization",
-  "Win32_Storage_FileSystem",
-  "Win32_System_Threading",
-  "Win32_System_Console",
-]
-version = "0.52"
+features = ["Win32_Foundation", "Win32_Globalization", "Win32_Storage_FileSystem", "Win32_System_Threading", "Win32_System_Console"]
+version = "0.61"
 
 [features]
 all = [

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -231,8 +231,8 @@ fn run_server_process(startup_timeout: Option<Duration>) -> Result<ServerStartup
     // TODO: Expose `bInheritHandles` argument of `CreateProcessW` through the
     //       standard library's `Command` type and then use that instead.
     let mut pi = PROCESS_INFORMATION {
-        hProcess: 0,
-        hThread: 0,
+        hProcess: std::ptr::null_mut(),
+        hThread: std::ptr::null_mut(),
         dwProcessId: 0,
         dwThreadId: 0,
     };


### PR DESCRIPTION
I'm running the unstable version of everything, from the OS up to the Rust compiler.
In this environment I can no longer build/install `sccache`.
I haven't bisected when this stopped working but it seems to be tied to the `windows-sys` dependency

```text
> cargo install --path=.

...

Compiling sccache v0.12.0 (C:\Users\Dominic Della Valle\Projects\3P\Rust\sccache)
error[E0432]: unresolved import `windows_sys::Win32::System::Threading::CreateProcessW`
   --> src\commands.rs:186:81
    |
186 |         CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, CREATE_UNICODE_ENVIRONMENT, CreateProcessW,
    |                                                                                 ^^^^^^^^^^^^^^ no `CreateProcessW` in `Win32::System::Threading`

warning: use of deprecated method `tempfile::TempDir::into_path`: use TempDir::keep()
   --> src\compiler\nvcc.rs:389:10
    |
389 |         .into_path();
    |          ^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

For more information about this error, try `rustc --explain E0432`.
warning: `sccache` (lib) generated 1 warning
error: could not compile `sccache` (lib) due to 1 previous error; 1 warning emitted
warning: build failed, waiting for other jobs to finish...
error: failed to compile `sccache v0.12.0 (C:\Users\Dominic Della Valle\Projects\3P\Rust\sccache)`, intermediate artifacts can be found at `C:\Users\Dominic Della Valle\Projects\3P\Rust\sccache\target`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```


Updating it, and adapting the source code to match the API change seems to fix it.
The only change is related to using an explicitly typed null pointer versus an implicit pointer of integer `0`.
Assuming this works fine on stable, but I'm sure the CI will let us know.

Specifically I did this:
`cargo update --verbose --breaking -Z unstable-options -p windows-sys`
And then edited `src\commands.rs` to conform to the breaking changes.
