### PR TITLE
Split Storage trait into Storage and PreprocessorCacheStorage traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,6 +222,7 @@ test = false
 workspace = true
 
 [workspace.lints.clippy]
+cloned_instead_of_copied = "warn"
 cloned_ref_to_slice_refs = "warn"
 implicit_clone = "warn"
 semicolon_if_nothing_returned = "warn"

--- a/docs/Caching.md
+++ b/docs/Caching.md
@@ -48,12 +48,63 @@ See https://github.com/mozilla/sccache/blob/8567bbe2ba493153e76177c1f9a6f98cc7ba
 
 ### C/C++ preprocessor
 
-In "preprocessor cache mode", [explained in the local doc](Local.md), an
-extra key is computed to cache the preprocessor output itself. It is very close
-to the C/C++ compiler one, but with additional elements:
+In "preprocessor cache mode" explained below, an extra key is computed to cache the preprocessor output itself.
+It is very close to the C/C++ compiler one, but with additional elements:
 
 * The path of the input file
 * The hash of the input file
 
 Note that some compiler options can disable preprocessor cache mode. As of this
 writing, only `-Xpreprocessor` and `-Wp,*` do.
+
+#### Preprocessor cache mode
+
+This is inspired by [ccache's direct mode](https://ccache.dev/manual/3.7.9.html#_the_direct_mode) and works roughly the same.
+It adds a cache that allows to skip preprocessing when compiling C/C++. This can make it much faster to return compilation results
+from cache since preprocessing is a major expense for these.
+
+Preprocessor cache mode is controlled by a configuration option which is true by default, as well as additional conditions described below.
+
+To ensure that the cached preprocessor results for a source file correspond to the un-preprocessed inputs, sccache needs
+to remember, among other things, all files included by the source file. sccache also needs to recognize
+when "external factors" may change the results, such as system time if the `__TIME__` macro is used
+in a source file. How conservative sccache is about some of these external factors is configurable, see below.
+
+Preprocessor cache mode will be disabled in any of the following cases:
+
+- Not compiling C or C++
+- The configuration option is false
+- Not using GCC or Clang
+- Not using local storage for the cache
+- Any of the compiler options `-Xpreprocessor`, `-Wp,` are present
+- The modification time of one of the header files is too new (avoids a race condition)
+- Certain strings such as `__DATE__`, `__TIME__`, `__TIMESTAMP__` are present in the source code,
+  indicating that the preprocessor result may change based on external factors
+
+The preprocessor cache may silently produce stale results in any of the following cases:
+
+- When a source file was compiled and its results were cached, a header file would have been included if it existed, but it did
+  not exist at the time. sccache does not know about such files, so it cannot invalidate the result if the header file later exists.
+- A macro such as `__TIME__` (etc) is used in the source code and `ignore_time_macros` is enabled
+- There are other external factors influencing the preprocessing result that sccache does not know about
+
+Configuration options and their default values:
+
+- `use_preprocessor_cache_mode`: `true`. Whether to use preprocessor cache mode. This can be overridden for an sccache invocation by setting the environment variable `SCCACHE_DIRECT` to `true`/`on`/`1` or `false`/`off`/`0`.
+- `file_stat_matches`: `false`. If false, only compare header files by hashing their contents. If true, will use size + ctime + mtime to check whether a file has changed. See other flags below for more control over this behavior.
+- `use_ctime_for_stat`: `true`. If true, uses the ctime (file status change on UNIX, creation time on Windows) to check that a file has/hasn't changed. Can be useful to disable when backdating modification times in a controlled manner.
+
+- `ignore_time_macros`: `false`. If true, ignore `__DATE__`, `__TIME__` and `__TIMESTAMP__` being present in the source code. Will speed up preprocessor cache mode, but can produce stale results.
+
+- `skip_system_headers`: `false`. If true, the preprocessor cache will only add the paths of included system headers to the cache key but ignore the headers' contents.
+
+- `hash_working_directory`: `true`. If true, will add the current working directory to the cache key to distinguish two compilations from different directories.
+- `max_size`: `10737418240`. The size of the preprocessor cache, defaults to the default disk cache size.
+- `rw_mode`: `ReadWrite`. ReadOnly or ReadWrite mode for the cache.
+- `dir`: `path_to_cache_directory`. Path to the preprocessor cache, By default it will use DiskCache's directory, under subdirectory `preprocessor`.
+
+See where to write the config in [the configuration doc](Configuration.md).
+
+`sccache --debug-preprocessor-cache` can be used to investigate the content of the preprocessor cache.
+
+The preprocessor cache uses random read and write; thus, certain file systems, including `s3fs`, are not supported.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -53,7 +53,7 @@ dir = "/tmp/.cache/sccache"
 size = 7516192768 # 7 GiBytes
 
 # See the local docs on more explanations about this mode
-[cache.disk.preprocessor_cache_mode]
+[cache.preprocessor_cache_mode]
 # Whether to use the preprocessor cache mode
 use_preprocessor_cache_mode = true
 # Whether to use file times to check for changes
@@ -66,6 +66,12 @@ ignore_time_macros = false
 skip_system_headers = false
 # Whether hash the current working directory
 hash_working_directory = true
+# Maximum size of the cache
+max_size = 1048576
+# ReadOnly/ReadWrite mode
+rw_mode = "ReadWrite"
+# Path to the cache
+dir = "/tmp/.cache/sccache-preprocess/"
 
 [cache.gcs]
 # optional oauth url

--- a/docs/Local.md
+++ b/docs/Local.md
@@ -6,51 +6,6 @@ The default cache size is 10 gigabytes. To change this, set `SCCACHE_CACHE_SIZE`
 
 The local storage only supports a single sccache server at a time. Multiple concurrent servers will race and cause spurious build failures.
 
-## Preprocessor cache mode
-
-This is inspired by [ccache's direct mode](https://ccache.dev/manual/3.7.9.html#_the_direct_mode) and works roughly the same.
-It adds a cache that allows to skip preprocessing when compiling C/C++. This can make it much faster to return compilation results
-from cache since preprocessing is a major expense for these.
-
-Preprocessor cache mode is controlled by a configuration option which is true by default, as well as additional conditions described below.
-
-To ensure that the cached preprocessor results for a source file correspond to the un-preprocessed inputs, sccache needs
-to remember, among other things, all files included by the source file. sccache also needs to recognize
-when "external factors" may change the results, such as system time if the `__TIME__` macro is used
-in a source file. How conservative sccache is about some of these external factors is configurable, see below.
-
-Preprocessor cache mode will be disabled in any of the following cases:
-
-- Not compiling C or C++
-- The configuration option is false
-- Not using GCC or Clang
-- Not using local storage for the cache
-- Any of the compiler options `-MP`, `-Xpreprocessor`, `-Wp,` are present
-- The modification time of one of the header files is too new (avoids a race condition)
-- Certain strings such as `__DATE__`, `__TIME__`, `__TIMESTAMP__` are present in the source code,
-  indicating that the preprocessor result may change based on external factors
-
-The preprocessor cache may silently produce stale results in any of the following cases:
-
-- When a source file was compiled and its results were cached, a header file would have been included if it existed, but it did
-  not exist at the time. sccache does not know about such files, so it cannot invalidate the result if the header file later exists.
-- A macro such as `__TIME__` (etc) is used in the source code and `ignore_time_macros` is enabled
-- There are other external factors influencing the preprocessing result that sccache does not know about
-
-Configuration options and their default values:
-
-- `use_preprocessor_cache_mode`: `true`. Whether to use preprocessor cache mode. This can be overridden for an sccache invocation by setting the environment variable `SCCACHE_DIRECT` to `true`/`on`/`1` or `false`/`off`/`0`.
-- `file_stat_matches`: `false`. If false, only compare header files by hashing their contents. If true, will use size + ctime + mtime to check whether a file has changed. See other flags below for more control over this behavior.
-- `use_ctime_for_stat`: `true`. If true, uses the ctime (file status change on UNIX, creation time on Windows) to check that a file has/hasn't changed. Can be useful to disable when backdating modification times in a controlled manner.
-
-- `ignore_time_macros`: `false`. If true, ignore `__DATE__`, `__TIME__` and `__TIMESTAMP__` being present in the source code. Will speed up preprocessor cache mode, but can produce stale results.
-
-- `skip_system_headers`: `false`. If true, the preprocessor cache will only add the paths of included system headers to the cache key but ignore the headers' contents.
-
-- `hash_working_directory`: `true`. If true, will add the current working directory to the cache key to distinguish two compilations from different directories.
-
-See where to write the config in [the configuration doc](Configuration.md).
-
 ## Read-only cache mode
 
 By default, the local cache operates in read/write mode. The `SCCACHE_LOCAL_RW_MODE` environment variable can be set to `READ_ONLY` (or `READ_WRITE`) to modify this behavior.

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -30,11 +30,13 @@ pub mod lazy_disk_cache;
 pub mod memcached;
 #[cfg(feature = "oss")]
 pub mod oss;
+pub mod preprocessor_cache;
 pub mod readonly;
 #[cfg(feature = "redis")]
 pub mod redis;
 #[cfg(feature = "s3")]
 pub mod s3;
+pub mod storage;
 pub(crate) mod utils;
 #[cfg(feature = "webdav")]
 pub mod webdav;
@@ -53,3 +55,5 @@ pub(crate) mod http_client;
 pub use crate::cache::cache::*;
 pub use crate::cache::cache_io::*;
 pub use crate::cache::lazy_disk_cache::*;
+pub use crate::cache::preprocessor_cache::*;
+pub use crate::cache::storage::*;

--- a/src/cache/preprocessor_cache.rs
+++ b/src/cache/preprocessor_cache.rs
@@ -1,0 +1,135 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    io::BufWriter,
+    sync::{Arc, Mutex},
+};
+
+use crate::{
+    cache::{LazyDiskCache, utils::normalize_key},
+    compiler::PreprocessorCacheEntry,
+    config::{CacheModeConfig, PreprocessorCacheModeConfig, default_disk_cache_dir},
+    errors::*,
+};
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait PreprocessorCacheStorage: Send + Sync {
+    /// Return the config for preprocessor cache mode if applicable
+    fn get_config(&self) -> &PreprocessorCacheModeConfig;
+
+    /// Return the preprocessor cache entry for a given preprocessor key,
+    /// if it exists.
+    /// Only applicable when using preprocessor cache mode.
+    async fn get_preprocessor_cache_entry(
+        &self,
+        _key: &str,
+    ) -> Result<Option<Box<dyn crate::lru_disk_cache::ReadSeek>>> {
+        Ok(None)
+    }
+
+    /// Insert a preprocessor cache entry at the given preprocessor key,
+    /// overwriting the entry if it exists.
+    /// Only applicable when using preprocessor cache mode.
+    async fn put_preprocessor_cache_entry(
+        &self,
+        _key: &str,
+        _preprocessor_cache_entry: PreprocessorCacheEntry,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Store the hashed source file as preprocessor cache entries.
+/// If preprocessor cache mode is enabled,
+pub(crate) struct PreprocessorCache {
+    cache: Option<Arc<Mutex<LazyDiskCache>>>,
+    config: PreprocessorCacheModeConfig,
+}
+
+impl PreprocessorCache {
+    pub fn new(config: &PreprocessorCacheModeConfig) -> PreprocessorCache {
+        info!("Creating PreprocessorCache with config: {:?}", config);
+        let cache_dir = match config.dir {
+            Some(ref dir) => dir.clone(),
+            None => {
+                let default_dir = default_disk_cache_dir();
+                info!(
+                    "No preprocessor cache directory configured, using disk cache directory: {:?}",
+                    default_dir
+                );
+                default_dir
+            }
+        };
+        PreprocessorCache {
+            cache: if config.use_preprocessor_cache_mode {
+                Some(Arc::new(Mutex::new(LazyDiskCache::Uninit {
+                    root: cache_dir.join("preprocessor").into_os_string(),
+                    max_size: config.max_size,
+                })))
+            } else {
+                None
+            },
+            config: config.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl PreprocessorCacheStorage for PreprocessorCache {
+    /// Return the config for preprocessor cache mode if applicable
+    fn get_config(&self) -> &PreprocessorCacheModeConfig {
+        &self.config
+    }
+
+    /// Return the preprocessor cache entry for a given preprocessor key,
+    /// if it exists.
+    /// Only applicable when using preprocessor cache mode.
+    async fn get_preprocessor_cache_entry(
+        &self,
+        key: &str,
+    ) -> Result<Option<Box<dyn crate::lru_disk_cache::ReadSeek>>> {
+        match self.cache {
+            None => Ok(None),
+            Some(ref cache) => {
+                assert!(self.config.use_preprocessor_cache_mode);
+                let key = normalize_key(key);
+                Ok(cache.lock().unwrap().get_or_init()?.get(key).ok())
+            }
+        }
+    }
+
+    /// Insert a preprocessor cache entry at the given preprocessor key,
+    /// overwriting the entry if it exists.
+    /// Only applicable when using preprocessor cache mode.
+    async fn put_preprocessor_cache_entry(
+        &self,
+        key: &str,
+        preprocessor_cache_entry: PreprocessorCacheEntry,
+    ) -> Result<()> {
+        if self.config.rw_mode == CacheModeConfig::ReadOnly {
+            bail!("Cannot write to a read-only cache");
+        }
+        match self.cache {
+            None => Ok(()),
+            Some(ref cache) => {
+                assert!(self.config.use_preprocessor_cache_mode);
+                let key = normalize_key(key);
+                info!("PreprocessorCache: put_preprocessor_cache_entry({})", key);
+                let mut f = cache.lock().unwrap().get_or_init()?.prepare_add(key, 0)?;
+                preprocessor_cache_entry.serialize_to(BufWriter::new(f.as_file_mut()))?;
+                Ok(cache.lock().unwrap().get().unwrap().commit(f)?)
+            }
+        }
+    }
+}

--- a/src/cache/readonly.rs
+++ b/src/cache/readonly.rs
@@ -16,8 +16,6 @@ use std::time::Duration;
 use async_trait::async_trait;
 
 use crate::cache::{Cache, CacheMode, CacheWrite, Storage};
-use crate::compiler::PreprocessorCacheEntry;
-use crate::config::PreprocessorCacheModeConfig;
 use crate::errors::*;
 
 pub struct ReadOnlyStorage(pub Arc<dyn Storage>);
@@ -63,35 +61,9 @@ impl Storage for ReadOnlyStorage {
         self.0.max_size().await
     }
 
-    /// Return the config for preprocessor cache mode if applicable
-    fn preprocessor_cache_mode_config(&self) -> PreprocessorCacheModeConfig {
-        self.0.preprocessor_cache_mode_config()
-    }
-
     /// Return the base directories for path normalization if configured
     fn basedirs(&self) -> &[Vec<u8>] {
         self.0.basedirs()
-    }
-
-    /// Return the preprocessor cache entry for a given preprocessor key,
-    /// if it exists.
-    /// Only applicable when using preprocessor cache mode.
-    async fn get_preprocessor_cache_entry(
-        &self,
-        key: &str,
-    ) -> Result<Option<Box<dyn crate::lru_disk_cache::ReadSeek>>> {
-        self.0.get_preprocessor_cache_entry(key).await
-    }
-
-    /// Insert a preprocessor cache entry at the given preprocessor key,
-    /// overwriting the entry if it exists.
-    /// Only applicable when using preprocessor cache mode.
-    async fn put_preprocessor_cache_entry(
-        &self,
-        _key: &str,
-        _preprocessor_cache_entry: PreprocessorCacheEntry,
-    ) -> Result<()> {
-        Err(anyhow!("Cannot write to read-only storage"))
     }
 }
 
@@ -104,29 +76,10 @@ mod test {
 
     #[test]
     fn readonly_storage_is_readonly() {
-        let storage = ReadOnlyStorage(Arc::new(MockStorage::new(None, false)));
+        let storage = ReadOnlyStorage(Arc::new(MockStorage::new(None)));
         assert_eq!(
             storage.check().now_or_never().unwrap().unwrap(),
             CacheMode::ReadOnly
-        );
-    }
-
-    #[test]
-    fn readonly_storage_forwards_preprocessor_cache_mode_config() {
-        let storage_no_preprocessor_cache =
-            ReadOnlyStorage(Arc::new(MockStorage::new(None, false)));
-        assert!(
-            !storage_no_preprocessor_cache
-                .preprocessor_cache_mode_config()
-                .use_preprocessor_cache_mode
-        );
-
-        let storage_with_preprocessor_cache =
-            ReadOnlyStorage(Arc::new(MockStorage::new(None, true)));
-        assert!(
-            storage_with_preprocessor_cache
-                .preprocessor_cache_mode_config()
-                .use_preprocessor_cache_mode
         );
     }
 
@@ -154,7 +107,6 @@ mod test {
             &cache_dir,
             1024 * 1024,
             runtime.handle(),
-            super::PreprocessorCacheModeConfig::default(),
             super::CacheMode::ReadWrite,
             basedirs.clone(),
         );
@@ -172,19 +124,11 @@ mod test {
             .build()
             .unwrap();
 
-        let storage = ReadOnlyStorage(Arc::new(MockStorage::new(None, true)));
+        let storage = ReadOnlyStorage(Arc::new(MockStorage::new(None)));
         runtime.block_on(async move {
             assert_eq!(
                 storage
                     .put("test1", CacheWrite::default())
-                    .await
-                    .unwrap_err()
-                    .to_string(),
-                "Cannot write to read-only storage"
-            );
-            assert_eq!(
-                storage
-                    .put_preprocessor_cache_entry("test1", PreprocessorCacheEntry::default())
                     .await
                     .unwrap_err()
                     .to_string(),
@@ -212,7 +156,6 @@ mod test {
             &cache_dir,
             1024 * 1024,
             runtime.handle(),
-            super::PreprocessorCacheModeConfig::default(),
             super::CacheMode::ReadWrite,
             vec![],
         );

--- a/src/cache/storage.rs
+++ b/src/cache/storage.rs
@@ -1,0 +1,69 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::cache_io::{Cache, CacheMode, CacheWrite};
+use crate::errors::*;
+use async_trait::async_trait;
+use std::time::Duration;
+
+/// An interface to cache storage.
+#[async_trait]
+pub trait Storage: Send + Sync {
+    /// Get a cache entry by `key`.
+    ///
+    /// If an error occurs, this method should return a `Cache::Error`.
+    /// If nothing fails but the entry is not found in the cache,
+    /// it should return a `Cache::Miss`.
+    /// If the entry is successfully found in the cache, it should
+    /// return a `Cache::Hit`.
+    async fn get(&self, key: &str) -> Result<Cache>;
+
+    /// Put `entry` in the cache under `key`.
+    ///
+    /// Returns a `Future` that will provide the result or error when the put is
+    /// finished.
+    async fn put(&self, key: &str, entry: CacheWrite) -> Result<Duration>;
+
+    /// Check the cache capability.
+    ///
+    /// - `Ok(CacheMode::ReadOnly)` means cache can only be used to `get`
+    ///   cache.
+    /// - `Ok(CacheMode::ReadWrite)` means cache can do both `get` and `put`.
+    /// - `Err(err)` means cache is not setup correctly or not match with
+    ///   users input (for example, user try to use `ReadWrite` but cache
+    ///   is `ReadOnly`).
+    ///
+    /// We will provide a default implementation which returns
+    /// `Ok(CacheMode::ReadWrite)` for service that doesn't
+    /// support check yet.
+    async fn check(&self) -> Result<CacheMode> {
+        Ok(CacheMode::ReadWrite)
+    }
+
+    /// Get the storage location.
+    fn location(&self) -> String;
+
+    /// Get the current storage usage, if applicable.
+    async fn current_size(&self) -> Result<Option<u64>>;
+
+    /// Get the maximum storage size, if applicable.
+    async fn max_size(&self) -> Result<Option<u64>>;
+
+    /// Get the cache backend type name (e.g., "disk", "redis", "s3").
+    /// Used for statistics and display purposes.
+    fn cache_type_name(&self) -> &'static str;
+
+    /// Return the base directories for path normalization, if configured
+    fn basedirs(&self) -> &[Vec<u8>] {
+        &[]
+    }
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::cache::storage_from_config;
+use crate::cache::get_storage_from_config;
 use crate::client::{ServerConnection, connect_to_server, connect_with_retry};
 use crate::cmdline::{Command, StatsFormat};
 use crate::compiler::ColorMode;
@@ -628,8 +628,14 @@ pub fn run_command(cmd: Command) -> Result<i32> {
                 // anyways, so we can just return (mostly) empty stats directly.
                 Err(_) => {
                     let runtime = Runtime::new()?;
-                    let storage = storage_from_config(config, runtime.handle()).ok();
-                    runtime.block_on(ServerInfo::new(ServerStats::default(), storage.as_deref()))?
+                    let storage_data = get_storage_from_config(config, runtime.handle()).ok();
+                    let storage = storage_data.as_ref().map(|(s, _)| s.clone());
+                    let preprocessor_cache_storage = storage_data.as_ref().map(|(_, p)| p.clone());
+                    runtime.block_on(ServerInfo::new(
+                        ServerStats::default(),
+                        storage.as_deref(),
+                        preprocessor_cache_storage.as_deref(),
+                    ))?
                 }
             };
             match fmt {

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::cache::{FileObjectSource, Storage};
+use crate::cache::{FileObjectSource, PreprocessorCacheStorage, Storage};
 use crate::compiler::preprocessor_cache::preprocessor_cache_entry_hash_key;
 use crate::compiler::{
     Cacheable, ColorMode, Compilation, CompileCommand, Compiler, CompilerArguments, CompilerHasher,
@@ -374,6 +374,7 @@ where
         pool: &tokio::runtime::Handle,
         rewrite_includes_only: bool,
         storage: Arc<dyn Storage>,
+        preprocessor_cache_storage: Arc<dyn PreprocessorCacheStorage>,
         cache_control: CacheControl,
     ) -> Result<HashResult<T>> {
         let start_of_compilation = std::time::SystemTime::now();
@@ -394,7 +395,7 @@ where
 
         // Try to look for a cached preprocessing step for this compilation
         // request.
-        let preprocessor_cache_mode_config = storage.preprocessor_cache_mode_config();
+        let preprocessor_cache_mode_config = preprocessor_cache_storage.get_config();
         let too_hard_for_preprocessor_cache_mode = self
             .parsed_args
             .too_hard_for_preprocessor_cache_mode
@@ -416,6 +417,7 @@ where
             let mut use_preprocessor_cache_mode = can_use_preprocessor_cache_mode;
 
             // Allow overrides from the env
+            // FIXME: Is this needed when the environmental config is merged?
             for (key, val) in env_vars.iter() {
                 if key == "SCCACHE_DIRECT" {
                     if let Some(val) = val.to_str() {
@@ -452,7 +454,7 @@ where
                 &env_vars,
                 &absolute_input_path,
                 self.compiler.plusplus(),
-                preprocessor_cache_mode_config,
+                &preprocessor_cache_mode_config,
                 storage.basedirs(),
             )?
         } else {
@@ -462,7 +464,7 @@ where
         let (preprocessor_output, include_files) = if needs_preprocessing {
             if let Some(preprocessor_key) = &preprocessor_key {
                 if cache_control == CacheControl::Default {
-                    if let Some(mut seekable) = storage
+                    if let Some(mut seekable) = preprocessor_cache_storage
                         .get_preprocessor_cache_entry(preprocessor_key)
                         .await?
                     {
@@ -481,7 +483,7 @@ where
                                 "Preprocessor cache updated because of time macros: {preprocessor_key}"
                             );
 
-                            if let Err(e) = storage
+                            if let Err(e) = preprocessor_cache_storage
                                 .put_preprocessor_cache_entry(
                                     preprocessor_key,
                                     preprocessor_cache_entry,
@@ -648,7 +650,7 @@ where
                 files.sort_unstable_by(|a, b| a.1.cmp(&b.1));
                 preprocessor_cache_entry.add_result(start_of_compilation, &key, files);
 
-                if let Err(e) = storage
+                if let Err(e) = preprocessor_cache_storage
                     .put_preprocessor_cache_entry(&preprocessor_key, preprocessor_cache_entry)
                     .await
                 {
@@ -710,7 +712,7 @@ fn process_preprocessed_file(
     cwd: &Path,
     bytes: &mut [u8],
     included_files: &mut HashMap<PathBuf, String>,
-    config: PreprocessorCacheModeConfig,
+    config: &PreprocessorCacheModeConfig,
     time_of_compilation: std::time::SystemTime,
     fs_impl: impl PreprocessorFSAbstraction,
 ) -> Result<bool> {
@@ -829,7 +831,7 @@ fn process_preprocessor_line(
     input_file: &Path,
     cwd: &Path,
     included_files: &mut HashMap<PathBuf, String>,
-    config: PreprocessorCacheModeConfig,
+    config: &PreprocessorCacheModeConfig,
     time_of_compilation: std::time::SystemTime,
     bytes: &mut [u8],
     mut start: usize,
@@ -1036,7 +1038,7 @@ fn remember_include_file(
     included_files: &mut HashMap<PathBuf, String>,
     digest: &mut Digest,
     system: bool,
-    config: PreprocessorCacheModeConfig,
+    config: &PreprocessorCacheModeConfig,
     time_of_compilation: std::time::SystemTime,
     fs_impl: &impl PreprocessorFSAbstraction,
 ) -> Result<bool> {
@@ -1864,7 +1866,7 @@ mod test {
             Path::new(""),
             &mut bytes,
             &mut include_files,
-            config,
+            &config,
             std::time::SystemTime::now(),
             StandardFsAbstraction,
         )
@@ -1938,7 +1940,7 @@ mod test {
             input_file,
             Path::new(""),
             include_files,
-            config,
+            &config,
             std::time::SystemTime::now(),
             &mut bytes,
             0,

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -454,7 +454,7 @@ where
                 &env_vars,
                 &absolute_input_path,
                 self.compiler.plusplus(),
-                &preprocessor_cache_mode_config,
+                preprocessor_cache_mode_config,
                 storage.basedirs(),
             )?
         } else {

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -961,7 +961,7 @@ fn process_preprocessor_line(
 pub fn normalize_path(path: &Path) -> PathBuf {
     use std::path::Component;
     let mut components = path.components().peekable();
-    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().copied() {
         components.next();
         PathBuf::from(c.as_os_str())
     } else {

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -265,6 +265,7 @@ mod test {
     use crate::compiler::*;
     use crate::mock_command::*;
     use crate::server;
+    use crate::test::mock_preprocessor_cache::MockPreprocessorCacheStorage;
     use crate::test::mock_storage::MockStorage;
     use crate::test::utils::*;
     use std::collections::HashMap;
@@ -1163,9 +1164,15 @@ mod test {
             too_hard_for_preprocessor_cache_mode: None,
         };
         let runtime = single_threaded_runtime();
-        let storage = MockStorage::new(None, false);
+        let storage = MockStorage::new(None);
         let storage: std::sync::Arc<MockStorage> = std::sync::Arc::new(storage);
-        let service = server::SccacheService::mock_with_storage(storage, runtime.handle().clone());
+        let preprocessor_cache_storage =
+            std::sync::Arc::new(MockPreprocessorCacheStorage::new(false));
+        let service = server::SccacheService::mock_with_storage(
+            storage,
+            preprocessor_cache_storage,
+            runtime.handle().clone(),
+        );
         let compiler = &f.bins[0];
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -13,7 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::cache::{Cache, CacheWrite, DecompressionFailure, FileObjectSource, Storage};
+use crate::cache::{
+    Cache, CacheWrite, DecompressionFailure, FileObjectSource, PreprocessorCacheStorage, Storage,
+};
 use crate::compiler::args::*;
 use crate::compiler::c::{CCompiler, CCompilerKind};
 use crate::compiler::cicc::Cicc;
@@ -500,6 +502,7 @@ where
         pool: &tokio::runtime::Handle,
         rewrite_includes_only: bool,
         storage: Arc<dyn Storage>,
+        preprocessor_cache_storage: Arc<dyn PreprocessorCacheStorage>,
         cache_control: CacheControl,
     ) -> Result<HashResult<T>>;
 
@@ -515,6 +518,7 @@ where
         dist_client: Option<Arc<dyn dist::Client>>,
         creator: T,
         storage: Arc<dyn Storage>,
+        preprocessor_cache_storage: Arc<dyn PreprocessorCacheStorage>,
         arguments: Vec<OsString>,
         cwd: PathBuf,
         env_vars: Vec<(OsString, OsString)>,
@@ -538,6 +542,7 @@ where
                 &pool,
                 rewrite_includes_only,
                 storage.clone(),
+                preprocessor_cache_storage.clone(),
                 cache_control,
             )
             .await;
@@ -696,12 +701,14 @@ where
                     // This compilation only had enough information to find and use a cache entry (or to
                     // run a local compile, which doesn't need locally preprocessed code).
                     // For distributed compilation, the local preprocessing step still needs to be done.
+
                     return self
                         .get_cached_or_compile(
                             service,
                             dist_client,
                             creator,
                             storage,
+                            preprocessor_cache_storage,
                             arguments,
                             cwd,
                             env_vars,
@@ -1882,9 +1889,10 @@ where
 mod test {
     use super::*;
     use crate::cache::disk::DiskCache;
-    use crate::cache::{CacheMode, CacheRead};
+    use crate::cache::{CacheMode, CacheRead, PreprocessorCache};
     use crate::config::PreprocessorCacheModeConfig;
     use crate::mock_command::*;
+    use crate::test::mock_preprocessor_cache::MockPreprocessorCacheStorage;
     use crate::test::mock_storage::MockStorage;
     use crate::test::utils::*;
     use fs::File;
@@ -2358,7 +2366,8 @@ LLVM version: 6.0",
                         false,
                         pool,
                         false,
-                        Arc::new(MockStorage::new(None, preprocessor_cache_mode)),
+                        Arc::new(MockStorage::new(None)),
+                        Arc::new(MockPreprocessorCacheStorage::new(preprocessor_cache_mode)),
                         CacheControl::Default,
                     )
                     .wait()
@@ -2426,7 +2435,8 @@ LLVM version: 6.0",
                         false,
                         pool,
                         false,
-                        Arc::new(MockStorage::new(None, preprocessor_cache_mode)),
+                        Arc::new(MockStorage::new(None)),
+                        Arc::new(MockPreprocessorCacheStorage::new(preprocessor_cache_mode)),
                         CacheControl::Default,
                     )
                     .wait()
@@ -2492,7 +2502,8 @@ LLVM version: 6.0",
                         false,
                         pool,
                         false,
-                        Arc::new(MockStorage::new(None, preprocessor_cache_mode)),
+                        Arc::new(MockStorage::new(None)),
+                        Arc::new(MockPreprocessorCacheStorage::new(preprocessor_cache_mode)),
                         CacheControl::Default,
                     )
                     .wait()
@@ -2536,17 +2547,28 @@ LLVM version: 6.0",
             f.tempdir.path().join("cache"),
             u64::MAX,
             &pool,
-            PreprocessorCacheModeConfig {
-                use_preprocessor_cache_mode: preprocessor_cache_mode,
-                ..Default::default()
-            },
             CacheMode::ReadWrite,
             vec![],
         );
+        let preprocessor_cache_storage = if preprocessor_cache_mode {
+            Arc::new(PreprocessorCache::new(&PreprocessorCacheModeConfig {
+                use_preprocessor_cache_mode: true,
+                ..Default::default()
+            }))
+        } else {
+            Arc::new(PreprocessorCache::new(&PreprocessorCacheModeConfig {
+                use_preprocessor_cache_mode: false,
+                ..Default::default()
+            }))
+        };
         // Write a dummy input file so the preprocessor cache mode can work
         std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
         let storage = Arc::new(storage);
-        let service = server::SccacheService::mock_with_storage(storage.clone(), pool.clone());
+        let service = server::SccacheService::mock_with_storage(
+            storage.clone(),
+            preprocessor_cache_storage.clone(),
+            pool.clone(),
+        );
 
         // Pretend to be GCC.
         next_command(
@@ -2599,6 +2621,7 @@ LLVM version: 6.0",
                         None,
                         creator.clone(),
                         storage.clone(),
+                        preprocessor_cache_storage.clone(),
                         arguments.clone(),
                         cwd.to_path_buf(),
                         vec![],
@@ -2636,6 +2659,7 @@ LLVM version: 6.0",
                         None,
                         creator,
                         storage,
+                        preprocessor_cache_storage,
                         arguments,
                         cwd.to_path_buf(),
                         vec![],
@@ -2667,13 +2691,20 @@ LLVM version: 6.0",
             f.tempdir.path().join("cache"),
             u64::MAX,
             &pool,
-            PreprocessorCacheModeConfig {
-                use_preprocessor_cache_mode: preprocessor_cache_mode,
-                ..Default::default()
-            },
             CacheMode::ReadWrite,
             vec![],
         );
+        let preprocessor_cache_storage = if preprocessor_cache_mode {
+            Arc::new(PreprocessorCache::new(&PreprocessorCacheModeConfig {
+                use_preprocessor_cache_mode: true,
+                ..Default::default()
+            }))
+        } else {
+            Arc::new(PreprocessorCache::new(&PreprocessorCacheModeConfig {
+                use_preprocessor_cache_mode: false,
+                ..Default::default()
+            }))
+        };
         // Write a dummy input file so the preprocessor cache mode can work
         std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
         let storage = Arc::new(storage);
@@ -2712,6 +2743,7 @@ LLVM version: 6.0",
         let service = server::SccacheService::mock_with_dist_client(
             dist_client.clone(),
             storage.clone(),
+            preprocessor_cache_storage.clone(),
             pool.clone(),
         );
 
@@ -2729,6 +2761,7 @@ LLVM version: 6.0",
                         Some(dist_client.clone()),
                         creator.clone(),
                         storage.clone(),
+                        preprocessor_cache_storage.clone(),
                         arguments.clone(),
                         cwd.to_path_buf(),
                         vec![],
@@ -2766,6 +2799,7 @@ LLVM version: 6.0",
                         Some(dist_client.clone()),
                         creator,
                         storage,
+                        preprocessor_cache_storage,
                         arguments,
                         cwd.to_path_buf(),
                         vec![],
@@ -2794,9 +2828,15 @@ LLVM version: 6.0",
         let gcc = f.mk_bin("gcc").unwrap();
         let runtime = Runtime::new().unwrap();
         let pool = runtime.handle().clone();
-        let storage = MockStorage::new(None, preprocessor_cache_mode);
+        let storage = MockStorage::new(None);
         let storage: Arc<MockStorage> = Arc::new(storage);
-        let service = server::SccacheService::mock_with_storage(storage.clone(), pool.clone());
+        let preprocessor_cache_storage =
+            Arc::new(MockPreprocessorCacheStorage::new(preprocessor_cache_mode));
+        let service = server::SccacheService::mock_with_storage(
+            storage.clone(),
+            preprocessor_cache_storage.clone(),
+            pool.clone(),
+        );
 
         // Write a dummy input file so the preprocessor cache mode can work
         std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
@@ -2851,6 +2891,7 @@ LLVM version: 6.0",
                 None,
                 creator,
                 storage,
+                preprocessor_cache_storage,
                 arguments.clone(),
                 cwd.to_path_buf(),
                 vec![],
@@ -2887,9 +2928,15 @@ LLVM version: 6.0",
         std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
         // Make our storage wait 2ms for each get/put operation.
         let storage_delay = Duration::from_millis(2);
-        let storage = MockStorage::new(Some(storage_delay), preprocessor_cache_mode);
+        let storage = MockStorage::new(Some(storage_delay));
         let storage: Arc<MockStorage> = Arc::new(storage);
-        let service = server::SccacheService::mock_with_storage(storage.clone(), pool.clone());
+        let preprocessor_cache_storage =
+            Arc::new(MockPreprocessorCacheStorage::new(preprocessor_cache_mode));
+        let service = server::SccacheService::mock_with_storage(
+            storage.clone(),
+            preprocessor_cache_storage.clone(),
+            pool.clone(),
+        );
         // Pretend to be GCC.
         next_command(
             &creator,
@@ -2943,6 +2990,7 @@ LLVM version: 6.0",
                 None,
                 creator,
                 storage,
+                preprocessor_cache_storage,
                 arguments.clone(),
                 cwd.to_path_buf(),
                 vec![],
@@ -2971,15 +3019,26 @@ LLVM version: 6.0",
             f.tempdir.path().join("cache"),
             u64::MAX,
             &pool,
-            PreprocessorCacheModeConfig {
-                use_preprocessor_cache_mode: preprocessor_cache_mode,
-                ..Default::default()
-            },
             CacheMode::ReadWrite,
             vec![],
         );
         let storage = Arc::new(storage);
-        let service = server::SccacheService::mock_with_storage(storage.clone(), pool.clone());
+        let preprocessor_cache_storage = if preprocessor_cache_mode {
+            Arc::new(PreprocessorCache::new(&PreprocessorCacheModeConfig {
+                use_preprocessor_cache_mode: true,
+                ..Default::default()
+            }))
+        } else {
+            Arc::new(PreprocessorCache::new(&PreprocessorCacheModeConfig {
+                use_preprocessor_cache_mode: false,
+                ..Default::default()
+            }))
+        };
+        let service = server::SccacheService::mock_with_storage(
+            storage.clone(),
+            preprocessor_cache_storage.clone(),
+            pool.clone(),
+        );
         // Write a dummy input file so the preprocessor cache mode can work
         std::fs::write(f.tempdir.path().join("foo.c"), "whatever").unwrap();
         // Pretend to be GCC.
@@ -3037,6 +3096,7 @@ LLVM version: 6.0",
                         None,
                         creator.clone(),
                         storage.clone(),
+                        preprocessor_cache_storage.clone(),
                         arguments.clone(),
                         cwd.to_path_buf(),
                         vec![],
@@ -3066,6 +3126,7 @@ LLVM version: 6.0",
                 None,
                 creator,
                 storage,
+                preprocessor_cache_storage,
                 arguments,
                 cwd.to_path_buf(),
                 vec![],
@@ -3101,15 +3162,26 @@ LLVM version: 6.0",
             f.tempdir.path().join("cache"),
             u64::MAX,
             &pool,
-            PreprocessorCacheModeConfig {
-                use_preprocessor_cache_mode: preprocessor_cache_mode,
-                ..Default::default()
-            },
             CacheMode::ReadWrite,
             vec![],
         );
         let storage = Arc::new(storage);
-        let service = server::SccacheService::mock_with_storage(storage.clone(), pool.clone());
+        let preprocessor_cache_storage = if preprocessor_cache_mode {
+            Arc::new(PreprocessorCache::new(&PreprocessorCacheModeConfig {
+                use_preprocessor_cache_mode: true,
+                ..Default::default()
+            }))
+        } else {
+            Arc::new(PreprocessorCache::new(&PreprocessorCacheModeConfig {
+                use_preprocessor_cache_mode: false,
+                ..Default::default()
+            }))
+        };
+        let service = server::SccacheService::mock_with_storage(
+            storage.clone(),
+            preprocessor_cache_storage.clone(),
+            pool.clone(),
+        );
 
         // Pretend to be GCC.  Also inject a fake object file that the subsequent
         // preprocessor failure should remove.
@@ -3160,6 +3232,7 @@ LLVM version: 6.0",
                         None,
                         creator,
                         storage,
+                        preprocessor_cache_storage,
                         arguments,
                         cwd.to_path_buf(),
                         vec![],
@@ -3200,14 +3273,21 @@ LLVM version: 6.0",
             f.tempdir.path().join("cache"),
             u64::MAX,
             &pool,
-            PreprocessorCacheModeConfig {
-                use_preprocessor_cache_mode: preprocessor_cache_mode,
-                ..Default::default()
-            },
             CacheMode::ReadWrite,
             vec![],
         );
         let storage = Arc::new(storage);
+        let preprocessor_cache_storage = if preprocessor_cache_mode {
+            Arc::new(PreprocessorCache::new(&PreprocessorCacheModeConfig {
+                use_preprocessor_cache_mode: true,
+                ..Default::default()
+            }))
+        } else {
+            Arc::new(PreprocessorCache::new(&PreprocessorCacheModeConfig {
+                use_preprocessor_cache_mode: false,
+                ..Default::default()
+            }))
+        };
         // Pretend to be GCC.
         next_command(
             &creator,
@@ -3260,6 +3340,7 @@ LLVM version: 6.0",
             let service = server::SccacheService::mock_with_dist_client(
                 dist_client.clone(),
                 storage.clone(),
+                preprocessor_cache_storage.clone(),
                 pool.clone(),
             );
 
@@ -3273,6 +3354,7 @@ LLVM version: 6.0",
                     Some(dist_client.clone()),
                     creator.clone(),
                     storage.clone(),
+                    preprocessor_cache_storage.clone(),
                     arguments.clone(),
                     cwd.to_path_buf(),
                     vec![],

--- a/src/compiler/diab.rs
+++ b/src/compiler/diab.rs
@@ -463,6 +463,7 @@ mod test {
     use crate::compiler::*;
     use crate::mock_command::*;
     use crate::server;
+    use crate::test::mock_preprocessor_cache::MockPreprocessorCacheStorage;
     use crate::test::mock_storage::MockStorage;
     use crate::test::utils::*;
     use fs::File;
@@ -792,9 +793,15 @@ mod test {
             too_hard_for_preprocessor_cache_mode: None,
         };
         let runtime = single_threaded_runtime();
-        let storage = MockStorage::new(None, false);
+        let storage = MockStorage::new(None);
         let storage: std::sync::Arc<MockStorage> = std::sync::Arc::new(storage);
-        let service = server::SccacheService::mock_with_storage(storage, runtime.handle().clone());
+        let preprocessor_cache_storage =
+            std::sync::Arc::new(MockPreprocessorCacheStorage::new(false));
+        let service = server::SccacheService::mock_with_storage(
+            storage,
+            preprocessor_cache_storage,
+            runtime.handle().clone(),
+        );
         let compiler = &f.bins[0];
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));

--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -1036,6 +1036,7 @@ mod test {
     use crate::compiler::*;
     use crate::mock_command::*;
     use crate::server;
+    use crate::test::mock_preprocessor_cache::MockPreprocessorCacheStorage;
     use crate::test::mock_storage::MockStorage;
     use crate::test::utils::*;
 
@@ -2274,9 +2275,15 @@ mod test {
             too_hard_for_preprocessor_cache_mode: None,
         };
         let runtime = single_threaded_runtime();
-        let storage = MockStorage::new(None, false);
+        let storage = MockStorage::new(None);
         let storage: std::sync::Arc<MockStorage> = std::sync::Arc::new(storage);
-        let service = server::SccacheService::mock_with_storage(storage, runtime.handle().clone());
+        let preprocessor_cache_storage =
+            std::sync::Arc::new(MockPreprocessorCacheStorage::new(false));
+        let service = server::SccacheService::mock_with_storage(
+            storage,
+            preprocessor_cache_storage,
+            runtime.handle().clone(),
+        );
         let compiler = &f.bins[0];
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));
@@ -2335,9 +2342,15 @@ mod test {
             too_hard_for_preprocessor_cache_mode: None,
         };
         let runtime = single_threaded_runtime();
-        let storage = MockStorage::new(None, false);
+        let storage = MockStorage::new(None);
         let storage: std::sync::Arc<MockStorage> = std::sync::Arc::new(storage);
-        let service = server::SccacheService::mock_with_storage(storage, runtime.handle().clone());
+        let preprocessor_cache_storage =
+            std::sync::Arc::new(MockPreprocessorCacheStorage::new(false));
+        let service = server::SccacheService::mock_with_storage(
+            storage,
+            preprocessor_cache_storage,
+            runtime.handle().clone(),
+        );
         let compiler = &f.bins[0];
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));
@@ -2394,9 +2407,15 @@ mod test {
             too_hard_for_preprocessor_cache_mode: None,
         };
         let runtime = single_threaded_runtime();
-        let storage = MockStorage::new(None, false);
+        let storage = MockStorage::new(None);
         let storage: std::sync::Arc<MockStorage> = std::sync::Arc::new(storage);
-        let service = server::SccacheService::mock_with_storage(storage, runtime.handle().clone());
+        let preprocessor_cache_storage =
+            std::sync::Arc::new(MockPreprocessorCacheStorage::new(false));
+        let service = server::SccacheService::mock_with_storage(
+            storage,
+            preprocessor_cache_storage,
+            runtime.handle().clone(),
+        );
         let compiler = &f.bins[0];
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -1393,6 +1393,7 @@ mod test {
     use crate::compiler::*;
     use crate::mock_command::*;
     use crate::server;
+    use crate::test::mock_preprocessor_cache::MockPreprocessorCacheStorage;
     use crate::test::mock_storage::MockStorage;
     use crate::test::utils::*;
 
@@ -2553,9 +2554,15 @@ mod test {
             too_hard_for_preprocessor_cache_mode: None,
         };
         let runtime = single_threaded_runtime();
-        let storage = MockStorage::new(None, false);
+        let storage = MockStorage::new(None);
         let storage: std::sync::Arc<MockStorage> = std::sync::Arc::new(storage);
-        let service = server::SccacheService::mock_with_storage(storage, runtime.handle().clone());
+        let preprocessor_cache_storage =
+            std::sync::Arc::new(MockPreprocessorCacheStorage::new(false));
+        let service = server::SccacheService::mock_with_storage(
+            storage,
+            preprocessor_cache_storage,
+            runtime.handle().clone(),
+        );
         let compiler = &f.bins[0];
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));
@@ -2643,9 +2650,15 @@ mod test {
             too_hard_for_preprocessor_cache_mode: None,
         };
         let runtime = single_threaded_runtime();
-        let storage = MockStorage::new(None, false);
+        let storage = MockStorage::new(None);
         let storage: std::sync::Arc<MockStorage> = std::sync::Arc::new(storage);
-        let service = server::SccacheService::mock_with_storage(storage, runtime.handle().clone());
+        let preprocessor_cache_storage =
+            std::sync::Arc::new(MockPreprocessorCacheStorage::new(false));
+        let service = server::SccacheService::mock_with_storage(
+            storage,
+            preprocessor_cache_storage,
+            runtime.handle().clone(),
+        );
         let compiler = &f.bins[0];
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));

--- a/src/compiler/preprocessor_cache.rs
+++ b/src/compiler/preprocessor_cache.rs
@@ -176,7 +176,7 @@ impl PreprocessorCacheEntry {
     /// are already on disk and have not changed.
     pub fn lookup_result_digest(
         &mut self,
-        config: PreprocessorCacheModeConfig,
+        config: &PreprocessorCacheModeConfig,
         updated: &mut bool,
     ) -> Option<String> {
         // Check newest result first since it's more likely to match.
@@ -193,7 +193,7 @@ impl PreprocessorCacheEntry {
     fn result_matches(
         digest: &str,
         includes: &mut [IncludeEntry],
-        config: PreprocessorCacheModeConfig,
+        config: &PreprocessorCacheModeConfig,
         updated: &mut bool,
     ) -> bool {
         for include in includes {
@@ -380,7 +380,7 @@ pub fn preprocessor_cache_entry_hash_key(
     env_vars: &[(OsString, OsString)],
     input_file: &Path,
     plusplus: bool,
-    config: PreprocessorCacheModeConfig,
+    config: &PreprocessorCacheModeConfig,
     basedirs: &[Vec<u8>],
 ) -> anyhow::Result<Option<String>> {
     // If you change any of the inputs to the hash, you should change `FORMAT_VERSION`.
@@ -679,7 +679,7 @@ mod test {
             &[],
             &file1_path,
             false,
-            config,
+            &config,
             &dirs,
         )
         .unwrap()
@@ -693,7 +693,7 @@ mod test {
             &[],
             &file2_path,
             false,
-            config,
+            &config,
             &dirs,
         )
         .unwrap()
@@ -713,7 +713,7 @@ mod test {
             &[],
             &file1_path,
             false,
-            config,
+            &config,
             &dirs[..1],
         )
         .unwrap()
@@ -727,7 +727,7 @@ mod test {
             &[],
             &file2_path,
             false,
-            config,
+            &config,
             &dirs[1..],
         )
         .unwrap()
@@ -747,7 +747,7 @@ mod test {
             &[],
             &file1_path,
             false,
-            config,
+            &config,
             &[],
         )
         .unwrap()
@@ -761,7 +761,7 @@ mod test {
             &[],
             &file2_path,
             false,
-            config,
+            &config,
             &[],
         )
         .unwrap()

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::cache::{FileObjectSource, Storage};
+use crate::cache::{FileObjectSource, PreprocessorCacheStorage, Storage};
 use crate::compiler::args::*;
 use crate::compiler::{
     CCompileCommand, Cacheable, ColorMode, Compilation, CompileCommand, Compiler,
@@ -1334,6 +1334,7 @@ where
         pool: &tokio::runtime::Handle,
         _rewrite_includes_only: bool,
         _storage: Arc<dyn Storage>,
+        _preprocessor_cache_storage: Arc<dyn PreprocessorCacheStorage>,
         _cache_control: CacheControl,
     ) -> Result<HashResult<T>> {
         trace!("[{}]: generate_hash_key", self.parsed_args.crate_name);
@@ -2658,6 +2659,7 @@ mod test {
 
     use crate::compiler::*;
     use crate::mock_command::*;
+    use crate::test::mock_preprocessor_cache::MockPreprocessorCacheStorage;
     use crate::test::mock_storage::MockStorage;
     use crate::test::utils::*;
     use fs::File;
@@ -3511,7 +3513,8 @@ proc_macro false
                 false,
                 &pool,
                 false,
-                Arc::new(MockStorage::new(None, preprocessor_cache_mode)),
+                Arc::new(MockStorage::new(None)),
+                Arc::new(MockPreprocessorCacheStorage::new(preprocessor_cache_mode)),
                 CacheControl::Default,
             )
             .wait()
@@ -3603,7 +3606,8 @@ proc_macro false
                 false,
                 &pool,
                 false,
-                Arc::new(MockStorage::new(None, preprocessor_cache_mode)),
+                Arc::new(MockStorage::new(None)),
+                Arc::new(MockPreprocessorCacheStorage::new(preprocessor_cache_mode)),
                 CacheControl::Default,
             )
             .wait()

--- a/src/compiler/tasking_vx.rs
+++ b/src/compiler/tasking_vx.rs
@@ -406,6 +406,7 @@ mod test {
     use crate::compiler::*;
     use crate::mock_command::*;
     use crate::server;
+    use crate::test::mock_preprocessor_cache::MockPreprocessorCacheStorage;
     use crate::test::mock_storage::MockStorage;
     use crate::test::utils::*;
 
@@ -730,9 +731,15 @@ mod test {
             too_hard_for_preprocessor_cache_mode: None,
         };
         let runtime = single_threaded_runtime();
-        let storage = MockStorage::new(None, false);
+        let storage = MockStorage::new(None);
         let storage: std::sync::Arc<MockStorage> = std::sync::Arc::new(storage);
-        let service = server::SccacheService::mock_with_storage(storage, runtime.handle().clone());
+        let preprocessor_cache_storage =
+            std::sync::Arc::new(MockPreprocessorCacheStorage::new(false));
+        let service = server::SccacheService::mock_with_storage(
+            storage,
+            preprocessor_cache_storage,
+            runtime.handle().clone(),
+        );
         let compiler = &f.bins[0];
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));
@@ -784,9 +791,15 @@ mod test {
             too_hard_for_preprocessor_cache_mode: None,
         };
         let runtime = single_threaded_runtime();
-        let storage = MockStorage::new(None, false);
+        let storage = MockStorage::new(None);
         let storage: std::sync::Arc<MockStorage> = std::sync::Arc::new(storage);
-        let service = server::SccacheService::mock_with_storage(storage, runtime.handle().clone());
+        let preprocessor_cache_storage =
+            std::sync::Arc::new(MockPreprocessorCacheStorage::new(false));
+        let service = server::SccacheService::mock_with_storage(
+            storage,
+            preprocessor_cache_storage,
+            runtime.handle().clone(),
+        );
         let compiler = &f.bins[0];
         // Compiler invocation.
         next_command(&creator, Ok(MockChild::new(exit_status(0), "", "")));

--- a/src/config.rs
+++ b/src/config.rs
@@ -1005,14 +1005,11 @@ fn config_from_env() -> Result<EnvConfig> {
     };
 
     // ======= Preprocessor cache =======
-    let preprocessor_mode_config = if let Some(value) = bool_from_env_var("SCCACHE_DIRECT")? {
-        Some(PreprocessorCacheModeConfig {
+    let preprocessor_mode_config =
+        bool_from_env_var("SCCACHE_DIRECT")?.map(|value| PreprocessorCacheModeConfig {
             use_preprocessor_cache_mode: value,
             ..Default::default()
-        })
-    } else {
-        None
-    };
+        });
 
     // ======= Local =======
     let disk_dir = env::var_os("SCCACHE_DIR").map(PathBuf::from);

--- a/src/config.rs
+++ b/src/config.rs
@@ -189,7 +189,7 @@ pub struct AzureCacheConfig {
 }
 
 /// Configuration switches for preprocessor cache mode.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(default)]
 pub struct PreprocessorCacheModeConfig {
@@ -214,6 +214,15 @@ pub struct PreprocessorCacheModeConfig {
     /// If true (default), will add the current working directory in the hash to
     /// distinguish two compilations from different directories.
     pub hash_working_directory: bool,
+    /// Maximum space of the cache
+    #[serde(deserialize_with = "deserialize_size_from_str")]
+    pub max_size: u64,
+    /// Readonly mode for preprocessor cache
+    pub rw_mode: CacheModeConfig,
+    /// Cache directory
+    /// NOTE The dir is an optional value, as if it is not configured the disk cache directory
+    /// will be used.
+    pub dir: Option<PathBuf>,
 }
 
 impl Default for PreprocessorCacheModeConfig {
@@ -225,6 +234,9 @@ impl Default for PreprocessorCacheModeConfig {
             ignore_time_macros: false,
             skip_system_headers: false,
             hash_working_directory: true,
+            max_size: default_disk_cache_size(),
+            rw_mode: CacheModeConfig::ReadWrite,
+            dir: None,
         }
     }
 }
@@ -246,7 +258,6 @@ pub struct DiskCacheConfig {
     pub dir: PathBuf,
     #[serde(deserialize_with = "deserialize_size_from_str")]
     pub size: u64,
-    pub preprocessor_cache_mode: PreprocessorCacheModeConfig,
     pub rw_mode: CacheModeConfig,
 }
 
@@ -255,7 +266,6 @@ impl Default for DiskCacheConfig {
         DiskCacheConfig {
             dir: default_disk_cache_dir(),
             size: default_disk_cache_size(),
-            preprocessor_cache_mode: PreprocessorCacheModeConfig::activated(),
             rw_mode: CacheModeConfig::ReadWrite,
         }
     }
@@ -448,13 +458,19 @@ pub struct CacheConfigs {
     pub s3: Option<S3CacheConfig>,
     pub webdav: Option<WebdavCacheConfig>,
     pub oss: Option<OSSCacheConfig>,
+    pub preprocessor: Option<PreprocessorCacheModeConfig>,
     pub cos: Option<COSCacheConfig>,
 }
 
 impl CacheConfigs {
-    /// Return cache type in an arbitrary but
-    /// consistent ordering
-    fn into_fallback(self) -> (Option<CacheType>, DiskCacheConfig) {
+    /// Return cache type in an arbitrary but consistent ordering
+    fn into_fallback(
+        self,
+    ) -> (
+        Option<CacheType>,
+        DiskCacheConfig,
+        PreprocessorCacheModeConfig,
+    ) {
         let CacheConfigs {
             azure,
             disk,
@@ -465,6 +481,7 @@ impl CacheConfigs {
             s3,
             webdav,
             oss,
+            preprocessor,
             cos,
         } = self;
 
@@ -480,8 +497,13 @@ impl CacheConfigs {
             .or_else(|| cos.map(CacheType::COS));
 
         let fallback = disk.unwrap_or_default();
+        let mut preprocessor_config = preprocessor.unwrap_or_default();
 
-        (cache_type, fallback)
+        if preprocessor_config.dir.is_none() {
+            preprocessor_config.dir = Some(fallback.dir.join("preprocessor"));
+        }
+
+        (cache_type, fallback, preprocessor_config)
     }
 
     /// Override self with any existing fields from other
@@ -496,6 +518,7 @@ impl CacheConfigs {
             s3,
             webdav,
             oss,
+            preprocessor,
             cos,
         } = other;
 
@@ -528,6 +551,9 @@ impl CacheConfigs {
         }
         if cos.is_some() {
             self.cos = cos;
+        }
+        if preprocessor.is_some() {
+            self.preprocessor = preprocessor;
         }
     }
 }
@@ -978,19 +1004,21 @@ fn config_from_env() -> Result<EnvConfig> {
         None
     };
 
+    // ======= Preprocessor cache =======
+    let preprocessor_mode_config = if let Some(value) = bool_from_env_var("SCCACHE_DIRECT")? {
+        Some(PreprocessorCacheModeConfig {
+            use_preprocessor_cache_mode: value,
+            ..Default::default()
+        })
+    } else {
+        None
+    };
+
     // ======= Local =======
     let disk_dir = env::var_os("SCCACHE_DIR").map(PathBuf::from);
     let disk_sz = env::var("SCCACHE_CACHE_SIZE")
         .ok()
         .and_then(|v| parse_size(&v));
-
-    let mut preprocessor_mode_config = PreprocessorCacheModeConfig::activated();
-    let preprocessor_mode_overridden = if let Some(value) = bool_from_env_var("SCCACHE_DIRECT")? {
-        preprocessor_mode_config.use_preprocessor_cache_mode = value;
-        true
-    } else {
-        false
-    };
 
     let (disk_rw_mode, disk_rw_mode_overridden) = match env::var("SCCACHE_LOCAL_RW_MODE")
         .as_ref()
@@ -1005,15 +1033,11 @@ fn config_from_env() -> Result<EnvConfig> {
         _ => (CacheModeConfig::ReadWrite, false),
     };
 
-    let any_overridden = disk_dir.is_some()
-        || disk_sz.is_some()
-        || preprocessor_mode_overridden
-        || disk_rw_mode_overridden;
+    let any_overridden = disk_dir.is_some() || disk_sz.is_some() || disk_rw_mode_overridden;
     let disk = if any_overridden {
         Some(DiskCacheConfig {
             dir: disk_dir.unwrap_or_else(default_disk_cache_dir),
             size: disk_sz.unwrap_or_else(default_disk_cache_size),
-            preprocessor_cache_mode: preprocessor_mode_config,
             rw_mode: disk_rw_mode,
         })
     } else {
@@ -1030,6 +1054,7 @@ fn config_from_env() -> Result<EnvConfig> {
         s3,
         webdav,
         oss,
+        preprocessor: preprocessor_mode_config,
         cos,
     };
 
@@ -1077,6 +1102,7 @@ fn config_file(env_var: &str, leaf: &str) -> PathBuf {
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Config {
     pub cache: Option<CacheType>,
+    pub preprocessor_cache: PreprocessorCacheModeConfig,
     pub fallback_cache: DiskCacheConfig,
     pub dist: DistConfig,
     pub server_startup_timeout: Option<std::time::Duration>,
@@ -1167,9 +1193,10 @@ impl Config {
             debug!("Using basedirs for path normalization: {:?}", basedirs_str);
         }
 
-        let (caches, fallback_cache) = conf_caches.into_fallback();
+        let (caches, fallback_cache, preprocessor_cache) = conf_caches.into_fallback();
         Ok(Self {
             cache: caches,
+            preprocessor_cache,
             fallback_cache,
             dist,
             server_startup_timeout,
@@ -1433,7 +1460,6 @@ fn config_overrides() {
             disk: Some(DiskCacheConfig {
                 dir: "/env-cache".into(),
                 size: 5,
-                preprocessor_cache_mode: Default::default(),
                 rw_mode: CacheModeConfig::ReadWrite,
             }),
             redis: Some(RedisCacheConfig {
@@ -1455,7 +1481,6 @@ fn config_overrides() {
             disk: Some(DiskCacheConfig {
                 dir: "/file-cache".into(),
                 size: 15,
-                preprocessor_cache_mode: Default::default(),
                 rw_mode: CacheModeConfig::ReadWrite,
             }),
             memcached: Some(MemcachedCacheConfig {
@@ -1489,10 +1514,13 @@ fn config_overrides() {
                 password: Some("secret".to_owned()),
                 ..Default::default()
             })),
+            preprocessor_cache: PreprocessorCacheModeConfig {
+                dir: Some("/env-cache/preprocessor".into()),
+                ..Default::default()
+            },
             fallback_cache: DiskCacheConfig {
                 dir: "/env-cache".into(),
                 size: 5,
-                preprocessor_cache_mode: Default::default(),
                 rw_mode: CacheModeConfig::ReadWrite,
             },
             dist: Default::default(),
@@ -2070,6 +2098,17 @@ token = "secrettoken"
 dir = "/tmp/.cache/sccache"
 size = 7516192768 # 7 GiBytes
 
+[cache.preprocessor]
+use_preprocessor_cache_mode = true
+file_stat_matches = true
+use_ctime_for_stat = true
+ignore_time_macros = false
+skip_system_headers = true
+hash_working_directory = true
+max_size = 1028576 # 1 MiBytes
+rw_mode = "READ_WRITE"
+dir = "/tmp/.cache/sccache-preprocessor"
+
 [cache.gcs]
 rw_mode = "READ_ONLY"
 # rw_mode = "READ_WRITE"
@@ -2139,7 +2178,6 @@ key_prefix = "cosprefix"
                 disk: Some(DiskCacheConfig {
                     dir: PathBuf::from("/tmp/.cache/sccache"),
                     size: 7 * 1024 * 1024 * 1024,
-                    preprocessor_cache_mode: PreprocessorCacheModeConfig::activated(),
                     rw_mode: CacheModeConfig::ReadWrite,
                 }),
                 gcs: Some(GCSCacheConfig {
@@ -2198,6 +2236,17 @@ key_prefix = "cosprefix"
                     bucket: "name".to_owned(),
                     endpoint: Some("cos.na-siliconvalley.myqcloud.com".to_owned()),
                     key_prefix: "cosprefix".into(),
+                }),
+                preprocessor: Some(PreprocessorCacheModeConfig {
+                    use_preprocessor_cache_mode: true,
+                    file_stat_matches: true,
+                    use_ctime_for_stat: true,
+                    ignore_time_macros: false,
+                    skip_system_headers: true,
+                    hash_working_directory: true,
+                    max_size: 1028576,
+                    rw_mode: CacheModeConfig::ReadWrite,
+                    dir: Some("/tmp/.cache/sccache-preprocessor".into()),
                 }),
             },
             dist: DistConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,7 +229,7 @@ impl Default for PreprocessorCacheModeConfig {
     fn default() -> Self {
         Self {
             use_preprocessor_cache_mode: false,
-            file_stat_matches: false,
+            file_stat_matches: true,
             use_ctime_for_stat: true,
             ignore_time_macros: false,
             skip_system_headers: false,

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,7 +13,7 @@
 // limitations under the License.SCCACHE_MAX_FRAME_LENGTH
 
 use crate::cache::readonly::ReadOnlyStorage;
-use crate::cache::{CacheMode, Storage, storage_from_config};
+use crate::cache::{CacheMode, PreprocessorCacheStorage, Storage, get_storage_from_config};
 use crate::compiler::{
     CacheControl, CompileResult, Compiler, CompilerArguments, CompilerHasher, CompilerKind,
     CompilerProxy, DistType, Language, MissType, get_compiler_info,
@@ -449,7 +449,8 @@ pub fn start_server(config: &Config, addr: &crate::net::SocketAddr) -> Result<()
 
     let notify = env::var_os("SCCACHE_STARTUP_NOTIFY");
 
-    let raw_storage = match storage_from_config(config, &pool) {
+    let (raw_storage, raw_preprocessor_cache_storage) = match get_storage_from_config(config, &pool)
+    {
         Ok(storage) => storage,
         Err(err) => {
             error!("storage init failed for: {err:?}");
@@ -494,8 +495,14 @@ pub fn start_server(config: &Config, addr: &crate::net::SocketAddr) -> Result<()
             crate::net::SocketAddr::Net(addr) => {
                 trace!("binding TCP {addr}");
                 let l = runtime.block_on(tokio::net::TcpListener::bind(addr))?;
-                let srv =
-                    SccacheServer::<_>::with_listener(l, runtime, client, dist_client, storage);
+                let srv = SccacheServer::<_>::with_listener(
+                    l,
+                    runtime,
+                    client,
+                    dist_client,
+                    storage,
+                    raw_preprocessor_cache_storage,
+                );
                 Ok((
                     srv.local_addr().unwrap(),
                     Box::new(move |f| srv.run(f)) as Box<dyn FnOnce(_) -> _>,
@@ -510,8 +517,14 @@ pub fn start_server(config: &Config, addr: &crate::net::SocketAddr) -> Result<()
                     let _guard = runtime.enter();
                     tokio::net::UnixListener::bind(path)?
                 };
-                let srv =
-                    SccacheServer::<_>::with_listener(l, runtime, client, dist_client, storage);
+                let srv = SccacheServer::<_>::with_listener(
+                    l,
+                    runtime,
+                    client,
+                    dist_client,
+                    storage,
+                    raw_preprocessor_cache_storage,
+                );
                 Ok((
                     srv.local_addr().unwrap(),
                     Box::new(move |f| srv.run(f)) as Box<dyn FnOnce(_) -> _>,
@@ -584,6 +597,7 @@ impl<C: CommandCreatorSync> SccacheServer<tokio::net::TcpListener, C> {
         client: Client,
         dist_client: DistClientContainer,
         storage: Arc<dyn Storage>,
+        preprocessor_cache_storage: Arc<dyn PreprocessorCacheStorage>,
     ) -> Result<Self> {
         let addr = crate::net::SocketAddr::with_port(port);
         let listener = runtime.block_on(tokio::net::TcpListener::bind(addr.as_net().unwrap()))?;
@@ -594,6 +608,7 @@ impl<C: CommandCreatorSync> SccacheServer<tokio::net::TcpListener, C> {
             client,
             dist_client,
             storage,
+            preprocessor_cache_storage,
         ))
     }
 }
@@ -605,13 +620,22 @@ impl<A: crate::net::Acceptor, C: CommandCreatorSync> SccacheServer<A, C> {
         client: Client,
         dist_client: DistClientContainer,
         storage: Arc<dyn Storage>,
+        preprocessor_cache_storage: Arc<dyn PreprocessorCacheStorage>,
     ) -> Self {
         // Prepare the service which we'll use to service all incoming TCP
         // connections.
         let (tx, rx) = mpsc::channel(1);
         let (wait, info) = WaitUntilZero::new();
         let pool = runtime.handle().clone();
-        let service = SccacheService::new(dist_client, storage, &client, pool, tx, info);
+        let service = SccacheService::new(
+            dist_client,
+            storage,
+            preprocessor_cache_storage,
+            &client,
+            pool,
+            tx,
+            info,
+        );
 
         SccacheServer {
             runtime,
@@ -631,8 +655,13 @@ impl<A: crate::net::Acceptor, C: CommandCreatorSync> SccacheServer<A, C> {
 
     /// Set the storage this server will use.
     #[allow(dead_code)]
-    pub fn set_storage(&mut self, storage: Arc<dyn Storage>) {
+    pub fn set_storage(
+        &mut self,
+        storage: Arc<dyn Storage>,
+        preprocessor_cache_storage: Arc<dyn PreprocessorCacheStorage>,
+    ) {
         self.service.storage = storage;
+        self.service.preprocessor_cache_storage = preprocessor_cache_storage;
     }
 
     /// Returns a reference to a thread pool to run work on
@@ -792,6 +821,9 @@ where
     /// Cache storage.
     storage: Arc<dyn Storage>,
 
+    /// Preprocessor cache storage.
+    preprocessor_cache_storage: Arc<dyn PreprocessorCacheStorage>,
+
     /// A cache of known compiler info.
     compilers: Arc<RwLock<CompilerMap<C>>>,
 
@@ -917,6 +949,7 @@ where
     pub fn new(
         dist_client: DistClientContainer,
         storage: Arc<dyn Storage>,
+        preprocessor_cache_storage: Arc<dyn PreprocessorCacheStorage>,
         client: &Client,
         rt: tokio::runtime::Handle,
         tx: mpsc::Sender<ServerMessage>,
@@ -926,6 +959,7 @@ where
             stats: Arc::default(),
             dist_client: Arc::new(dist_client),
             storage,
+            preprocessor_cache_storage,
             compilers: Arc::default(),
             compiler_proxies: Arc::default(),
             rt,
@@ -937,6 +971,7 @@ where
 
     pub fn mock_with_storage(
         storage: Arc<dyn Storage>,
+        preprocessor_cache_storage: Arc<dyn PreprocessorCacheStorage>,
         rt: tokio::runtime::Handle,
     ) -> SccacheService<C> {
         let (tx, _) = mpsc::channel(1);
@@ -947,6 +982,7 @@ where
             stats: Arc::default(),
             dist_client: Arc::new(dist_client),
             storage,
+            preprocessor_cache_storage,
             compilers: Arc::default(),
             compiler_proxies: Arc::default(),
             rt,
@@ -960,6 +996,7 @@ where
     pub fn mock_with_dist_client(
         dist_client: Arc<dyn dist::Client>,
         storage: Arc<dyn Storage>,
+        preprocessor_cache_storage: Arc<dyn PreprocessorCacheStorage>,
         rt: tokio::runtime::Handle,
     ) -> SccacheService<C> {
         let (tx, _) = mpsc::channel(1);
@@ -980,6 +1017,7 @@ where
                 dist_client,
             ))),
             storage,
+            preprocessor_cache_storage,
             compilers: Arc::default(),
             compiler_proxies: Arc::default(),
             rt: rt.clone(),
@@ -1043,7 +1081,12 @@ where
     /// Get info and stats about the cache.
     async fn get_info(&self) -> Result<ServerInfo> {
         let stats = self.stats.lock().await.clone();
-        ServerInfo::new(stats, Some(&*self.storage)).await
+        ServerInfo::new(
+            stats,
+            Some(&*self.storage),
+            Some(&*self.preprocessor_cache_storage),
+        )
+        .await
     }
 
     /// Zero stats about the cache.
@@ -1339,6 +1382,7 @@ where
                         client,
                         me.creator.clone(),
                         me.storage.clone(),
+                        me.preprocessor_cache_storage.clone(),
                         arguments,
                         cwd,
                         env_vars,
@@ -1928,17 +1972,17 @@ fn set_percentage_stat(
 }
 
 impl ServerInfo {
-    pub async fn new(stats: ServerStats, storage: Option<&dyn Storage>) -> Result<Self> {
+    pub async fn new(
+        stats: ServerStats,
+        storage: Option<&dyn Storage>,
+        preprocessor_cache_storage: Option<&dyn PreprocessorCacheStorage>,
+    ) -> Result<Self> {
         let cache_location;
-        let use_preprocessor_cache_mode;
         let cache_size;
         let max_cache_size;
         let basedirs;
         if let Some(storage) = storage {
             cache_location = storage.location();
-            use_preprocessor_cache_mode = storage
-                .preprocessor_cache_mode_config()
-                .use_preprocessor_cache_mode;
             (cache_size, max_cache_size) =
                 futures::try_join!(storage.current_size(), storage.max_size())?;
             basedirs = storage
@@ -1948,11 +1992,18 @@ impl ServerInfo {
                 .collect();
         } else {
             cache_location = String::new();
-            use_preprocessor_cache_mode = false;
             cache_size = None;
             max_cache_size = None;
             basedirs = Vec::new();
         }
+
+        let mut use_preprocessor_cache_mode = false;
+        if let Some(preprocessor_storage) = preprocessor_cache_storage {
+            let config = preprocessor_storage.get_config();
+
+            use_preprocessor_cache_mode = config.use_preprocessor_cache_mode;
+        }
+
         let version = env!("CARGO_PKG_VERSION").to_string();
         Ok(ServerInfo {
             stats,

--- a/src/server.rs
+++ b/src/server.rs
@@ -540,8 +540,14 @@ pub fn start_server(config: &Config, addr: &crate::net::SocketAddr) -> Result<()
                     let _guard = runtime.enter();
                     tokio::net::UnixListener::from_std(l)?
                 };
-                let srv =
-                    SccacheServer::<_>::with_listener(l, runtime, client, dist_client, storage);
+                let srv = SccacheServer::<_>::with_listener(
+                    l,
+                    runtime,
+                    client,
+                    dist_client,
+                    storage,
+                    raw_preprocessor_cache_storage,
+                );
                 Ok((
                     srv.local_addr()
                         .unwrap_or_else(|| crate::net::SocketAddr::UnixAbstract(p.clone())),

--- a/src/test/mock_preprocessor_cache.rs
+++ b/src/test/mock_preprocessor_cache.rs
@@ -1,0 +1,42 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+
+use crate::cache::preprocessor_cache::PreprocessorCacheStorage;
+use crate::config::PreprocessorCacheModeConfig;
+
+/// A mock `PreprocessorCacheStorage` implementation.
+pub struct MockPreprocessorCacheStorage {
+    config: PreprocessorCacheModeConfig,
+}
+
+impl MockPreprocessorCacheStorage {
+    /// Create a new `MockPreprocessorCacheStorage`.
+    pub(crate) fn new(use_preprocessor_cache_mode: bool) -> MockPreprocessorCacheStorage {
+        Self {
+            config: PreprocessorCacheModeConfig {
+                use_preprocessor_cache_mode,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl PreprocessorCacheStorage for MockPreprocessorCacheStorage {
+    fn get_config(&self) -> &PreprocessorCacheModeConfig {
+        &self.config
+    }
+
+    // TODO Implement get_preprocessor_cache_entry and put_preprocessor_cache_entry
+}

--- a/src/test/mock_storage.rs
+++ b/src/test/mock_storage.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::cache::{Cache, CacheWrite, Storage};
-use crate::config::PreprocessorCacheModeConfig;
 use crate::errors::*;
 use async_trait::async_trait;
 use futures::channel::mpsc;
@@ -27,18 +26,16 @@ pub struct MockStorage {
     rx: Arc<Mutex<mpsc::UnboundedReceiver<Result<Cache>>>>,
     tx: mpsc::UnboundedSender<Result<Cache>>,
     delay: Option<Duration>,
-    preprocessor_cache_mode: bool,
 }
 
 impl MockStorage {
     /// Create a new `MockStorage`. if `delay` is `Some`, wait for that amount of time before returning from operations.
-    pub(crate) fn new(delay: Option<Duration>, preprocessor_cache_mode: bool) -> MockStorage {
+    pub(crate) fn new(delay: Option<Duration>) -> MockStorage {
         let (tx, rx) = mpsc::unbounded();
         Self {
             tx,
             rx: Arc::new(Mutex::new(rx)),
             delay,
-            preprocessor_cache_mode,
         }
     }
 
@@ -66,19 +63,20 @@ impl Storage for MockStorage {
             Duration::from_secs(0)
         })
     }
+
     fn location(&self) -> String {
         "Mock Storage".to_string()
     }
+
     async fn current_size(&self) -> Result<Option<u64>> {
         Ok(None)
     }
+
     async fn max_size(&self) -> Result<Option<u64>> {
         Ok(None)
     }
-    fn preprocessor_cache_mode_config(&self) -> PreprocessorCacheModeConfig {
-        PreprocessorCacheModeConfig {
-            use_preprocessor_cache_mode: self.preprocessor_cache_mode,
-            ..Default::default()
-        }
+
+    fn cache_type_name(&self) -> &'static str {
+        "mock"
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod mock_preprocessor_cache;
 pub mod mock_storage;
 #[macro_use]
 pub mod utils;

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -84,13 +84,29 @@ where
             &cache_dir,
             cache_size,
             runtime.handle(),
-            PreprocessorCacheModeConfig::default(),
             CacheMode::ReadWrite,
             vec![],
         ));
+        let preprocessor_cache_storage =
+            Arc::new(crate::cache::preprocessor_cache::PreprocessorCache::new(
+                &PreprocessorCacheModeConfig {
+                    dir: Some(cache_dir.join("preprocessor_cache")),
+                    max_size: cache_size / 10,
+                    use_preprocessor_cache_mode: true,
+                    ..Default::default()
+                },
+            ));
 
         let client = Client::new();
-        let srv = SccacheServer::new(0, runtime, client, dist_client, storage).unwrap();
+        let srv = SccacheServer::new(
+            0,
+            runtime,
+            client,
+            dist_client,
+            storage,
+            preprocessor_cache_storage,
+        )
+        .unwrap();
         let mut srv: SccacheServer<_, Arc<Mutex<MockCommandCreator>>> = srv;
         let addr = srv.local_addr().unwrap();
         assert!(matches!(addr, crate::net::SocketAddr::Net(a) if a.port() > 0));

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -364,10 +364,9 @@ fn test_dist_preprocesspr_cache_bug_2173() {
 
     let mut sccache_cfg = dist_test_sccache_client_cfg(tmpdir, system.scheduler_url());
     let disk_cache = sccache_cfg.cache.disk.as_mut().unwrap();
-    disk_cache
-        .preprocessor_cache_mode
-        .use_preprocessor_cache_mode = true;
     disk_cache.size = 10_000_000; // enough for one tiny object file
+    let preprocessor_cache = sccache_cfg.cache.preprocessor.as_mut().unwrap();
+    preprocessor_cache.use_preprocessor_cache_mode = true;
     let sccache_cfg_path = tmpdir.join("sccache-cfg.json");
     write_json_cfg(tmpdir, "sccache-cfg.json", &sccache_cfg);
     let sccache_cached_cfg_path = tmpdir.join("sccache-cached-cfg");

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -163,10 +163,10 @@ pub fn sccache_client_cfg(
 
     let disk_cache = sccache::config::DiskCacheConfig {
         dir: tmpdir.join(cache_relpath),
-        preprocessor_cache_mode: sccache::config::PreprocessorCacheModeConfig {
-            use_preprocessor_cache_mode: preprocessor_cache_mode,
-            ..Default::default()
-        },
+        ..Default::default()
+    };
+    let preprocessor_cache_config = sccache::config::PreprocessorCacheModeConfig {
+        use_preprocessor_cache_mode: preprocessor_cache_mode,
         ..Default::default()
     };
     sccache::config::FileConfig {
@@ -180,6 +180,7 @@ pub fn sccache_client_cfg(
             s3: None,
             webdav: None,
             oss: None,
+            preprocessor: Some(preprocessor_cache_config),
             cos: None,
         },
         dist: sccache::config::DistConfig {


### PR DESCRIPTION
This is a series of PRs that

 * Extracts PreprocessorCache from DiskCache.
 * Cleanup some existing code

This is the Part 4. The previous part is https://github.com/mozilla/sccache/pull/2604.

See https://github.com/mozilla/sccache/pull/2571 and https://github.com/mozilla/sccache/issues/2481 for more details.