### PR TITLE
fix: refuse to trim rlibs without a sibling .rmeta

### DIFF
--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -1921,6 +1921,8 @@ fn can_trim_this(input_path: &Path) -> bool {
     trace!("can_trim_this: input_path={:?}", input_path);
     let mut ar_path = input_path.to_path_buf();
     ar_path.set_extension("a");
+    let mut rmeta_path = input_path.to_path_buf();
+    rmeta_path.set_extension("rmeta");
     // Check if the input path exists with both a .rlib and a .a, in which case
     // we want to refuse to trim, otherwise triggering
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1760743
@@ -1929,6 +1931,7 @@ fn can_trim_this(input_path: &Path) -> bool {
         .map(|e| e == RLIB_EXTENSION)
         .unwrap_or(false)
         && !ar_path.exists()
+        && rmeta_path.exists() // refuse trim if rustc does not generate an .rmeta file to prevent compilation failures
 }
 
 #[test]


### PR DESCRIPTION
Fixes a Rust distributed compilation failure where `.rlib`s lacking a sibling `.rmeta` are trimmed to a metadata-only stub that the remote rustc cannot read, leading to `extern location for <crate> does not exist` errors. Similar mode of failure to https://bugzilla.mozilla.org/show_bug.cgi?id=1760743.

Reproducible while trying to compile tracing_wasm from a Linux client.

Extends the fix from 1760743: updates `can_trim_this` to refuse to trim rlibs that do not have associated metadata files (so that *something* is sent to the remote rustc). Resolves the tracing_wasm compilation failures in testing on my team's cluster.