### PR TITLE
fix: exclude `CARGO_ENCODED_RUSTFLAGS` from env var hash

### DIFF
--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1523,9 +1523,11 @@ where
             // Registry override config doesn't need to be hashed, because deps' package IDs
             // already uniquely identify the relevant registries.
             // CARGO_BUILD_JOBS only affects Cargo's parallelism, not rustc output.
+            // CARGO_ENCODED_RUSTFLAGS is already cached in argument list
             if var == "CARGO_MAKEFLAGS"
                 || var.starts_with("CARGO_REGISTRIES_")
                 || var == "CARGO_BUILD_JOBS"
+                || var == "CARGO_ENCODED_RUSTFLAGS"
             {
                 continue;
             }


### PR DESCRIPTION
For normal crate compilations, cargo consumes `CARGO_ENCODED_RUSTFLAGS` and passes the flags as command-line arguments to rustc. They are already hashed as part of the argument list (step 3), so hashing the env var is redundant.

For build-script probe compilations (like proc-macro2's autocfg probes), the build script inherits the env var but does NOT pass those flags to its probe rustc invocation. The flags are irrelevant to the probe's output. Even if they passes it, it will then be in the argument list.

In both cases, the env var value may contain build-specific paths, for example, `--remap-path-prefix=/random/build/path=...`. Those may cause unnecessary cache misses across builds.

---

While we have <https://github.com/mozilla/sccache/issues/2494> and <https://github.com/mozilla/sccache/pull/2495/>, I think this is less controversial so posted it separately