### PR TITLE
chore: update to tokio-serde 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3693,9 +3693,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-serde"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
+checksum = "caf600e7036b17782571dd44fa0a5cea3c82f60db5137f774a325a76a0d6852b"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ tokio = { version = "1", features = [
   "process",
   "macros",
 ] }
-tokio-serde = "0.8"
+tokio-serde = "0.9"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
 toml = "0.8"
 tower-service = "0.3"


### PR DESCRIPTION
Updates to `tokio-serde` 0.9.