### PR TITLE
docs: add comments about auth token requirements

### DIFF
--- a/docs/Distributed.md
+++ b/docs/Distributed.md
@@ -125,7 +125,7 @@ leak from anywhere allows any attacker to participate as a server.
 
 *To use it*:
 
-Choose a 'secure token' you can share between your scheduler and all servers.
+Choose a 'secure token' you can share between your scheduler and all servers. The token must be a valid HTTP header value.
 
 Put the following in your scheduler config file:
 
@@ -230,7 +230,7 @@ leak from anywhere allows any attacker to participate as a client.
 
 *To use it*:
 
-Choose a 'secure token' you can share between your scheduler and all clients.
+Choose a 'secure token' you can share between your scheduler and all clients. The token must be a valid HTTP header value.
 
 Put the following in your scheduler config file:
 

--- a/docs/DistributedQuickstart.md
+++ b/docs/DistributedQuickstart.md
@@ -31,7 +31,7 @@ public_addr = "127.0.0.1:10600"
 
 [client_auth]
 type = "token"
-token = "my client token"
+token = "my client token" # Must be a valid HTTP header value.
 
 [server_auth]
 type = "jwt_hs256"
@@ -122,7 +122,7 @@ toolchain_cache_size = 5368709120
 [dist.auth]
 type = "token"
 # This should match the `client_auth` section of the scheduler config.
-token = "my client token"
+token = "my client token" # Must be a valid HTTP header value.
 ```
 
 Clients using Mozilla build servers should configure their `dist.auth` section as follows:


### PR DESCRIPTION
Adds comments to the documentation for distributed compilation explaining the requirement of the token being a valid HTTP header value.
Hopefully this saves the next person running into this a bit of time :)