### PR TITLE
fix: create output directory before writing cached objects

### DIFF
--- a/src/cache/cache_io.rs
+++ b/src/cache/cache_io.rs
@@ -150,6 +150,7 @@ impl CacheRead {
                 // Write the cache entry to a tempfile and then atomically
                 // move it to its final location so that other rustc invocations
                 // happening in parallel don't see a partially-written file.
+                fs::create_dir_all(dir)?;
                 let mut tmp = NamedTempFile::new_in(dir)?;
                 match (self.get_object(&key, &mut tmp), optional) {
                     (Ok(mode), _) => {


### PR DESCRIPTION
`extract_objects` calls `NamedTempFile::new_in(dir)` without ensuring the output directory exists first. This causes a fatal error during parallel compilation in large workspaces:

```
sccache: encountered fatal error
sccache: error: No such file or directory (os error 2) at path ".../target/debug/deps/.tmpUCVapr"
```

Adds `fs::create_dir_all(dir)` before the temp file creation. No-op if the dir already exists.