### PR TITLE
Enable RE on Linux-aarch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,11 @@ jobs:
             target: aarch64-unknown-linux-musl
             container: '{"image": "messense/rust-musl-cross:aarch64-musl"}'
           - os: ubuntu-22.04
+            binary: sccache-dist
+            extra_args: --no-default-features --features="dist-server"
+            target: aarch64-unknown-linux-musl
+            container: '{"image": "messense/rust-musl-cross:aarch64-musl"}'
+          - os: ubuntu-22.04
             target: armv7-unknown-linux-musleabi
             container: '{"image": "messense/rust-musl-cross:armv7-musleabi"}'
           - os: ubuntu-22.04

--- a/src/bin/sccache-dist/main.rs
+++ b/src/bin/sccache-dist/main.rs
@@ -37,6 +37,7 @@ pub const INSECURE_DIST_SERVER_TOKEN: &str = "dangerously_insecure_server";
 
 #[cfg(not(any(
     all(target_os = "linux", target_arch = "x86_64"),
+    all(target_os = "linux", target_arch = "aarch64"),
     target_os = "freebsd"
 )))]
 fn main() {
@@ -46,6 +47,7 @@ fn main() {
 // Only supported on x86_64 Linux machines and on FreeBSD
 #[cfg(any(
     all(target_os = "linux", target_arch = "x86_64"),
+    all(target_os = "linux", target_arch = "aarch64"),
     target_os = "freebsd"
 ))]
 fn main() {

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -1331,7 +1331,7 @@ struct CToolchainPackager {
 }
 
 #[cfg(feature = "dist-client")]
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))]
 impl pkg::ToolchainPackager for CToolchainPackager {
     fn write_pkg(self: Box<Self>, f: fs::File) -> Result<()> {
         use std::os::unix::ffi::OsStringExt;

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -1331,7 +1331,10 @@ struct CToolchainPackager {
 }
 
 #[cfg(feature = "dist-client")]
-#[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 impl pkg::ToolchainPackager for CToolchainPackager {
     fn write_pkg(self: Box<Self>, f: fs::File) -> Result<()> {
         use std::os::unix::ffi::OsStringExt;

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -63,6 +63,7 @@ use crate::errors::*;
     feature = "dist-client",
     any(
         all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
         target_os = "freebsd"
     )
 ))]
@@ -71,6 +72,7 @@ pub const CAN_DIST_DYLIBS: bool = true;
     feature = "dist-client",
     not(any(
         all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
         target_os = "freebsd"
     ))
 ))]

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -2212,7 +2212,10 @@ struct RustToolchainPackager {
 }
 
 #[cfg(feature = "dist-client")]
-#[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 impl pkg::ToolchainPackager for RustToolchainPackager {
     fn write_pkg(self: Box<Self>, f: fs::File) -> Result<()> {
         info!(

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -2212,7 +2212,7 @@ struct RustToolchainPackager {
 }
 
 #[cfg(feature = "dist-client")]
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))]
 impl pkg::ToolchainPackager for RustToolchainPackager {
     fn write_pkg(self: Box<Self>, f: fs::File) -> Result<()> {
         info!(

--- a/src/dist/pkg.rs
+++ b/src/dist/pkg.rs
@@ -20,7 +20,7 @@ use std::str;
 
 use crate::errors::*;
 
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub use self::toolchain_imp::*;
 
 pub trait ToolchainPackager: Send {
@@ -36,7 +36,7 @@ pub trait OutputsRepackager {
     -> Result<dist::PathTransformer>;
 }
 
-#[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+#[cfg(not(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64"))))]
 mod toolchain_imp {
     use super::ToolchainPackager;
     use fs_err as fs;
@@ -52,7 +52,7 @@ mod toolchain_imp {
     }
 }
 
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))]
 mod toolchain_imp {
     use super::SimplifyPath;
     use fs_err as fs;

--- a/src/dist/pkg.rs
+++ b/src/dist/pkg.rs
@@ -20,7 +20,10 @@ use std::str;
 
 use crate::errors::*;
 
-#[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 pub use self::toolchain_imp::*;
 
 pub trait ToolchainPackager: Send {
@@ -36,7 +39,10 @@ pub trait OutputsRepackager {
     -> Result<dist::PathTransformer>;
 }
 
-#[cfg(not(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64"))))]
+#[cfg(not(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+)))]
 mod toolchain_imp {
     use super::ToolchainPackager;
     use fs_err as fs;
@@ -52,7 +58,10 @@ mod toolchain_imp {
     }
 }
 
-#[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 mod toolchain_imp {
     use super::SimplifyPath;
     use fs_err as fs;


### PR DESCRIPTION
It works exactly the same way as on x86 platform

Tested that it works in https://github.com/malfet/deleteme/blob/hauptzweig/build_aarch64_wheel.py plan to use it for PyTorch aarch64 CI build