### PR TITLE
fix: use single-threaded tokio runtime in sccache (dist-)client

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -92,7 +92,9 @@ fn run_server_process(startup_timeout: Option<Duration>) -> Result<ServerStartup
     trace!("run_server_process");
     let tempdir = tempfile::Builder::new().prefix("sccache").tempdir()?;
     let socket_path = tempdir.path().join("sock");
-    let runtime = Runtime::new()?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
     let exe_path = env::current_exe()?;
     let workdir = exe_path.parent().expect("executable path has no parent?!");
 
@@ -190,7 +192,9 @@ fn run_server_process(startup_timeout: Option<Duration>) -> Result<ServerStartup
     trace!("run_server_process");
 
     // Create a mini event loop and register our named pipe server
-    let runtime = Runtime::new()?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
     let pipe_name = &format!(r"\\.\pipe\{}", Uuid::new_v4().as_simple());
 
     // Spawn a server which should come back and connect to us
@@ -627,7 +631,9 @@ pub fn run_command(cmd: Command) -> Result<i32> {
                 // If there is no server, spawning a new server would start with zero stats
                 // anyways, so we can just return (mostly) empty stats directly.
                 Err(_) => {
-                    let runtime = Runtime::new()?;
+                    let runtime = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()?;
                     let storage = storage_from_config(config, runtime.handle()).ok();
                     runtime.block_on(ServerInfo::new(ServerStats::default(), storage.as_deref()))?
                 }
@@ -764,7 +770,9 @@ pub fn run_command(cmd: Command) -> Result<i32> {
             use crate::compiler;
 
             trace!("Command::PackageToolchain({})", executable.display());
-            let runtime = Runtime::new()?;
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
             let jobserver = Client::new();
             let creator = ProcessCommandCreator::new(&jobserver);
             let args: Vec<_> = env::args_os().collect();
@@ -808,7 +816,9 @@ pub fn run_command(cmd: Command) -> Result<i32> {
 
             let jobserver = Client::new();
             let conn = connect_or_start_server(&get_addr(), startup_timeout)?;
-            let mut runtime = Runtime::new()?;
+            let mut runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
             let res = do_compile(
                 ProcessCommandCreator::new(&jobserver),
                 &mut runtime,

--- a/src/dist/client_auth.rs
+++ b/src/dist/client_auth.rs
@@ -536,11 +536,10 @@ pub fn get_token_oauth2_code_grant_pkce(
     mut auth_url: Url,
     token_url: &str,
 ) -> Result<String> {
-    // We don't need to create multi-threaded runtime here:
-    // every client will create it's own NUM_THREADS,
-    // and with 96-core server we will have 96 x 96 = 9216 threads
-    // with short live time with default tokio runtime instead of 96 one
-    // with the single-threaded one
+    // We don't need a multi-threaded runtime here: with the default tokio
+    // runtime every client spawns its own NUM_THREADS worker threads, so on a
+    // 96-core server running 96 clients we would get 96 x 96 = 9216
+    // short-lived threads instead of a single one per client.
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;

--- a/src/dist/client_auth.rs
+++ b/src/dist/client_auth.rs
@@ -11,7 +11,6 @@ use std::io;
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::sync::mpsc;
 use std::time::Duration;
-use tokio::runtime::Runtime;
 use url::Url;
 use uuid::Uuid;
 
@@ -537,7 +536,14 @@ pub fn get_token_oauth2_code_grant_pkce(
     mut auth_url: Url,
     token_url: &str,
 ) -> Result<String> {
-    let runtime = Runtime::new()?;
+    // We don't need to create multi-threaded runtime here:
+    // every client will create it's own NUM_THREADS,
+    // and with 96-core server we will have 96 x 96 = 9216 threads
+    // with short live time with default tokio runtime instead of 96 one
+    // with the single-threaded one
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
     let mut server = runtime.block_on(async move { try_bind().await })?;
     let port = server.local_addr().port();
 
@@ -591,7 +597,9 @@ pub fn get_token_oauth2_code_grant_pkce(
 
 // https://auth0.com/docs/api-auth/tutorials/implicit-grant
 pub fn get_token_oauth2_implicit(client_id: &str, mut auth_url: Url) -> Result<String> {
-    let runtime = Runtime::new()?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
     let mut server = runtime.block_on(async move { try_bind().await })?;
     let port = server.local_addr().port();
     let _guard = runtime.enter();


### PR DESCRIPTION
It's the #2460 follow-up with `dist-client` similar fixes.

Thanks, @venkyt-arista, for the original fix