### PR TITLE
chore: update to itertools 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,9 +1344,9 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ hyper-util = { version = "0.1.3", optional = true, features = [
   "tokio",
   "server",
 ] }
-itertools = "0.12"
+itertools = "0.14"
 jobserver = "0.1"
 jwt = { package = "jsonwebtoken", version = "9", optional = true }
 libc = "0.2.153"
@@ -128,7 +128,6 @@ assert_cmd = "2.0.13"
 cc = "1.0"
 chrono = "0.4.42"
 filetime = "0.2"
-itertools = "0.12"
 predicates = "=3.1.0"
 serial_test = "3.1"
 temp-env = "0.3.6"


### PR DESCRIPTION
Updates to `itertools` 0.14.