### PR TITLE
Classify .s files as AssemblerToPreprocess so #include/#ifdef are honored

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -1770,7 +1770,11 @@ mod test {
             assert_eq!(actual, Some(expected));
         }
 
-        t("s", Language::Assembler);
+        // .s, .S, .sx all map to AssemblerToPreprocess. GCC's documented
+        // convention is .s = preprocessed, .S = needs CPP, but real-world
+        // .s sources commonly contain #include and #ifdef and rely on the
+        // driver to preprocess. See test_dot_s_extension_preprocesses.
+        t("s", Language::AssemblerToPreprocess);
         t("S", Language::AssemblerToPreprocess);
         t("sx", Language::AssemblerToPreprocess);
 
@@ -1829,6 +1833,31 @@ mod test {
         t("Hpp");
         t("Mm");
         t("Cu");
+    }
+
+    /// Regression: classifying `.s` as `Language::Assembler` made sccache
+    /// inject `-x assembler` into the compile command, which causes clang
+    /// to skip the C preprocessor. Real-world `.s` sources (NSPR's
+    /// nsprpub/pr/src/md/unix/os_Darwin.s, glibc, CPython) use `#include`
+    /// and `#ifdef` and rely on the driver to preprocess; without it the
+    /// emitted object is empty of symbols.
+    ///
+    /// This test pins the four invariants the fix depends on:
+    ///   1. `.s` classifies as `AssemblerToPreprocess` (not `Assembler`).
+    ///   2. The emitted `-x` arg is `assembler-with-cpp` for both gcc and
+    ///      clang front-ends.
+    ///   3. `needs_c_preprocessing()` is true, so the cache key is
+    ///      computed over the post-CPP source.
+    ///   4. `to_c_preprocessed_language()` resolves to `Assembler`, so the
+    ///      preprocessed-form variant is well-defined.
+    #[test]
+    fn test_dot_s_extension_preprocesses() {
+        let lang = Language::from_file_name(Path::new("input.s")).unwrap();
+        assert_eq!(lang, Language::AssemblerToPreprocess);
+        assert_eq!(lang.to_gcc_arg(), Some("assembler-with-cpp"));
+        assert_eq!(lang.to_clang_arg(), Some("assembler-with-cpp"));
+        assert!(lang.needs_c_preprocessing());
+        assert_eq!(lang.to_c_preprocessed_language(), Some(Language::Assembler));
     }
 
     #[test]

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -250,7 +250,7 @@ impl Language {
     pub fn from_file_name(file: &Path) -> Option<Self> {
         match file.extension().and_then(|e| e.to_str()) {
             // gcc: https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html
-            Some("s") => Some(Language::Assembler),
+            Some("s") => Some(Language::AssemblerToPreprocess),
             Some("S") | Some("sx") => Some(Language::AssemblerToPreprocess),
             Some("c") => Some(Language::C),
             // Could be C or C++


### PR DESCRIPTION
a previous change broke firefox with:
```

[task 2026-05-02T19:11:38.257+00:00] 19:11:38     INFO -  gmake[4]: Entering directory '/builds/worker/workspace/obj-build/security'
[task 2026-05-02T19:11:38.257+00:00] 19:11:38     INFO -  /builds/worker/fetches/sccache/sccache /builds/worker/fetches/clang/bin/clang -isysroot /builds/worker/fetches/MacOSX26.4.sdk -mmacosx-version-min=10.15 --target=x86_64-apple-darwin -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstrict-flex-arrays=1 -pthread -ffunction-sections -fdata-sections -fno-math-errno -fPIC -fcrash-diagnostics-dir=/builds/worker/artifacts -gdwarf-4 -gsimple-template-names -Xclang -load -Xclang /builds/worker/workspace/obj-build/build/clang-plugin/libclang-plugin.so -Xclang -add-plugin -Xclang moz-check -O3 -fno-omit-frame-pointer -funwind-tables -Werror  -o ../dist/bin/libnss3.dylib -Wl,@/builds/worker/workspace/obj-build/security/libnss3_dylib.list    -fuse-ld=lld -fstack-protector-strong -Wl,-dead_strip   ../dist/bin/libmozglue.dylib -Wl,-exported_symbols_list,libnss3.dylib.symbols -dynamiclib -install_name @rpath/libnss3.dylib -compatibility_version 1 -current_version 1  -framework CoreServices
[task 2026-05-02T19:11:38.257+00:00] 19:11:38     INFO -  gmake[4]: Leaving directory '/builds/worker/workspace/obj-build/security'
[task 2026-05-02T19:11:38.257+00:00] 19:11:38    ERROR -  ld64.lld: error: undefined symbol: _PR_Darwin_x86_64_AtomicIncrement
[task 2026-05-02T19:11:38.257+00:00] 19:11:38     INFO -  >>> referenced by pratom.c:245 (./../../../../../../checkouts/gecko/nsprpub/pr/src/misc/pratom.c:245)
[task 2026-05-02T19:11:38.257+00:00] 19:11:38     INFO -  >>>               ../config/external/nspr/pr/Unified_c_external_nspr_pr1.o:(symbol PR_AtomicIncrement+0x6)
[task 2026-05-02T19:11:38.257+00:00] 19:11:38    ERROR -  ld64.lld: error: undefined symbol: _PR_Darwin_x86_64_AtomicDecrement
[task 2026-05-02T19:11:38.257+00:00] 19:11:38     INFO -  >>> referenced by pratom.c:248 (./../../../../../../checkouts/gecko/nsprpub/pr/src/misc/pratom.c:248)
[task 2026-05-02T19:11:38.257+00:00] 19:11:38     INFO -  >>>               ../config/external/nspr/pr/Unified_c_external_nspr_pr1.o:(symbol PR_AtomicDecrement+0x6)
[task 2026-05-02T19:11:38.257+00:00] 19:11:38    ERROR -  ld64.lld: error: undefined symbol: _PR_Darwin_x86_64_AtomicSet
[task 2026-05-02T19:11:38.257+00:00] 19:11:38     INFO -  >>> referenced by pratom.c:252 (./../../../../../../checkouts/gecko/nsprpub/pr/src/misc/pratom.c:252)
[task 2026-05-02T19:11:38.257+00:00] 19:11:38     INFO -  >>>               ../config/external/nspr/pr/Unified_c_external_nspr_pr1.o:(symbol PR_AtomicSet+0x6)
[task 2026-05-02T19:11:38.257+00:00] 19:11:38    ERROR -  ld64.lld: error: undefined symbol: _PR_Darwin_x86_64_AtomicAdd
[task 2026-05-02T19:11:38.257+00:00] 19:11:38     INFO -  >>> referenced by pratom.c:256 (./../../../../../../checkouts/gecko/nsprpub/pr/src/misc/pratom.c:256)
[task 2026-05-02T19:11:38.258+00:00] 19:11:38     INFO -  >>>               ../config/external/nspr/pr/Unified_c_external_nspr_pr1.o:(symbol PR_AtomicAdd+0x6)
[task 2026-05-02T19:11:38.258+00:00] 19:11:38    ERROR -  clang: error: linker command failed with exit code 1 (use -v to see invocation)
```