### PR TITLE
chore: encode jwt key and cert digest with base64 in logs

### DIFF
--- a/src/dist/http.rs
+++ b/src/dist/http.rs
@@ -24,10 +24,9 @@ mod common {
     use reqwest::header;
     use serde::{Deserialize, Serialize};
     #[cfg(feature = "dist-server")]
-    use std::collections::HashMap;
+    use {crate::util::BASE64_URL_SAFE_ENGINE, base64::Engine, std::collections::HashMap};
 
     use crate::dist;
-
     use crate::errors::*;
 
     // Note that content-length is necessary due to https://github.com/tiny-http/tiny-http/issues/147
@@ -154,25 +153,17 @@ mod common {
     }
 
     #[cfg(feature = "dist-server")]
-    // cert_pem is quite long so elide it (you can retrieve it by hitting the server url anyway)
     impl std::fmt::Debug for HeartbeatServerHttpRequest {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            let HeartbeatServerHttpRequest {
-                jwt_key,
-                num_cpus,
-                server_nonce,
-                cert_digest,
-                cert_pem,
-            } = self;
-            write!(
-                f,
-                "HeartbeatServerHttpRequest {{ jwt_key: {:?}, num_cpus: {:?}, server_nonce: {:?}, cert_digest: {:?}, cert_pem: [...{} bytes...] }}",
-                jwt_key,
-                num_cpus,
-                server_nonce,
-                cert_digest,
-                cert_pem.len()
-            )
+            f.debug_struct("HeartbeatServerHttpRequest")
+                .field("jwt_key", &BASE64_URL_SAFE_ENGINE.encode(&self.jwt_key))
+                .field("num_cpus", &self.num_cpus)
+                .field("server_nonce", &self.server_nonce)
+                .field(
+                    "cert_digest",
+                    &BASE64_URL_SAFE_ENGINE.encode(&self.cert_digest),
+                )
+                .finish()
         }
     }
     #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Really small PR, just thought jwt_key and cert_digest were taking too much space in logs, and could easily be reduced by encoding them in base64. I also removed cert_pem, since it showed as `cert_pem: [...1058 bytes...] `

Before:
```
[2026-05-17T00:18:09Z TRACE sccache_heartbeat] Req 0: heartbeat_server: HeartbeatServerHttpRequest { jwt_key: [25, 54, 10, 14, 31, 226, 31, 242, 7, 245, 8, 116, 18, 112, 251, 219, 200, 173, 157, 132, 108, 116, 68, 57, 228, 213, 30, 81, 76, 182, 10, 72], num_cpus: 12, server_nonce: ServerNonce(11202272517116080065), cert_digest: [102, 111, 244, 156, 4, 40, 162, 175, 129, 80, 176, 154, 64, 5, 36, 208, 126, 204, 96, 10, 0, 192, 151, 126, 156, 4, 50, 72, 83, 155, 2, 220], cert_pem: [...1050 bytes...] }
```

After:
```
[2026-05-17T00:14:58Z TRACE sccache_heartbeat] Req 1: heartbeat_server: HeartbeatServerHttpRequest { jwt_key: "5Gg6mVLJNGeMU1LvKI7KLOewxFlz1GI_Ef6NAieeHYI", num_cpus: 12, server_nonce: ServerNonce(15425886545403093633), cert_digest: "pc89Scum-6zejZQIOEY-UTPXbnV2DWHQ4exPoddCDqg" }
```
