### PR TITLE
fix: expand quoted @file response files for GCC/Clang (#2650)

### DIFF
--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -1099,13 +1099,13 @@ impl Iterator for ExpandIncludeFile<'_> {
             //     recursively.
             //
             // So here we interpret any I/O errors as "just return this
-            // argument". Currently we don't implement handling of arguments
-            // with quotes, so if those are encountered we just pass the option
-            // through literally anyway.
-            //
-            // At this time we interpret all `@` arguments above as non
-            // cacheable, so if we fail to interpret this we'll just call the
-            // compiler anyway.
+            // argument". Quoted arguments (CMake 4.3+ emits modmap content
+            // like `-fmodule-file="key=value"`) are tokenised through the
+            // existing MSVC `CommandLineToArgvW`-style splitter, which handles
+            // double-quoted runs correctly; for the unquoted shape that older
+            // GCC/Clang response files use, the splitter degenerates to plain
+            // whitespace tokenisation, so existing inputs stay byte-equivalent.
+            // See mozilla/sccache#2650.
             //
             // [1]: https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html#Overall-Options
             let mut contents = String::new();
@@ -1114,10 +1114,8 @@ impl Iterator for ExpandIncludeFile<'_> {
                 debug!("failed to read @-file `{}`: {}", file.display(), e);
                 return Some(arg);
             }
-            if contents.contains('"') || contents.contains('\'') {
-                return Some(arg);
-            }
-            let new_args = contents.split_whitespace().collect::<Vec<_>>();
+            let new_args: Vec<String> =
+                crate::compiler::msvc::SplitMsvcResponseFileArgs::from(&contents).collect();
             self.stack.extend(new_args.iter().rev().map(|s| s.into()));
         }
     }
@@ -2415,6 +2413,55 @@ mod test {
         assert!(preprocessor_args.is_empty());
         assert!(common_args.is_empty());
         assert!(!msvc_show_includes);
+    }
+
+    /// Regression test for mozilla/sccache#2650 — CMake 4.3+ wraps modmap values
+    /// in double quotes when emitting `@<file>.modmap` on clang command lines.
+    /// Before the fix, any quoted character in a response file caused
+    /// `ExpandIncludeFile` to abort and the unexpanded `@arg` reached the
+    /// `cannot_cache!("@")` bailout. After the fix, the quoted run is tokenised
+    /// through the MSVC-style splitter and reaches the parser as an inline
+    /// argument identical to the older unquoted form (`-fmodule-file=key=value`).
+    #[test]
+    fn at_signs_quoted_modmap() {
+        let td = tempfile::Builder::new()
+            .prefix("sccache")
+            .tempdir()
+            .unwrap();
+        // Simulates CMake 4.3+'s modmap content: quoted key=value, no spaces.
+        File::create(td.path().join("main.cpp.o.modmap"))
+            .unwrap()
+            .write_all(b"-fmodule-file=\"greet=greet.pcm\"\n")
+            .unwrap();
+        let at_arg = format!("@{}", td.path().join("main.cpp.o.modmap").display());
+        let expanded: Vec<OsString> =
+            ExpandIncludeFile::new(td.path(), &[OsString::from(at_arg)]).collect();
+        assert_eq!(
+            expanded,
+            vec![OsString::from("-fmodule-file=greet=greet.pcm")]
+        );
+    }
+
+    /// Regression test for the unquoted shape (CMake ≤ 4.2.x and hand-written
+    /// GCC response files): tokenisation must remain whitespace-only equivalent
+    /// to the previous `split_whitespace` implementation.
+    #[test]
+    fn at_signs_unquoted_modmap() {
+        let td = tempfile::Builder::new()
+            .prefix("sccache")
+            .tempdir()
+            .unwrap();
+        File::create(td.path().join("main.cpp.o.modmap"))
+            .unwrap()
+            .write_all(b"-fmodule-file=greet=greet.pcm\n")
+            .unwrap();
+        let at_arg = format!("@{}", td.path().join("main.cpp.o.modmap").display());
+        let expanded: Vec<OsString> =
+            ExpandIncludeFile::new(td.path(), &[OsString::from(at_arg)]).collect();
+        assert_eq!(
+            expanded,
+            vec![OsString::from("-fmodule-file=greet=greet.pcm")]
+        );
     }
 
     #[test]

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -1324,7 +1324,7 @@ where
 ///  - https://msdn.microsoft.com/en-us/library/windows/desktop/bb776391(v=vs.85).aspx
 ///  - https://msdn.microsoft.com/en-us/library/windows/desktop/17w5ykft(v=vs.85).aspx
 #[derive(Clone, Debug)]
-struct SplitMsvcResponseFileArgs<'a> {
+pub(crate) struct SplitMsvcResponseFileArgs<'a> {
     /// String slice of the file content that is being parsed.
     /// Slice is mutated as this iterator is executed.
     file_content: &'a str,

--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -95,7 +95,7 @@ help:
 	@echo "Build System Tests:"
 	@echo "  make test-cmake              Run CMake integration test"
 	@echo "  make test-cmake-modules      Run CMake C++20 modules test"
-	@echo "  make test-cmake-modules-v4   Run CMake 4.x C++20 modules test (xfail)"
+	@echo "  make test-cmake-modules-v4   Run CMake 4.x C++20 modules test"
 	@echo "  make test-autotools          Run Autotools integration test"
 	@echo ""
 	@echo "Advanced Tests:"

--- a/tests/integration/scripts/test-cmake-modules-v4.sh
+++ b/tests/integration/scripts/test-cmake-modules-v4.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
-# XFAIL: cmake 4.x generates arguments that trigger sccache's @ response file
-# rejection in gcc.rs:349. This test tracks the issue and captures the actual
-# compiler commands for debugging.
+# Regression test for mozilla/sccache#2650 — CMake 4.3+ writes quoted modmap
+# content (`-fmodule-file="key=value"`) into `@<file>.modmap` arguments on
+# clang++ command lines. Before the fix, sccache's response-file expander
+# (gcc.rs `ExpandIncludeFile`) bailed on any quoted content and the raw
+# `@file` arg surfaced as `Non-cacheable: @`. After the fix, the response
+# file is tokenised via the MSVC `CommandLineToArgvW`-style splitter and the
+# inlined `-fmodule-file=…` reaches the C++20 modules parser like on cmake
+# 3.31/4.1/4.2. This test asserts the success path; any non-zero @ counter
+# is treated as a regression.
 
 SCCACHE="${SCCACHE_PATH:-/sccache/target/debug/sccache}"
 
 echo "=========================================="
-echo "Testing: CMake 4.x C++20 Modules (XFAIL)"
+echo "Testing: CMake 4.x C++20 Modules"
 echo "=========================================="
 
 echo "cmake version: $(cmake --version | head -1)"
@@ -49,16 +55,44 @@ echo ""
 echo "Cache hits: $CACHE_HITS"
 echo "Non-cacheable @: $NOT_CACHED"
 
-if [ "$CACHE_HITS" -gt 0 ]; then
-    echo "XPASS: CMake 4.x C++20 modules now cacheable! Remove XFAIL status."
+if [ "$NOT_CACHED" -gt 0 ]; then
+    echo "FAIL (regression): sccache reported $NOT_CACHED non-cacheable compile(s)"
+    echo "                    due to '@' response files — see mozilla/sccache#2650."
+    echo "$STATS_JSON" | python3 -m json.tool
     exit 1
 fi
 
-if [ "$NOT_CACHED" -gt 0 ]; then
-    echo "XFAIL: cmake 4.x @ issue reproduced (expected failure)"
-    exit 0
+# Build 1 was a cold run, so we expect cache_misses, not hits. Re-run the
+# build against a clean build dir while keeping the on-disk cache populated
+# so we can also assert the warm-path hit rate.
+echo ""
+echo "Build 2: warm pass (build dir wiped, sccache disk cache persists)"
+rm -rf build
+cmake -B build -G Ninja \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_C_COMPILER_LAUNCHER="$SCCACHE" \
+    -DCMAKE_CXX_COMPILER_LAUNCHER="$SCCACHE"
+cmake --build build
+
+STATS_JSON=$("$SCCACHE" --show-stats --stats-format=json)
+WARM_HITS=$(echo "$STATS_JSON" | python3 -c "import sys, json; stats = json.load(sys.stdin).get('stats', {}); print(stats.get('cache_hits', {}).get('counts', {}).get('C/C++', 0))")
+WARM_NOT_CACHED=$(echo "$STATS_JSON" | python3 -c "import sys, json; print(json.load(sys.stdin).get('stats', {}).get('not_cached', {}).get('@', 0))")
+
+echo ""
+echo "Warm cache hits: $WARM_HITS"
+echo "Warm non-cacheable @: $WARM_NOT_CACHED"
+
+if [ "$WARM_NOT_CACHED" -gt 0 ]; then
+    echo "FAIL (regression): warm pass produced $WARM_NOT_CACHED '@' bailout(s)"
+    exit 1
 fi
 
-echo "FAIL: Unexpected failure"
-echo "$STATS_JSON" | python3 -m json.tool
-exit 1
+if [ "$WARM_HITS" -lt 2 ]; then
+    echo "FAIL: warm pass expected at least 2 cache hits, got $WARM_HITS"
+    echo "$STATS_JSON" | python3 -m json.tool
+    exit 1
+fi
+
+echo "PASS: CMake 4.x C++20 modules cache correctly (cold misses + warm hits)."
+exit 0


### PR DESCRIPTION
## Summary

Fixes #2650. CMake 4.3+ writes `@<file>.modmap` arguments whose content is wrapped in double quotes (`-fmodule-file="key=value"`). Before this PR, the response-file expander in `src/compiler/gcc.rs` (`ExpandIncludeFile`) aborted on any quoted character, leaving the raw `@file` token in the argument stream where it triggered `cannot_cache!("@")` and disabled the cache for every C++20 module TU.

This PR reuses the existing MSVC `SplitMsvcResponseFileArgs` tokenizer (which already handles `CommandLineToArgvW`-style quoted runs and degenerates to plain whitespace tokenisation on the unquoted shape) so existing GCC response-file inputs stay byte-equivalent.

This is the same approach attempted in #1781 (closed 2024-02 for inactivity, not for technical reasons), reduced to a minimal-surface diff: no new shared module yet, just `pub(crate)` on the existing MSVC tokenizer and a single call site change in GCC. A future PR can extract `response_file.rs` along the lines of #1781 if maintainers prefer that direction.

## Empirical bisection

The bug bisects cleanly to a single behavioural difference in the **modmap content** emitted by CMake — not in the compile-launcher command line, which is byte-identical between working and broken setups. Tested with LLVM 22.1.1, sccache `main` + this patch:

| CMake | release date | modmap content | sccache result |
|---|---|---|---|
| 3.31.6 | 2025-… | `-fmodule-file=greet=…pcm` | 2 misses cold → 2 hits warm |
| 4.1.2 | 2025-09-30 | `-fmodule-file=greet=…pcm` | 2 misses cold → 2 hits warm |
| 4.2.0 | 2025-11-19 | `-fmodule-file=greet=…pcm` | 2 misses cold → 2 hits warm |
| 4.2.5 | 2026-04-21 | `-fmodule-file=greet=…pcm` | 2 misses cold → 2 hits warm |
| 4.3.0 (no patch) | 2026-03-17 | `-fmodule-file="greet=…pcm"` | `Non-cacheable: @ × 2` |
| 4.3.1 (no patch) | 2026-03-27 | `-fmodule-file="greet=…pcm"` | `Non-cacheable: @ × 2` |
| 4.3.1 + this patch | — | `-fmodule-file="greet=…pcm"` | **2 misses cold → 2 hits warm** |

`clang++` accepts both shapes (verified with `cmp` on the produced `.o` — byte-identical), so the quoting was only ever a serialisation choice. Note that 4.2.5 was published **after** 4.3.0 and is still clean — the 4.2.x maintenance line never picked up the quote-wrapping change, so the change was 4.3-development-only and was not back-ported. This confirms @TroyKomodo's earlier comment on #2650 that 4.1.2 worked.

## Changes

- `src/compiler/msvc.rs` — make `SplitMsvcResponseFileArgs` `pub(crate)` so `gcc.rs` can reuse it.
- `src/compiler/gcc.rs` — replace the bailout-on-quote (`if contents.contains('"')`) and naive `split_whitespace` with a single call to the MSVC tokenizer. Net diff: **−1 line of code** (the comment block grew, the logic shrank).
- `src/compiler/gcc.rs` — add two regression tests: `at_signs_quoted_modmap` (the bug fix) and `at_signs_unquoted_modmap` (proves backward compatibility on the older shape).
- `tests/integration/scripts/test-cmake-modules-v4.sh` — flip from XFAIL to PASS, with a warm pass that asserts ≥ 2 cache hits after wiping the build dir (proves the cache is actually populated, not just that the bailout no longer fires).
- `tests/integration/Makefile` — drop the `(xfail)` label from the help text.

## Limitations / follow-up

The MSVC tokenizer follows `CommandLineToArgvW` semantics, which differ from the GCC `@file` spec on a few edge cases the current CMake-emitted modmap shape does not exercise:

| input | MSVC parser (now used for GCC) | GCC spec |
|---|---|---|
| `'foo bar'` | 2 tokens: `'foo` and `bar'` | 1 token: `foo bar` |
| `\$HOME` | 2 chars: `\` + `$HOME` | 1 char: `$HOME` |
| `"a\nb"` | `a\nb` (literal `\`) | `anb` (`\` escapes `n`) |

For the CMake-emitted format (`-fmodule-file="key=value"`, no embedded spaces, no backslashes, no single-quotes), MSVC parser and GCC parser produce identical output, so this PR is correct in practice. A follow-up PR could move the tokenizer into a shared `src/compiler/response_file.rs` and add a GCC-spec-conformant variant — that was the ultimate direction of #1781.

## Test plan

- [x] `cargo test --lib` — 451 passed / 0 failed (449 existing + 2 new)
- [x] `cargo fmt --check` — clean
- [x] New regression tests `at_signs_quoted_modmap` + `at_signs_unquoted_modmap` pass
- [x] Hand-rolled minimal repro (cmake 4.3.1 + clang 22.1.1) — 2 misses cold → 2 hits warm
- [x] Updated `tests/integration/scripts/test-cmake-modules-v4.sh` exercised manually on host — passes
- [ ] CI's full integration matrix (will run on push)

Closes #2650.
References #2649 (test fixture), #1781 (prior approach), #2516 (C++20 modules support that is now reachable for cmake 4.3+).