### PR TITLE
feat: show individual build servers capacity in --dist-status

### DIFF
--- a/docs/DistributedQuickstart.md
+++ b/docs/DistributedQuickstart.md
@@ -143,6 +143,8 @@ You can check the status with `sccache --dist-status`, it should say something l
 
 ```
 $ sccache --dist-status
+{"SchedulerStatus":["https://sccache1.corpdmz.ber3.mozilla.com/",{"num_servers":3,"num_cpus":56,"in_progress":24,"servers":[{"address":"10.0.0.1:10501","num_cpus":16,"in_progress":8},{"address":"10.0.0.2:10501","num_cpus":20,"in_progress":8},{"address":"10.0.0.3:10501","num_cpus":20,"in_progress":8}]}]}
+```
 {"SchedulerStatus":["https://sccache1.corpdmz.ber3.mozilla.com/",{"num_servers":3,"num_cpus":56,"in_progress":24}]}
 ```
 

--- a/src/bin/sccache-dist/main.rs
+++ b/src/bin/sccache-dist/main.rs
@@ -740,10 +740,20 @@ impl SchedulerIncoming for Scheduler {
 
         self.prune_servers(&mut servers, &mut jobs);
 
+        let server_list: Vec<dist::BuildServerStatus> = servers
+            .iter()
+            .map(|(server_id, details)| dist::BuildServerStatus {
+                address: server_id.addr().to_string(),
+                num_cpus: details.num_cpus,
+                in_progress: details.jobs_assigned.len(),
+            })
+            .collect();
+
         Ok(SchedulerStatusResult {
             num_servers: servers.len(),
             num_cpus: servers.values().map(|v| v.num_cpus).sum(),
             in_progress: jobs.len(),
+            servers: server_list,
         })
     }
 }

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -583,10 +583,19 @@ pub struct JobComplete {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct BuildServerStatus {
+    pub address: String,
+    pub num_cpus: usize,
+    pub in_progress: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SchedulerStatusResult {
     pub num_servers: usize,
     pub num_cpus: usize,
     pub in_progress: usize,
+    pub servers: Vec<BuildServerStatus>,
 }
 
 // SubmitToolchain

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -176,6 +176,40 @@ fn test_dist_restartedserver() {
 
 #[test]
 #[cfg_attr(not(feature = "dist-tests"), ignore)]
+fn test_dist_scheduler_status_servers() {
+    let tmpdir = tempfile::Builder::new()
+        .prefix("sccache_dist_test")
+        .tempdir()
+        .unwrap();
+    let tmpdir = tmpdir.path();
+    let sccache_dist = harness::sccache_dist_path();
+
+    let mut system = harness::DistSystem::new(&sccache_dist, tmpdir);
+    system.add_scheduler();
+    system.add_server();
+
+    let sccache_cfg = dist_test_sccache_client_cfg(tmpdir, system.scheduler_url());
+    let sccache_cfg_path = tmpdir.join("sccache-cfg.json");
+    write_json_cfg(tmpdir, "sccache-cfg.json", &sccache_cfg);
+    let sccache_cached_cfg_path = tmpdir.join("sccache-cached-cfg");
+
+    stop_local_daemon();
+    start_local_daemon(&sccache_cfg_path, &sccache_cached_cfg_path);
+
+    let status = system.get_scheduler_status();
+    assert_eq!(status.num_servers, 1);
+    assert!(status.num_cpus > 0);
+    assert_eq!(status.in_progress, 0);
+    assert_eq!(status.servers.len(), 1);
+
+    let server = &status.servers[0];
+    assert!(!server.address.is_empty());
+    assert!(server.num_cpus > 0);
+    assert_eq!(server.in_progress, 0);
+}
+
+#[test]
+#[cfg_attr(not(feature = "dist-tests"), ignore)]
 fn test_dist_nobuilder() {
     let tmpdir = tempfile::Builder::new()
         .prefix("sccache_dist_test")

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -359,14 +359,15 @@ impl DistSystem {
         wait_for_http(scheduler_url, Duration::from_millis(100), MAX_STARTUP_WAIT);
         wait_for(
             || {
-                let status = self.scheduler_status();
+                let status = self.get_scheduler_status();
                 if matches!(
                     status,
                     SchedulerStatusResult {
                         num_servers: 0,
                         num_cpus: _,
-                        in_progress: 0
-                    }
+                        in_progress: 0,
+                        ref servers
+                    } if servers.is_empty()
                 ) {
                     Ok(())
                 } else {
@@ -533,15 +534,14 @@ impl DistSystem {
         wait_for_http(url, Duration::from_millis(100), MAX_STARTUP_WAIT);
         wait_for(
             || {
-                let status = self.scheduler_status();
-                if matches!(
-                    status,
-                    SchedulerStatusResult {
-                        num_servers: 1,
-                        num_cpus: _,
-                        in_progress: 0
-                    }
-                ) {
+                let status = self.get_scheduler_status();
+                if let SchedulerStatusResult {
+                    num_servers: 1,
+                    num_cpus: _,
+                    in_progress: 0,
+                    servers: _,
+                } = &status
+                {
                     Ok(())
                 } else {
                     Err(format!("{:?}", status))
@@ -557,7 +557,7 @@ impl DistSystem {
         HTTPUrl::from_url(reqwest::Url::parse(&url).unwrap())
     }
 
-    fn scheduler_status(&self) -> SchedulerStatusResult {
+    pub fn get_scheduler_status(&self) -> SchedulerStatusResult {
         let res = reqwest::blocking::get(dist::http::urls::scheduler_status(
             &self.scheduler_url().to_url(),
         ))


### PR DESCRIPTION
This PR adds a field `servers` to the status returned by the scheduler, and subsequently to the JSON returned by `sccache --dist-status`. The primary benefit of this (for me) is to have a `in_progress` status per-server, which can be useful for the user to have a view of his compilation cluster.

I plan to submit a PR to add Prometheus metrics to the scheduler/build servers later, which would include this information among other, so I'd understand if you closed this PR (although I still see avalue in being able to quickly tell which servers are being scheduled atm)

New JSON:
```json
{
  "SchedulerStatus": [
    "https://sccache.example.com",
    {
      "num_servers": 5,
      "num_cpus": 60,
      "in_progress": 0,
      "servers": [
        {
          "address": "1.1.1.1:8080",
          "num_cpus": 12,
          "in_progress": 0
        },
        {
          "address": "2.1.1.1:8080",
          "num_cpus": 12,
          "in_progress": 0
        },
        {
          "address": "3.1.1.1:8080",
          "num_cpus": 12,
          "in_progress": 0
        },
        {
          "address": "4.1.1.1:8080",
          "num_cpus": 12,
          "in_progress": 0
        },
        {
          "address": "5.1.1.1:8080",
          "num_cpus": 12,
          "in_progress": 0
        }
      ]
    }
  ]
}
```