### PR TITLE
ci: show diff for toml_format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v5
 
+      - name: Install taplo-cli
+        uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli
+
       - name: Check
-        run: npx --yes @taplo/cli fmt --check
+        run: taplo fmt --check --diff
 
 
 


### PR DESCRIPTION
- The `--diff` parameter isn't available via npx
- Also runs faster
- Use [`taiki-e/install-action`](https://github.com/taiki-e/install-action) to install from a binary