### PR TITLE
dist: skip stale cert when rebuilding scheduler HTTP client

### DIFF
--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -742,14 +742,19 @@ mod server {
                     server_id.addr()
                 );
                 let mut client_builder = reqwest::blocking::ClientBuilder::new();
-                // Add all the certificates we know about
+                // Add the new/updated certificate for this server
                 client_builder = client_builder.add_root_certificate(
                     reqwest::Certificate::from_pem(&cert_pem)
                         .context("failed to interpret pem as certificate")?,
                 );
-                for (_, cert_pem) in certs.values() {
+                // Add all OTHER existing certificates (skip the one we're updating)
+                for (sid, (_, existing_cert_pem)) in certs.iter() {
+                    if sid == &server_id {
+                        continue;
+                    }
                     client_builder = client_builder.add_root_certificate(
-                        reqwest::Certificate::from_pem(cert_pem).expect("previously valid cert"),
+                        reqwest::Certificate::from_pem(existing_cert_pem)
+                            .expect("previously valid cert"),
                     );
                 }
                 // Finish the client


### PR DESCRIPTION
When a build server registers with a new certificate, the scheduler rebuilds its outbound reqwest client with the new cert plus every other cert it knows about. The loop over `certs.values()` ran before `certs.insert(...)` overwrote the map entry, so it still contained the stale cert for the same `server_id` — meaning both the old and new self-signed certs for that server were installed as trust anchors in the rebuilt client.

Each build server's cert is self-signed, so old and new share a Subject DN. TLS validators index trust anchors by Subject; with two anchors having the same name, path building can pick the stale one, fail signature verification against its public key, and reject the handshake. The result is that cert rotation on a build server deterministically breaks the scheduler's ability to talk to it until the scheduler restarts.

Skip the entry matching `server_id` when iterating existing certs so only the up-to-date cert for that server ends up as a trust anchor.

We've been running with this change since mid December and it's fixed this problem for us.