### PR TITLE
docs: add installation steps for nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,11 @@ We also provide a flake with an overlay for getting the latest version:
 ```nix
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
-    sccache.url = "github:mozilla/sccache";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    sccache = {
+      url = "github:mozilla/sccache";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = { self, nixpkgs, sccache, ... }:


### PR DESCRIPTION
Adds installation steps for nix after #2518

likely should have been in that PR, but I forgot.. Sorry!

cc @nbp

maybe cc @doronbehar (upstream nixpkgs maintainer for sccache)

not sure if the upstream can take advantage of this create exporting a flake now, just pinging for awareness. 