### PR TITLE
fix: add Win32_Security feature to windows-sys dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ features = [
   "Win32_Storage_FileSystem",
   "Win32_System_Threading",
   "Win32_System_Console",
+  "Win32_Security",
 ]
 version = "0.52"
 


### PR DESCRIPTION
CreateProcessW requires the Win32_Security feature because its signature includes SECURITY_ATTRIBUTES. Without this feature, `cargo install sccache` fails on Windows with:

  error[E0432]: unresolved import `windows_sys::Win32::System::Threading::CreateProcessW`

Fixes #2484
Fixes #2508