### PR TITLE
docs(Rust.md): Add caveats from README

### DIFF
--- a/docs/Rust.md
+++ b/docs/Rust.md
@@ -6,6 +6,8 @@ sccache includes support for caching Rust compilation. This includes many caveat
 * `-o file` is not supported.
 * Compilation from stdin is not supported, a source file must be provided.
 * Values from `env!` require Rust >= 1.46 to be tracked in caching.
-* Procedural macros that read files from the filesystem may not be cached properly
+* Procedural macros that read files from the filesystem may not be cached properly.
+* `rustc`'s incremental compilation needs to be disabled. See [The Cargo Book](https://doc.rust-lang.org/cargo/reference/profiles.html#incremental)
+* Crates that invoke the system linker cannot be cached. Examples are `bin`, `dylib`, `cdylib`, and `proc-macro` crates.
 
 If you are using Rust 1.18 or later, you can ask cargo to wrap all compilation with sccache by setting `RUSTC_WRAPPER=sccache` in your build environment.


### PR DESCRIPTION
The README mentions two caveats that are not currently mentioned in the more detailed Rust.md. I've added these to Rust.md