### PR TITLE
feat: Make REQUEST_TIMEOUT_SECS and CONNECT configurable

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -180,6 +180,8 @@ Note that some env variables may need sccache server restart to take effect.
 * `SCCACHE_LOG_MILLIS` when set (to any value), enables millisecond precision timestamps in log output instead of the default second precision.
 * `SCCACHE_ERROR_LOG` path to a file where sccache will log errors
 * `SCCACHE_LOG` log level, accepting standard env_logger values, see [env_logger documentation](https://docs.rs/env_logger/latest/env_logger/#enabling-logging) for details
+* `SCCACHE_REQUEST_TIMEOUT_SECS` configurable timeout for requests sent by the Http Client.
+* `SCCACHE_CONNECT_TIMEOUT_SECS` configurable timeout for how long a Http Client will try to connect.
 
 ### cache configs
 

--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -1081,9 +1081,10 @@ mod client {
     use futures::TryFutureExt;
     use reqwest::Body;
     use std::collections::HashMap;
+    use std::env;
     use std::io::Write;
     use std::path::{Path, PathBuf};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, LazyLock, Mutex};
     use std::time::Duration;
 
     use super::common::{
@@ -1093,8 +1094,21 @@ mod client {
     use super::urls;
     use crate::errors::*;
 
-    const REQUEST_TIMEOUT_SECS: u64 = 1200;
-    const CONNECT_TIMEOUT_SECS: u64 = 5;
+    static REQUEST_TIMEOUT_SECS: LazyLock<Duration> = LazyLock::new(|| {
+        let timeout_env: u64 = env::var("SCCACHE_REQUEST_TIMEOUT_SECS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(1200);
+        Duration::new(timeout_env, 0)
+    });
+
+    static CONNECT_TIMEOUT_SECS: LazyLock<Duration> = LazyLock::new(|| {
+        let connect_timeout_env: u64 = env::var("SCCACHE_CONNECT_TIMEOUT_SECS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(5);
+        Duration::new(connect_timeout_env, 0)
+    });
 
     pub struct Client {
         auth_token: String,
@@ -1117,11 +1131,9 @@ mod client {
             auth_token: String,
             rewrite_includes_only: bool,
         ) -> Result<Self> {
-            let timeout = Duration::new(REQUEST_TIMEOUT_SECS, 0);
-            let connect_timeout = Duration::new(CONNECT_TIMEOUT_SECS, 0);
             let client = reqwest::ClientBuilder::new()
-                .timeout(timeout)
-                .connect_timeout(connect_timeout)
+                .timeout(*REQUEST_TIMEOUT_SECS)
+                .connect_timeout(*CONNECT_TIMEOUT_SECS)
                 // Disable connection pool to avoid broken connection
                 // between runtime
                 .pool_max_idle_per_host(0)
@@ -1159,9 +1171,9 @@ mod client {
                 );
             }
             // Finish the client
-            let timeout = Duration::new(REQUEST_TIMEOUT_SECS, 0);
             let new_client_async = client_async_builder
-                .timeout(timeout)
+                .timeout(*REQUEST_TIMEOUT_SECS)
+                .connect_timeout(*CONNECT_TIMEOUT_SECS)
                 // Disable keep-alive
                 .pool_max_idle_per_host(0)
                 .build()
@@ -1333,6 +1345,32 @@ mod client {
                 Some(Ok((_, _, path))) => Some(path),
                 _ => None,
             }
+        }
+    }
+
+    #[test]
+    fn test_request_timeout_secs_from_env() {
+        unsafe {
+            std::env::set_var("SCCACHE_REQUEST_TIMEOUT_SECS", "2400");
+        }
+
+        assert_eq!(*REQUEST_TIMEOUT_SECS, Duration::from_secs(2400));
+
+        unsafe {
+            std::env::remove_var("SCCACHE_REQUEST_TIMEOUT_SECS");
+        }
+    }
+
+    #[test]
+    fn test_connect_timeout_secs_from_env() {
+        unsafe {
+            std::env::set_var("SCCACHE_CONNECT_TIMEOUT_SECS", "10");
+        }
+
+        assert_eq!(*CONNECT_TIMEOUT_SECS, Duration::from_secs(10));
+
+        unsafe {
+            std::env::remove_var("SCCACHE_CONNECT_TIMEOUT_SECS");
         }
     }
 }


### PR DESCRIPTION
Some kernels can take upwards of 5 minutes to compile but 10 minutes might be too high of a timeout in the most common use cases.

Add a runtime configuration option for both the Request and the Connect timeout.

Closes: https://github.com/mozilla/sccache/issues/2276