### PR TITLE
Revert "ci: show diff for toml_format"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,8 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v5
 
-      - name: Install taplo-cli
-        uses: taiki-e/install-action@v2
-        with:
-          tool: taplo-cli
-
       - name: Check
-        run: taplo fmt --check --diff
+        run: npx --yes @taplo/cli fmt --check
 
 
 


### PR DESCRIPTION
Reverts mozilla/sccache#2574

because  taiki-e/install-action isn't approved by the mozilla org yet
