### PR TITLE
feat: all backends support making them as read-only

### DIFF
--- a/docs/Azure.md
+++ b/docs/Azure.md
@@ -6,4 +6,6 @@ the container for you - you'll need to do that yourself.
 
 You can also define a prefix that will be prepended to the keys of all cache objects created and read within the container, effectively creating a scope. To do that use the `SCCACHE_AZURE_KEY_PREFIX` environment variable. This can be useful when sharing a bucket with another application.
 
+The `SCCACHE_AZURE_RW_MODE` environment variable can be set to `READ_ONLY` to make sccache use this backend in read-only mode. The default is `READ_WRITE`.
+
 **Important:** The environment variables are only taken into account when the server starts, i.e. only on the first run.

--- a/docs/COS.md
+++ b/docs/COS.md
@@ -6,6 +6,8 @@ You **must** specify the endpoint URL using the `SCCACHE_COS_ENDPOINT` environme
 
 You can also define a prefix that will be prepended to the keys of all cache objects created and read within the COS bucket, effectively creating a scope. To do that use the `SCCACHE_COS_KEY_PREFIX` environment variable. This can be useful when sharing a bucket with another application.
 
+The `SCCACHE_COS_RW_MODE` environment variable can be set to `READ_ONLY` to make sccache use this backend in read-only mode. The default is `READ_WRITE`.
+
 ## Credentials
 
 Sccache is able to load credentials from environment variables: `TENCENTCLOUD_SECRET_ID` and `TENCENTCLOUD_SECRET_KEY`. More details about the access of COS bucket can be found at the [introduction page](https://www.tencentcloud.com/document/product/436/7751).

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -232,6 +232,7 @@ export SCCACHE_MULTILEVEL_WRITE_ERROR_POLICY="all"
 * `SCCACHE_REGION` s3 region, required if using AWS S3
 * `SCCACHE_S3_USE_SSL` s3 endpoint requires TLS, set this to `true`
 * `SCCACHE_S3_KEY_PREFIX` s3 key prefix (optional)
+* `SCCACHE_S3_RW_MODE` allows to use s3 backend in read-only mode if set to `READ_ONLY`
 
 The endpoint used then becomes `${SCCACHE_BUCKET}.s3-{SCCACHE_REGION}.amazonaws.com`.
 If you are not using the default endpoint and `SCCACHE_REGION` is undefined, it
@@ -254,6 +255,7 @@ will default to `us-east-1`.
 * `SCCACHE_REDIS_DB` redis database (optional, default is 0).
 * `SCCACHE_REDIS_EXPIRATION` / `SCCACHE_REDIS_TTL` ttl for redis cache, don't set for default behavior.
 * `SCCACHE_REDIS_KEY_PREFIX` key prefix (optional).
+* `SCCACHE_REDIS_RW_MODE` allows to use redis backend in read-only mode if set to `READ_ONLY`
 
 The full url appears then as `redis://user:passwd@1.2.3.4:6379/?db=1`.
 
@@ -265,6 +267,7 @@ The full url appears then as `redis://user:passwd@1.2.3.4:6379/?db=1`.
 * `SCCACHE_MEMCACHED_PASSWORD` memcached password (optional).
 * `SCCACHE_MEMCACHED_EXPIRATION` ttl for memcached cache, don't set for default behavior.
 * `SCCACHE_MEMCACHED_KEY_PREFIX` key prefix (optional).
+* `SCCACHE_MEMCACHED_RW_MODE` allows to use memcached backend in read-only mode if set to `READ_ONLY`
 
 #### gcs
 
@@ -278,6 +281,7 @@ The full url appears then as `redis://user:passwd@1.2.3.4:6379/?db=1`.
 * `SCCACHE_AZURE_CONNECTION_STRING`
 * `SCCACHE_AZURE_BLOB_CONTAINER`
 * `SCCACHE_AZURE_KEY_PREFIX`
+* `SCCACHE_AZURE_RW_MODE`
 
 #### gha
 
@@ -285,6 +289,7 @@ The full url appears then as `redis://user:passwd@1.2.3.4:6379/?db=1`.
 * `SCCACHE_GHA_RUNTIME_TOKEN` / `ACTIONS_RUNTIME_TOKEN` GitHub Actions access token
 * `SCCACHE_GHA_CACHE_TO` cache key to write
 * `SCCACHE_GHA_CACHE_FROM` comma separated list of cache keys to read from
+* `SCCACHE_GHA_RW_MODE` allows to use GHA cache backend in read-only mode if set to `READ_ONLY`
 
 #### webdav
 
@@ -293,6 +298,7 @@ The full url appears then as `redis://user:passwd@1.2.3.4:6379/?db=1`.
 * `SCCACHE_WEBDAV_USERNAME` a username to authenticate with webdav service (optional).
 * `SCCACHE_WEBDAV_PASSWORD` a password to authenticate with webdav service (optional).
 * `SCCACHE_WEBDAV_TOKEN` a token to authenticate with webdav service (optional) - may be used instead of login & password.
+* `SCCACHE_WEBDAV_RW_MODE` allows to use webdav backend in read-only mode if set to `READ_ONLY`
 
 #### OSS
 
@@ -302,6 +308,7 @@ The full url appears then as `redis://user:passwd@1.2.3.4:6379/?db=1`.
 * `ALIBABA_CLOUD_ACCESS_KEY_ID`
 * `ALIBABA_CLOUD_ACCESS_KEY_SECRET`
 * `SCCACHE_OSS_NO_CREDENTIALS`
+* `SCCACHE_OSS_RW_MODE`
 
 #### Tencent Cloud Object Storage (COS)
 
@@ -310,3 +317,4 @@ The full url appears then as `redis://user:passwd@1.2.3.4:6379/?db=1`.
 * `SCCACHE_COS_KEY_PREFIX`
 * `TENCENTCLOUD_SECRET_ID`
 * `TENCENTCLOUD_SECRET_KEY`
+* `SCCACHE_COS_RW_MODE`

--- a/docs/GHA.md
+++ b/docs/GHA.md
@@ -15,6 +15,8 @@ This cache type will need tokens like `ACTIONS_RESULTS_URL` and `ACTIONS_RUNTIME
       core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 ```
 
+The `SCCACHE_GHA_RW_MODE` environment variable can be set to `READ_ONLY` to make sccache use this backend in read-only mode. The default is `READ_WRITE`.
+
 ## Behavior
 
 In case sccache reaches the rate limit of the service, the build will continue, but the storage might not be performed.

--- a/docs/Memcached.md
+++ b/docs/Memcached.md
@@ -10,3 +10,5 @@ Set `SCCACHE_MEMCACHED_EXPIRATION` to the default expiration seconds of memcache
 
 Set `SCCACHE_MEMCACHED_KEY_PREFIX` if you want to prefix all cache keys. This can be
 useful when sharing a Memcached instance with another application or cache.
+
+The `SCCACHE_MEMCACHED_RW_MODE` environment variable can be set to `READ_ONLY` to make sccache use this backend in read-only mode. The default is `READ_WRITE`.

--- a/docs/OSS.md
+++ b/docs/OSS.md
@@ -6,6 +6,8 @@ You **must** specify the endpoint URL using the `SCCACHE_OSS_ENDPOINT` environme
 
 You can also define a prefix that will be prepended to the keys of all cache objects created and read within the OSS bucket, effectively creating a scope. To do that use the `SCCACHE_OSS_KEY_PREFIX` environment variable. This can be useful when sharing a bucket with another application.
 
+The `SCCACHE_OSS_RW_MODE` environment variable can be set to `READ_ONLY` to make sccache use this backend in read-only mode. The default is `READ_WRITE`.
+
 ## Credentials
 
 Sccache is able to load credentials from environment variables: `ALIBABA_CLOUD_ACCESS_KEY_ID` and `ALIBABA_CLOUD_ACCESS_KEY_SECRET`.

--- a/docs/Redis.md
+++ b/docs/Redis.md
@@ -26,6 +26,8 @@ useful when sharing a Redis instance with another application or cache.
 `SCCACHE_REDIS` is deprecated for security reasons, use `SCCACHE_REDIS_ENDPOINT` instead. See mozilla/sccache#2083 for details.
 If you really want to use `SCCACHE_REDIS`, you should URL in format `redis://[[<username>]:<passwd>@]<hostname>[:port][/?db=<db>]`.
 
+The `SCCACHE_REDIS_RW_MODE` environment variable can be set to `READ_ONLY` to make sccache use this backend in read-only mode. The default is `READ_WRITE`.
+
 ## Deprecated API Examples
 
 Use the local Redis instance with no password:

--- a/docs/S3.md
+++ b/docs/S3.md
@@ -9,10 +9,12 @@ If you want to use S3 storage for the sccache cache, you need to set the followi
 
 If your endpoint requires HTTPS/TLS, set `SCCACHE_S3_USE_SSL=true`. If you don't need a secure network layer, HTTP (`SCCACHE_S3_USE_SSL=false`) might be better for performance.
 
-Enable server-side encryption with s3 managed key (SSE-S3), set `SCCACHE_S3_SERVER_SIDE_ENCRYPTION=true`.  
+Enable server-side encryption with s3 managed key (SSE-S3), set `SCCACHE_S3_SERVER_SIDE_ENCRYPTION=true`.
 More details about encryption [here](https://opendal.apache.org/docs/services/s3/#server-side-encryption) and documentation [here](https://docs.rs/opendal/latest/opendal/services/struct.S3.html#method.server_side_encryption_with_s3_key).
 
 You can also define a prefix that will be prepended to the keys of all cache objects created and read within the S3 bucket, effectively creating a scope. To do that use the `SCCACHE_S3_KEY_PREFIX` environment variable. This can be useful when sharing a bucket with another application.
+
+The `SCCACHE_S3_RW_MODE` environment variable can be set to `READ_ONLY` to make sccache use this backend in read-only mode. The default is `READ_WRITE`.
 
 # R2
 

--- a/docs/Webdav.md
+++ b/docs/Webdav.md
@@ -10,6 +10,8 @@ The following services all expose a WebDAV interface and can be used as a backen
 Set `SCCACHE_WEBDAV_ENDPOINT` to an appropriate webdav service endpoint to enable remote caching.
 Set `SCCACHE_WEBDAV_KEY_PREFIX` to specify the key prefix of cache.
 
+The `SCCACHE_WEBDAV_RW_MODE` environment variable can be set to `READ_ONLY` to make sccache use this backend in read-only mode. The default is `READ_WRITE`.
+
 ## Credentials
 
 Sccache is able to load credentials from the following sources:

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -170,6 +170,7 @@ pub trait Storage: Send + Sync {
 pub struct RemoteStorage {
     operator: opendal::Operator,
     basedirs: Vec<Vec<u8>>,
+    rw_mode: CacheMode,
 }
 
 #[cfg(any(
@@ -184,8 +185,12 @@ pub struct RemoteStorage {
     feature = "cos"
 ))]
 impl RemoteStorage {
-    pub fn new(operator: opendal::Operator, basedirs: Vec<Vec<u8>>) -> Self {
-        Self { operator, basedirs }
+    pub fn new(operator: opendal::Operator, basedirs: Vec<Vec<u8>>, rw_mode: CacheMode) -> Self {
+        Self {
+            operator,
+            basedirs,
+            rw_mode,
+        }
     }
 }
 
@@ -247,6 +252,13 @@ impl Storage for RemoteStorage {
                 eprintln!("cache storage read check: {err:?}, but we decide to keep running");
             }
             Err(err) => bail!("cache storage failed to read: {:?}", err),
+        }
+
+        // No need to check write if we are in manually-set read-only mode
+        if self.rw_mode == CacheMode::ReadOnly {
+            let mode = CacheMode::ReadOnly;
+            debug!("storage check result: {mode:?} (manually set)");
+            return Ok(mode);
         }
 
         let can_write = match self.operator.write(path, "Hello, World!").await {
@@ -337,6 +349,10 @@ impl Storage for RemoteStorage {
         trace!("opendal::Operator::put_raw({}, {} bytes)", key, data.len());
         let start = std::time::Instant::now();
 
+        if self.rw_mode == CacheMode::ReadOnly {
+            bail!("storage is read-only");
+        }
+
         self.operator.write(&normalize_key(key), data).await?;
 
         Ok(start.elapsed())
@@ -367,11 +383,12 @@ pub fn build_single_cache(
             connection_string,
             container,
             key_prefix,
+            rw_mode,
         }) => {
             debug!("Init azure cache with container {container}, key_prefix {key_prefix}");
             let operator = AzureBlobCache::build(connection_string, container, key_prefix)
                 .map_err(|err| anyhow!("create azure cache failed: {err:?}"))?;
-            let storage = RemoteStorage::new(operator, basedirs.to_vec());
+            let storage = RemoteStorage::new(operator, basedirs.to_vec(), (*rw_mode).into());
             Ok(Arc::new(storage))
         }
         #[cfg(feature = "gcs")]
@@ -394,16 +411,18 @@ pub fn build_single_cache(
                 credential_url.as_deref(),
             )
             .map_err(|err| anyhow!("create gcs cache failed: {err:?}"))?;
-            let storage = RemoteStorage::new(operator, basedirs.to_vec());
+            let storage = RemoteStorage::new(operator, basedirs.to_vec(), (*rw_mode).into());
             Ok(Arc::new(storage))
         }
         #[cfg(feature = "gha")]
-        CacheType::GHA(config::GHACacheConfig { version, .. }) => {
+        CacheType::GHA(config::GHACacheConfig {
+            version, rw_mode, ..
+        }) => {
             debug!("Init gha cache with version {version}");
 
             let operator = GHACache::build(version)
                 .map_err(|err| anyhow!("create gha cache failed: {err:?}"))?;
-            let storage = RemoteStorage::new(operator, basedirs.to_vec());
+            let storage = RemoteStorage::new(operator, basedirs.to_vec(), (*rw_mode).into());
             Ok(Arc::new(storage))
         }
         #[cfg(feature = "memcached")]
@@ -413,6 +432,7 @@ pub fn build_single_cache(
             password,
             expiration,
             key_prefix,
+            rw_mode,
         }) => {
             debug!("Init memcached cache with url {url}");
 
@@ -424,7 +444,7 @@ pub fn build_single_cache(
                 *expiration,
             )
             .map_err(|err| anyhow!("create memcached cache failed: {err:?}"))?;
-            let storage = RemoteStorage::new(operator, basedirs.to_vec());
+            let storage = RemoteStorage::new(operator, basedirs.to_vec(), (*rw_mode).into());
             Ok(Arc::new(storage))
         }
         #[cfg(feature = "redis")]
@@ -437,6 +457,7 @@ pub fn build_single_cache(
             url,
             ttl,
             key_prefix,
+            rw_mode,
         }) => {
             let storage = match (endpoint, cluster_endpoints, url) {
                 (Some(url), None, None) => {
@@ -472,7 +493,7 @@ pub fn build_single_cache(
                 _ => bail!("Only one of `endpoint`, `cluster_endpoints`, `url` must be set"),
             }
             .map_err(|err| anyhow!("create redis cache failed: {err:?}"))?;
-            let storage = RemoteStorage::new(storage, basedirs.to_vec());
+            let storage = RemoteStorage::new(storage, basedirs.to_vec(), (*rw_mode).into());
             Ok(Arc::new(storage))
         }
         #[cfg(feature = "s3")]
@@ -492,7 +513,7 @@ pub fn build_single_cache(
                 .build()
                 .map_err(|err| anyhow!("create s3 cache failed: {err:?}"))?;
 
-            let storage = RemoteStorage::new(operator, basedirs.to_vec());
+            let storage = RemoteStorage::new(operator, basedirs.to_vec(), c.rw_mode.into());
             Ok(Arc::new(storage))
         }
         #[cfg(feature = "webdav")]
@@ -508,7 +529,7 @@ pub fn build_single_cache(
             )
             .map_err(|err| anyhow!("create webdav cache failed: {err:?}"))?;
 
-            let storage = RemoteStorage::new(operator, basedirs.to_vec());
+            let storage = RemoteStorage::new(operator, basedirs.to_vec(), c.rw_mode.into());
             Ok(Arc::new(storage))
         }
         #[cfg(feature = "oss")]
@@ -526,7 +547,7 @@ pub fn build_single_cache(
             )
             .map_err(|err| anyhow!("create oss cache failed: {err:?}"))?;
 
-            let storage = RemoteStorage::new(operator, basedirs.to_vec());
+            let storage = RemoteStorage::new(operator, basedirs.to_vec(), c.rw_mode.into());
             Ok(Arc::new(storage))
         }
         #[cfg(feature = "cos")]
@@ -539,7 +560,7 @@ pub fn build_single_cache(
             let operator = COSCache::build(&c.bucket, &c.key_prefix, c.endpoint.as_deref())
                 .map_err(|err| anyhow!("create cos cache failed: {err:?}"))?;
 
-            let storage = RemoteStorage::new(operator, basedirs.to_vec());
+            let storage = RemoteStorage::new(operator, basedirs.to_vec(), c.rw_mode.into());
             Ok(Arc::new(storage))
         }
         #[allow(unreachable_patterns)]
@@ -680,7 +701,7 @@ mod test {
         let basedirs = vec![b"/home/user/project".to_vec(), b"/opt/build".to_vec()];
 
         // Wrap with OperatorStorage
-        let storage = RemoteStorage::new(operator, basedirs.clone());
+        let storage = RemoteStorage::new(operator, basedirs.clone(), CacheMode::ReadWrite);
 
         // Verify basedirs are stored and retrieved correctly
         assert_eq!(storage.basedirs(), basedirs.as_slice());
@@ -706,10 +727,37 @@ mod test {
         let basedirs = vec![b"/workspace".to_vec()];
 
         // Wrap with OperatorStorage
-        let storage = RemoteStorage::new(operator, basedirs.clone());
+        let storage = RemoteStorage::new(operator, basedirs.clone(), CacheMode::ReadWrite);
 
         // Verify basedirs work
         assert_eq!(storage.basedirs(), basedirs.as_slice());
         assert_eq!(storage.basedirs().len(), 1);
+    }
+
+    #[test]
+    #[cfg(feature = "redis")]
+    fn test_operator_storage_redis_with_read_only() {
+        // Create Redis operator
+
+        use crate::test::utils::Waiter;
+        let operator = crate::cache::redis::RedisCache::build_single(
+            "redis://localhost:6379",
+            None,
+            None,
+            0,
+            "test-prefix",
+            0,
+        )
+        .expect("Failed to create Redis cache operator");
+
+        // Wrap with OperatorStorage
+        let storage = RemoteStorage::new(operator, vec![], CacheMode::ReadOnly);
+
+        // Verify put fails
+        let result = storage.put("test", CacheWrite::default()).wait();
+        match result {
+            Ok(_) => panic!("expected error, got success {result:?}"),
+            Err(err) => assert_eq!(err.to_string(), "storage is read-only"),
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,6 +236,8 @@ pub struct AzureCacheConfig {
     pub connection_string: String,
     pub container: String,
     pub key_prefix: String,
+    #[serde(default)]
+    pub rw_mode: CacheModeConfig,
 }
 
 /// Configuration switches for preprocessor cache mode.
@@ -311,12 +313,13 @@ impl Default for DiskCacheConfig {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub enum CacheModeConfig {
     #[serde(rename = "READ_ONLY")]
     ReadOnly,
     #[serde(rename = "READ_WRITE")]
+    #[default]
     ReadWrite,
 }
 
@@ -347,6 +350,8 @@ pub struct GHACacheConfig {
     /// Version for gha cache is a namespace. By setting different versions,
     /// we can avoid mixed caches.
     pub version: String,
+    #[serde(default)]
+    pub rw_mode: CacheModeConfig,
 }
 
 /// Memcached's default value of expiration is 10800s (3 hours), which is too
@@ -383,6 +388,9 @@ pub struct MemcachedCacheConfig {
 
     #[serde(default)]
     pub key_prefix: String,
+
+    #[serde(default)]
+    pub rw_mode: CacheModeConfig,
 }
 
 /// redis has no default TTL - all caches live forever
@@ -427,6 +435,9 @@ pub struct RedisCacheConfig {
 
     #[serde(default)]
     pub key_prefix: String,
+
+    #[serde(default)]
+    pub rw_mode: CacheModeConfig,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -438,6 +449,8 @@ pub struct WebdavCacheConfig {
     pub username: Option<String>,
     pub password: Option<String>,
     pub token: Option<String>,
+    #[serde(default)]
+    pub rw_mode: CacheModeConfig,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -452,6 +465,8 @@ pub struct S3CacheConfig {
     pub use_ssl: Option<bool>,
     pub server_side_encryption: Option<bool>,
     pub enable_virtual_host_style: Option<bool>,
+    #[serde(default)]
+    pub rw_mode: CacheModeConfig,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -462,6 +477,8 @@ pub struct OSSCacheConfig {
     pub key_prefix: String,
     pub endpoint: Option<String>,
     pub no_credentials: bool,
+    #[serde(default)]
+    pub rw_mode: CacheModeConfig,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -471,6 +488,8 @@ pub struct COSCacheConfig {
     #[serde(default)]
     pub key_prefix: String,
     pub endpoint: Option<String>,
+    #[serde(default)]
+    pub rw_mode: CacheModeConfig,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -819,6 +838,19 @@ fn key_prefix_from_env_var(env_var_name: &str) -> String {
         .to_owned()
 }
 
+fn cache_mode_from_env_var(env_var_name: &str) -> Option<CacheModeConfig> {
+    env::var(env_var_name)
+        .ok()
+        .and_then(|value| match value.to_uppercase().as_str() {
+            "READ_ONLY" => Some(CacheModeConfig::ReadOnly),
+            "READ_WRITE" => Some(CacheModeConfig::ReadWrite),
+            _ => {
+                warn!("{} must be 'READ_ONLY' or 'READ_WRITE'", env_var_name);
+                None
+            }
+        })
+}
+
 fn number_from_env_var<A: std::str::FromStr>(env_var_name: &str) -> Option<Result<A>>
 where
     <A as FromStr>::Err: std::fmt::Debug,
@@ -855,6 +887,8 @@ fn config_from_env() -> Result<EnvConfig> {
         let endpoint = env::var("SCCACHE_ENDPOINT").ok();
         let key_prefix = key_prefix_from_env_var("SCCACHE_S3_KEY_PREFIX");
         let enable_virtual_host_style = bool_from_env_var("SCCACHE_S3_ENABLE_VIRTUAL_HOST_STYLE")?;
+        let rw_mode =
+            cache_mode_from_env_var("SCCACHE_S3_RW_MODE").unwrap_or(CacheModeConfig::ReadWrite);
 
         Some(S3CacheConfig {
             bucket,
@@ -865,6 +899,7 @@ fn config_from_env() -> Result<EnvConfig> {
             use_ssl,
             server_side_encryption,
             enable_virtual_host_style,
+            rw_mode,
         })
     } else {
         None
@@ -899,6 +934,9 @@ fn config_from_env() -> Result<EnvConfig> {
 
             let key_prefix = key_prefix_from_env_var("SCCACHE_REDIS_KEY_PREFIX");
 
+            let rw_mode = cache_mode_from_env_var("SCCACHE_REDIS_RW_MODE")
+                .unwrap_or(CacheModeConfig::ReadWrite);
+
             Some(RedisCacheConfig {
                 url,
                 endpoint,
@@ -908,6 +946,7 @@ fn config_from_env() -> Result<EnvConfig> {
                 db,
                 ttl,
                 key_prefix,
+                rw_mode,
             })
         }
     };
@@ -931,12 +970,16 @@ fn config_from_env() -> Result<EnvConfig> {
 
         let key_prefix = key_prefix_from_env_var("SCCACHE_MEMCACHED_KEY_PREFIX");
 
+        let rw_mode = cache_mode_from_env_var("SCCACHE_MEMCACHED_RW_MODE")
+            .unwrap_or(CacheModeConfig::ReadWrite);
+
         Some(MemcachedCacheConfig {
             url,
             username,
             password,
             expiration,
             key_prefix,
+            rw_mode,
         })
     } else {
         None
@@ -974,20 +1017,10 @@ fn config_from_env() -> Result<EnvConfig> {
         let cred_path = env::var("SCCACHE_GCS_KEY_PATH").ok();
         let service_account = env::var("SCCACHE_GCS_SERVICE_ACCOUNT").ok();
 
-        let rw_mode = match env::var("SCCACHE_GCS_RW_MODE").as_ref().map(String::as_str) {
-            Ok("READ_ONLY") => CacheModeConfig::ReadOnly,
-            Ok("READ_WRITE") => CacheModeConfig::ReadWrite,
-            // TODO: unsure if these should warn during the configuration loading
-            // or at the time when they're actually used to connect to GCS
-            Ok(_) => {
-                warn!("Invalid SCCACHE_GCS_RW_MODE -- defaulting to READ_ONLY.");
-                CacheModeConfig::ReadOnly
-            }
-            _ => {
-                warn!("No SCCACHE_GCS_RW_MODE specified -- defaulting to READ_ONLY.");
-                CacheModeConfig::ReadOnly
-            }
-        };
+        let rw_mode = cache_mode_from_env_var("SCCACHE_GCS_RW_MODE").unwrap_or_else(|| {
+            warn!("No valid SCCACHE_GCS_RW_MODE value was found -- defaulting to READ_ONLY.");
+            CacheModeConfig::ReadOnly
+        });
 
         GCSCacheConfig {
             bucket,
@@ -1000,12 +1033,15 @@ fn config_from_env() -> Result<EnvConfig> {
     });
 
     // ======= GHA =======
+    let gha_rw_mode: CacheModeConfig =
+        cache_mode_from_env_var("SCCACHE_GHA_RW_MODE").unwrap_or(CacheModeConfig::ReadWrite);
     let gha = if let Ok(version) = env::var("SCCACHE_GHA_VERSION") {
         // If SCCACHE_GHA_VERSION has been set, we don't need to check
         // SCCACHE_GHA_ENABLED's value anymore.
         Some(GHACacheConfig {
             enabled: true,
             version,
+            rw_mode: gha_rw_mode,
         })
     } else if bool_from_env_var("SCCACHE_GHA_ENABLED")?.unwrap_or(false) {
         // If only SCCACHE_GHA_ENABLED has been set to the true value, enable with
@@ -1013,6 +1049,7 @@ fn config_from_env() -> Result<EnvConfig> {
         Some(GHACacheConfig {
             enabled: true,
             version: String::new(),
+            rw_mode: gha_rw_mode,
         })
     } else {
         None
@@ -1024,10 +1061,14 @@ fn config_from_env() -> Result<EnvConfig> {
         env::var("SCCACHE_AZURE_BLOB_CONTAINER"),
     ) {
         let key_prefix = key_prefix_from_env_var("SCCACHE_AZURE_KEY_PREFIX");
+        let rw_mode =
+            cache_mode_from_env_var("SCCACHE_AZURE_RW_MODE").unwrap_or(CacheModeConfig::ReadWrite);
+
         Some(AzureCacheConfig {
             connection_string,
             container,
             key_prefix,
+            rw_mode,
         })
     } else {
         None
@@ -1039,6 +1080,8 @@ fn config_from_env() -> Result<EnvConfig> {
         let username = env::var("SCCACHE_WEBDAV_USERNAME").ok();
         let password = env::var("SCCACHE_WEBDAV_PASSWORD").ok();
         let token = env::var("SCCACHE_WEBDAV_TOKEN").ok();
+        let rw_mode =
+            cache_mode_from_env_var("SCCACHE_WEBDAV_RW_MODE").unwrap_or(CacheModeConfig::ReadWrite);
 
         Some(WebdavCacheConfig {
             endpoint,
@@ -1046,6 +1089,7 @@ fn config_from_env() -> Result<EnvConfig> {
             username,
             password,
             token,
+            rw_mode,
         })
     } else {
         None
@@ -1058,11 +1102,15 @@ fn config_from_env() -> Result<EnvConfig> {
 
         let no_credentials = bool_from_env_var("SCCACHE_OSS_NO_CREDENTIALS")?.unwrap_or(false);
 
+        let rw_mode =
+            cache_mode_from_env_var("SCCACHE_OSS_RW_MODE").unwrap_or(CacheModeConfig::ReadWrite);
+
         Some(OSSCacheConfig {
             bucket,
             endpoint,
             key_prefix,
             no_credentials,
+            rw_mode,
         })
     } else {
         None
@@ -1083,10 +1131,14 @@ fn config_from_env() -> Result<EnvConfig> {
         let endpoint = env::var("SCCACHE_COS_ENDPOINT").ok();
         let key_prefix = key_prefix_from_env_var("SCCACHE_COS_KEY_PREFIX");
 
+        let rw_mode =
+            cache_mode_from_env_var("SCCACHE_COS_RW_MODE").unwrap_or(CacheModeConfig::ReadWrite);
+
         Some(COSCacheConfig {
             bucket,
             endpoint,
             key_prefix,
+            rw_mode,
         })
     } else {
         None
@@ -1106,18 +1158,11 @@ fn config_from_env() -> Result<EnvConfig> {
         false
     };
 
-    let (disk_rw_mode, disk_rw_mode_overridden) = match env::var("SCCACHE_LOCAL_RW_MODE")
-        .as_ref()
-        .map(String::as_str)
-    {
-        Ok("READ_ONLY") => (CacheModeConfig::ReadOnly, true),
-        Ok("READ_WRITE") => (CacheModeConfig::ReadWrite, true),
-        Ok(_) => {
-            warn!("Invalid SCCACHE_LOCAL_RW_MODE -- defaulting to READ_WRITE.");
-            (CacheModeConfig::ReadWrite, false)
-        }
-        _ => (CacheModeConfig::ReadWrite, false),
-    };
+    let (disk_rw_mode, disk_rw_mode_overridden) =
+        match cache_mode_from_env_var("SCCACHE_LOCAL_RW_MODE") {
+            Some(mode) => (mode, true),
+            _ => (CacheModeConfig::ReadWrite, false),
+        };
 
     let any_overridden = disk_dir.is_some()
         || disk_sz.is_some()
@@ -1563,6 +1608,7 @@ fn config_overrides() {
                 connection_string: String::new(),
                 container: String::new(),
                 key_prefix: String::new(),
+                rw_mode: CacheModeConfig::ReadWrite,
             }),
             disk: Some(DiskCacheConfig {
                 dir: "/env-cache".into(),
@@ -1628,6 +1674,7 @@ fn config_overrides() {
                     connection_string: String::new(),
                     container: String::new(),
                     key_prefix: String::new(),
+                    rw_mode: CacheModeConfig::ReadWrite,
                 }),
                 disk: Some(DiskCacheConfig {
                     dir: "/env-cache".into(),
@@ -1852,6 +1899,72 @@ fn test_deserialize_basedirs_missing() {
 
     let config: FileConfig = toml::from_str(toml).unwrap();
     assert!(config.basedirs.is_empty());
+}
+
+#[test]
+fn test_cache_mode_from_env_var() {
+    struct CacheEnvCheckInfo {
+        env_var_value: Option<String>,
+        expected_cache_mode: Option<CacheModeConfig>,
+    }
+
+    let env_check_infos = vec![
+        CacheEnvCheckInfo {
+            env_var_value: None,
+            expected_cache_mode: None,
+        },
+        CacheEnvCheckInfo {
+            env_var_value: Some(String::new()),
+            expected_cache_mode: None,
+        },
+        CacheEnvCheckInfo {
+            env_var_value: Some("read_only".to_string()),
+            expected_cache_mode: Some(CacheModeConfig::ReadOnly),
+        },
+        CacheEnvCheckInfo {
+            env_var_value: Some("read_write".to_string()),
+            expected_cache_mode: Some(CacheModeConfig::ReadWrite),
+        },
+        CacheEnvCheckInfo {
+            env_var_value: Some("ReAd_ONly".to_string()),
+            expected_cache_mode: Some(CacheModeConfig::ReadOnly),
+        },
+        CacheEnvCheckInfo {
+            env_var_value: Some("read_WRITE".to_string()),
+            expected_cache_mode: Some(CacheModeConfig::ReadWrite),
+        },
+        CacheEnvCheckInfo {
+            env_var_value: Some("read_only_typo".to_string()),
+            expected_cache_mode: None,
+        },
+        CacheEnvCheckInfo {
+            env_var_value: Some("foo".to_string()),
+            expected_cache_mode: None,
+        },
+        CacheEnvCheckInfo {
+            env_var_value: Some("any_unsupported_value".to_string()),
+            expected_cache_mode: None,
+        },
+    ];
+
+    let var_name = "SCCACHE_ANY_CACHE_MODE_ENV_VAR";
+
+    for info in env_check_infos {
+        unsafe {
+            if let Some(env_var_value) = &info.env_var_value {
+                std::env::set_var(var_name, env_var_value);
+            } else {
+                std::env::remove_var(var_name);
+            }
+        }
+        let cache_mode = cache_mode_from_env_var(var_name);
+
+        unsafe {
+            std::env::remove_var(var_name);
+        }
+
+        assert_eq!(cache_mode, info.expected_cache_mode);
+    }
 }
 
 #[test]
@@ -2273,6 +2386,7 @@ use_ssl = true
 key_prefix = "s3prefix"
 no_credentials = true
 server_side_encryption = false
+rw_mode = "READ_WRITE"
 
 [cache.webdav]
 endpoint = "http://127.0.0.1:8080"
@@ -2286,6 +2400,7 @@ bucket = "name"
 endpoint = "oss-us-east-1.aliyuncs.com"
 key_prefix = "ossprefix"
 no_credentials = true
+rw_mode = "READ_ONLY"
 
 [cache.cos]
 bucket = "name"
@@ -2315,7 +2430,9 @@ key_prefix = "cosprefix"
                 }),
                 gha: Some(GHACacheConfig {
                     enabled: true,
-                    version: "sccache".to_string()
+                    version: "sccache".to_string(),
+
+                    rw_mode: CacheModeConfig::ReadWrite,
                 }),
                 redis: Some(RedisCacheConfig {
                     url: Some("redis://user:passwd@1.2.3.4:6379/?db=1".to_owned()),
@@ -2326,6 +2443,7 @@ key_prefix = "cosprefix"
                     db: 12,
                     ttl: 24 * 3600,
                     key_prefix: "/my/redis/cache".into(),
+                    rw_mode: CacheModeConfig::ReadWrite,
                 }),
                 memcached: Some(MemcachedCacheConfig {
                     url: "tcp://127.0.0.1:11211".to_owned(),
@@ -2333,6 +2451,7 @@ key_prefix = "cosprefix"
                     password: Some("passwd".to_owned()),
                     expiration: 25 * 3600,
                     key_prefix: "/custom/prefix/if/need".into(),
+                    rw_mode: CacheModeConfig::ReadWrite,
                 }),
                 s3: Some(S3CacheConfig {
                     bucket: "name".to_owned(),
@@ -2343,6 +2462,7 @@ key_prefix = "cosprefix"
                     no_credentials: true,
                     server_side_encryption: Some(false),
                     enable_virtual_host_style: None,
+                    rw_mode: CacheModeConfig::ReadWrite,
                 }),
                 webdav: Some(WebdavCacheConfig {
                     endpoint: "http://127.0.0.1:8080".to_string(),
@@ -2350,17 +2470,20 @@ key_prefix = "cosprefix"
                     username: Some("webdavusername".to_string()),
                     password: Some("webdavpassword".to_string()),
                     token: Some("webdavtoken".to_string()),
+                    rw_mode: CacheModeConfig::ReadWrite,
                 }),
                 oss: Some(OSSCacheConfig {
                     bucket: "name".to_owned(),
                     endpoint: Some("oss-us-east-1.aliyuncs.com".to_owned()),
                     key_prefix: "ossprefix".into(),
                     no_credentials: true,
+                    rw_mode: CacheModeConfig::ReadOnly,
                 }),
                 cos: Some(COSCacheConfig {
                     bucket: "name".to_owned(),
                     endpoint: Some("cos.na-siliconvalley.myqcloud.com".to_owned()),
                     key_prefix: "cosprefix".into(),
+                    rw_mode: CacheModeConfig::ReadWrite,
                 }),
                 multilevel: None,
             },
@@ -2818,6 +2941,7 @@ fn test_get_cache_levels_single_cache() {
             use_ssl: None,
             server_side_encryption: None,
             enable_virtual_host_style: None,
+            rw_mode: CacheModeConfig::ReadWrite,
         }),
         ..Default::default()
     };


### PR DESCRIPTION
For the local developers we want to provide the access to the remote cache server in read-only mode.

So, this PR allows read-only access to read-write storages via per-storage specific flag