### PR TITLE
Minimize thread numbers for the client

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -21,7 +21,7 @@ use crate::jobserver::Client;
 use crate::mock_command::{CommandChild, CommandCreatorSync, ProcessCommandCreator, RunCommand};
 use crate::protocol::{Compile, CompileFinished, CompileResponse, Request, Response};
 use crate::server::{self, DistInfo, ServerInfo, ServerStartup, ServerStats};
-use crate::util::daemonize;
+use crate::util::{daemonize, num_cpus};
 use byteorder::{BigEndian, ByteOrder};
 use fs::{File, OpenOptions};
 use fs_err as fs;
@@ -808,7 +808,10 @@ pub fn run_command(cmd: Command) -> Result<i32> {
 
             let jobserver = Client::new();
             let conn = connect_or_start_server(&get_addr(), startup_timeout)?;
-            let mut runtime = Runtime::new()?;
+            let mut runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(std::cmp::min(4, num_cpus()))
+                .enable_all()
+                .build()?;
             let res = do_compile(
                 ProcessCommandCreator::new(&jobserver),
                 &mut runtime,


### PR DESCRIPTION
Minimize thread numbers for the client, its querying only after all.

This commit doesn't try to limit the thread size to 1. I was worried that there might be some hidden interacts that might lead to deadlock but would be very glad to be enlightened on this

