### PR TITLE
Avoid unreliable assert_cmd::cargo::cargo_bin

### DIFF
--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -54,7 +54,7 @@ fn basic_compile(tmpdir: &Path, sccache_cfg_path: &Path, sccache_cached_cfg_path
 }
 
 fn rust_compile(tmpdir: &Path, sccache_cfg_path: &Path, sccache_cached_cfg_path: &Path) -> Output {
-    let sccache_path = assert_cmd::cargo::cargo_bin("sccache").into_os_string();
+    let sccache_path = env!("CARGO_BIN_EXE_sccache");
     let envs: Vec<(_, &OsStr)> = vec![
         ("RUSTC_WRAPPER", sccache_path.as_ref()),
         ("CARGO_TARGET_DIR", "target".as_ref()),

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -140,7 +140,7 @@ pub fn prune_command(mut cmd: Command) -> Command {
 }
 
 pub fn sccache_command() -> Command {
-    prune_command(Command::new(assert_cmd::cargo::cargo_bin("sccache")))
+    prune_command(Command::new(env!("CARGO_BIN_EXE_sccache")))
 }
 
 pub fn cargo_command() -> Command {
@@ -149,7 +149,7 @@ pub fn cargo_command() -> Command {
 
 #[cfg(feature = "dist-server")]
 pub fn sccache_dist_path() -> PathBuf {
-    assert_cmd::cargo::cargo_bin("sccache-dist")
+    env!("CARGO_BIN_EXE_sccache-dist").into()
 }
 
 pub fn sccache_client_cfg(

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -15,7 +15,8 @@ use std::process::{Command, Stdio};
 pub static CRATE_DIR: Lazy<PathBuf> =
     Lazy::new(|| Path::new(file!()).parent().unwrap().join("../test-crate"));
 pub static CARGO: Lazy<OsString> = Lazy::new(|| std::env::var_os("CARGO").unwrap());
-pub static SCCACHE_BIN: Lazy<PathBuf> = Lazy::new(|| assert_cmd::cargo::cargo_bin("sccache"));
+pub static SCCACHE_BIN: Lazy<&Path> = Lazy::new(|| Path::new(env!("CARGO_BIN_EXE_sccache")));
+
 /// Ensures the logger is only initialized once. Panics if initialization fails.
 static LOGGER: Lazy<Result<(), Infallible>> = Lazy::new(|| {
     env_logger::Builder::new()

--- a/tests/oauth.rs
+++ b/tests/oauth.rs
@@ -64,7 +64,7 @@ fn config_with_dist_auth(
 }
 
 fn sccache_command() -> Command {
-    Command::new(assert_cmd::cargo::cargo_bin("sccache"))
+    Command::new(env!("CARGO_BIN_EXE_sccache"))
 }
 
 fn retry<F: FnMut() -> Option<T>, T>(interval: Duration, until: Duration, mut f: F) -> Option<T> {

--- a/tests/sccache_rustc.rs
+++ b/tests/sccache_rustc.rs
@@ -18,8 +18,7 @@ use std::{
 struct StopServer;
 impl Drop for StopServer {
     fn drop(&mut self) {
-        let _ = Command::cargo_bin("sccache")
-            .unwrap()
+        let _ = Command::from_std(std::process::Command::new(env!("CARGO_BIN_EXE_sccache")))
             .arg("--stop-server")
             .ok();
     }


### PR DESCRIPTION
`sccache`'s own tests fail when `[build] build-dir` is set in Cargo's config. This is because `cargo_bin()` makes no-longer-valid assumptions about Cargo's build directory layout: https://github.com/assert-rs/assert_cmd/issues/257

Cargo has a built-in env var for the path, so `cargo_bin()` can be removed. The var is set only at build time, not at test run time, which makes `env!` necessary.
