### PR TITLE
Add .rustfmt.toml for consistent style between `rustfmt` and `cargo fmt`

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,2 @@
+# Should match package.edition from Cargo.toml
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+# Should match .rustfmt.toml
 edition = "2024"
 name = "sccache"
 rust-version = "1.85.0"


### PR DESCRIPTION
A tiny improvement for the quality of life.