### PR TITLE
clippy: fix cloned_instead_of_copied lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,6 +222,7 @@ test = false
 workspace = true
 
 [workspace.lints.clippy]
+cloned_instead_of_copied = "warn"
 cloned_ref_to_slice_refs = "warn"
 implicit_clone = "warn"
 semicolon_if_nothing_returned = "warn"

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -959,7 +959,7 @@ fn process_preprocessor_line(
 pub fn normalize_path(path: &Path) -> PathBuf {
     use std::path::Component;
     let mut components = path.components().peekable();
-    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().copied() {
         components.next();
         PathBuf::from(c.as_os_str())
     } else {


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#cloned_instead_of_copied