### PR TITLE
clippy: fix cloned_ref_to_slice_refs lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,4 +222,5 @@ test = false
 workspace = true
 
 [workspace.lints.clippy]
+cloned_ref_to_slice_refs = "warn"
 implicit_clone = "warn"

--- a/benches/sccache_bench.rs
+++ b/benches/sccache_bench.rs
@@ -869,7 +869,7 @@ fn strip_basedirs_typical(bencher: Bencher) {
     bencher.bench(|| {
         black_box(strip_basedirs(
             black_box(&output),
-            black_box(&[basedir.clone()]),
+            black_box(std::slice::from_ref(&basedir)),
         ))
     });
 }


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#cloned_ref_to_slice_refs