### PR TITLE
Use generator in `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ By default, sccache will fail your build if it fails to successfully communicate
 
 **For versions of cmake 3.25 and later**, to compile with MSVC, you have to use the new `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` option, meant to configure the `-Z7` flag.  Additionally, you must set the cmake policy number 0141 to the NEW setting:
 ```cmake
-set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded)
+set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
 cmake_policy(SET CMP0141 NEW)
 ```
 
@@ -170,7 +170,7 @@ find_program(SCCACHE sccache REQUIRED)
 
 set(CMAKE_C_COMPILER_LAUNCHER ${SCCACHE})
 set(CMAKE_CXX_COMPILER_LAUNCHER ${SCCACHE})
-set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded)
+set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
 cmake_policy(SET CMP0141 NEW)
 ```
 


### PR DESCRIPTION
As it is probably the recommended way to do integrate cache in cmake, without introducing unexpected debug symbols to Release / MinSizeRel builds. 

Also consistent with the usage described in the official docs - https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_DEBUG_INFORMATION_FORMAT.html