### PR TITLE
fix: add newline when printing dist-status to stdout

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -757,6 +757,7 @@ pub fn run_command(cmd: Command) -> Result<i32> {
             let status =
                 request_dist_status(srv).context("failed to get dist-status from server")?;
             serde_json::to_writer(&mut io::stdout(), &status)?;
+            println!();
         }
         #[cfg(feature = "dist-client")]
         Command::PackageToolchain(executable, out) => {


### PR DESCRIPTION
Very simple PR, allowing users to do `sccache dist-status` without messing up their shell, since a command is expected to send a newline after each line

<img width="1005" height="48" alt="image" src="https://github.com/user-attachments/assets/43db02ff-5322-4d4f-a496-cefdaf48aaec" />
