### PR TITLE
chore: switch once_cell crate to standard library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2787,7 +2787,6 @@ dependencies = [
  "nix 0.28.0",
  "number_prefix",
  "object 0.37.1",
- "once_cell",
  "opendal",
  "openssl",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ memmap2 = "0.9.4"
 mime = "0.3"
 number_prefix = "0.4"
 object = "0.37"
-once_cell = "1.19"
 opendal = { version = "0.54.0", optional = true, default-features = false }
 openssl = { version = "0.10.72", optional = true }
 rand = "0.8.4"

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -30,7 +30,6 @@ use crate::util::{
 };
 use async_trait::async_trait;
 use fs_err as fs;
-use once_cell::sync::Lazy;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
@@ -40,7 +39,7 @@ use std::io;
 use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 use std::process;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use crate::errors::*;
 
@@ -1425,7 +1424,7 @@ impl pkg::ToolchainPackager for CToolchainPackager {
 pub const CACHE_VERSION: &[u8] = b"11";
 
 /// Environment variables that are factored into the cache key.
-static CACHED_ENV_VARS: Lazy<HashSet<&'static OsStr>> = Lazy::new(|| {
+static CACHED_ENV_VARS: LazyLock<HashSet<&'static OsStr>> = LazyLock::new(|| {
     [
         // SCCACHE_C_CUSTOM_CACHE_BUSTER has no particular meaning behind it,
         // serving as a way for the user to factor custom data into the hash.

--- a/src/compiler/preprocessor_cache.rs
+++ b/src/compiler/preprocessor_cache.rs
@@ -24,12 +24,12 @@ use std::{
     hash::Hash,
     io::Write,
     path::{Path, PathBuf},
+    sync::LazyLock,
     time::SystemTime,
 };
 
 use anyhow::Context;
 use chrono::Datelike;
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -352,7 +352,7 @@ impl PreprocessorCacheEntry {
 }
 
 /// Environment variables that are factored into the preprocessor cache entry cached key.
-static CACHED_ENV_VARS: Lazy<HashSet<&'static OsStr>> = Lazy::new(|| {
+static CACHED_ENV_VARS: LazyLock<HashSet<&'static OsStr>> = LazyLock::new(|| {
     [
         // SCCACHE_C_CUSTOM_CACHE_BUSTER has no particular meaning behind it,
         // serving as a way for the user to factor custom data into the hash.

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -33,7 +33,6 @@ use async_trait::async_trait;
 use filetime::FileTime;
 use fs_err as fs;
 use log::Level::Trace;
-use once_cell::sync::Lazy;
 #[cfg(feature = "dist-client")]
 use semver::Version;
 #[cfg(feature = "dist-client")]
@@ -56,9 +55,9 @@ use std::iter;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::process;
-use std::sync::Arc;
 #[cfg(feature = "dist-client")]
 use std::sync::Mutex;
+use std::sync::{Arc, LazyLock};
 use std::time;
 
 use crate::errors::*;
@@ -232,8 +231,8 @@ pub struct CrateTypes {
 }
 
 /// Emit types that we will cache.
-static ALLOWED_EMIT: Lazy<HashSet<&'static str>> =
-    Lazy::new(|| ["link", "metadata", "dep-info"].iter().copied().collect());
+static ALLOWED_EMIT: LazyLock<HashSet<&'static str>> =
+    LazyLock::new(|| ["link", "metadata", "dep-info"].iter().copied().collect());
 
 /// Version number for cache key.
 const CACHE_VERSION: &[u8] = b"6";

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,6 @@ use crate::cache::CacheMode;
 use directories::ProjectDirs;
 use fs::File;
 use fs_err as fs;
-use once_cell::sync::Lazy;
 #[cfg(any(feature = "dist-client", feature = "dist-server"))]
 use serde::ser::Serializer;
 use serde::{
@@ -30,13 +29,13 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::result::Result as StdResult;
 use std::str::FromStr;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 use std::{collections::HashMap, fmt};
 
 pub use crate::cache::PreprocessorCacheModeConfig;
 use crate::errors::*;
 
-static CACHED_CONFIG_PATH: Lazy<PathBuf> = Lazy::new(CachedConfig::file_config_path);
+static CACHED_CONFIG_PATH: LazyLock<PathBuf> = LazyLock::new(CachedConfig::file_config_path);
 static CACHED_CONFIG: Mutex<Option<CachedFileConfig>> = Mutex::new(None);
 
 const ORGANIZATION: &str = "Mozilla";

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -254,7 +254,6 @@ mod server {
     use crate::util::{new_reqwest_blocking_client, num_cpus};
     use byteorder::{BigEndian, ReadBytesExt};
     use flate2::read::ZlibDecoder as ZlibReadDecoder;
-    use once_cell::sync::Lazy;
     use rand::{RngCore, rngs::OsRng};
     use rouille::accept;
     use serde::Serialize;
@@ -263,8 +262,8 @@ mod server {
     use std::io::Read;
     use std::net::SocketAddr;
     use std::result::Result as StdResult;
-    use std::sync::Mutex;
     use std::sync::atomic;
+    use std::sync::{LazyLock, Mutex};
     use std::thread;
     use std::time::Duration;
 
@@ -401,8 +400,9 @@ mod server {
     pub type ServerAuthCheck = Box<dyn Fn(&str) -> Option<ServerId> + Send + Sync>;
 
     const JWT_KEY_LENGTH: usize = 256 / 8;
-    static JWT_HEADER: Lazy<jwt::Header> = Lazy::new(|| jwt::Header::new(jwt::Algorithm::HS256));
-    static JWT_VALIDATION: Lazy<jwt::Validation> = Lazy::new(|| {
+    static JWT_HEADER: LazyLock<jwt::Header> =
+        LazyLock::new(|| jwt::Header::new(jwt::Algorithm::HS256));
+    static JWT_VALIDATION: LazyLock<jwt::Validation> = LazyLock::new(|| {
         let mut validation = jwt::Validation::new(jwt::Algorithm::HS256);
         validation.leeway = 0;
         validation.validate_exp = false;

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -5,20 +5,21 @@ use assert_cmd::assert::OutputAssertExt;
 use chrono::Local;
 use fs_err as fs;
 use log::trace;
-use once_cell::sync::Lazy;
 use std::convert::Infallible;
 use std::ffi::OsString;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::LazyLock;
 
-pub static CRATE_DIR: Lazy<PathBuf> =
-    Lazy::new(|| Path::new(file!()).parent().unwrap().join("../test-crate"));
-pub static CARGO: Lazy<OsString> = Lazy::new(|| std::env::var_os("CARGO").unwrap());
-pub static SCCACHE_BIN: Lazy<&Path> = Lazy::new(|| Path::new(env!("CARGO_BIN_EXE_sccache")));
+pub static CRATE_DIR: LazyLock<PathBuf> =
+    LazyLock::new(|| Path::new(file!()).parent().unwrap().join("../test-crate"));
+pub static CARGO: LazyLock<OsString> = LazyLock::new(|| std::env::var_os("CARGO").unwrap());
+pub static SCCACHE_BIN: LazyLock<&Path> =
+    LazyLock::new(|| Path::new(env!("CARGO_BIN_EXE_sccache")));
 
 /// Ensures the logger is only initialized once. Panics if initialization fails.
-static LOGGER: Lazy<Result<(), Infallible>> = Lazy::new(|| {
+static LOGGER: LazyLock<Result<(), Infallible>> = LazyLock::new(|| {
     env_logger::Builder::new()
         .format(|f, record| {
             writeln!(

--- a/tests/randomize_readdir/src/lib.rs
+++ b/tests/randomize_readdir/src/lib.rs
@@ -48,7 +48,6 @@ use libc::dirent as dirent64;
 use libc::dirent64;
 use libc::{c_char, c_int, c_void, dirent, dlsym, DIR, RTLD_NEXT};
 use log::{error, info};
-use once_cell::sync::OnceCell;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use simplelog::{Config, LevelFilter, WriteLogger};
@@ -57,7 +56,7 @@ use std::env;
 use std::ffi::CStr;
 use std::fs::File;
 use std::process;
-use std::sync::RwLock;
+use std::sync::{OnceLock, RwLock};
 
 type Opendir = unsafe extern "C" fn(dirname: *const c_char) -> *mut DIR;
 type Fdopendir = unsafe extern "C" fn(fd: c_int) -> *mut DIR;
@@ -173,7 +172,7 @@ impl State {
     }
 }
 
-static STATE: OnceCell<State> = OnceCell::new();
+static STATE: OnceLock<State> = OnceLock::new();
 
 fn load_next<Prototype: Copy>(name: &[u8]) -> Prototype {
     unsafe {


### PR DESCRIPTION
Switches the `once_cell` crate to the standard library.