### PR TITLE
Avoid double-caching on Solus and AerynOS

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1304,7 +1304,9 @@ mod tests {
         // Create a PATH with ccache directories
         let path_with_ccache = env::join_paths([
             "/usr/lib64/ccache",
+            "/usr/lib64/ccache/bin",
             "/usr/lib/ccache",
+            "/usr/lib/ccache/bin",
             "/usr/bin",
             "/usr/local/bin",
             "/home/user/bin",


### PR DESCRIPTION
Following up from https://github.com/mozilla/sccache/pull/2524 add the ccache path that Solus uses (`/usr/lib64/ccache/bin`) and the one that AerynOS uses (`/usr/lib/ccache/bin`).