### PR TITLE
Add -fno-cxx-modules to clang's known -Xclang flags

### DIFF
--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -212,6 +212,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("-fmodule-output", OsString, Concatenated, ClangModuleOutput),
     flag!("-fmodules-reduced-bmi", PassThroughFlag),
     flag!("-fno-color-diagnostics", NoDiagnosticsColorFlag),
+    flag!("-fno-cxx-modules", PassThroughFlag),
     flag!("-fno-pch-timestamp", PassThroughFlag),
     flag!("-fno-profile-instr-generate", TooHardFlag),
     flag!("-fno-profile-instr-use", TooHardFlag),

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -212,6 +212,7 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("-fmodule-output", OsString, Concatenated, ClangModuleOutput),
     flag!("-fmodules-reduced-bmi", PassThroughFlag),
     flag!("-fno-color-diagnostics", NoDiagnosticsColorFlag),
+    flag!("-fno-cxx-modules", PassThroughFlag),
     flag!("-fno-pch-timestamp", PassThroughFlag),
     flag!("-fno-profile-instr-generate", TooHardFlag),
     flag!("-fno-profile-instr-use", TooHardFlag),
@@ -929,6 +930,19 @@ mod test {
             "-no-opaque-pointers"
         );
         assert_eq!(ovec!["-Xclang", "-no-opaque-pointers"], a.preprocessor_args);
+    }
+
+    #[test]
+    fn test_parse_xclang_fno_cxx_modules() {
+        let a = parses!(
+            "-c",
+            "foo.c",
+            "-o",
+            "foo.o",
+            "-Xclang",
+            "-fno-cxx-modules"
+        );
+        assert_eq!(ovec!["-Xclang", "-fno-cxx-modules"], a.common_args);
     }
 
     #[test]

--- a/src/compiler/clang.rs
+++ b/src/compiler/clang.rs
@@ -934,14 +934,7 @@ mod test {
 
     #[test]
     fn test_parse_xclang_fno_cxx_modules() {
-        let a = parses!(
-            "-c",
-            "foo.c",
-            "-o",
-            "foo.o",
-            "-Xclang",
-            "-fno-cxx-modules"
-        );
+        let a = parses!("-c", "foo.c", "-o", "foo.o", "-Xclang", "-fno-cxx-modules");
         assert_eq!(ovec!["-Xclang", "-fno-cxx-modules"], a.common_args);
     }
 


### PR DESCRIPTION
Downstream Bazel's C++ toolchain passes `-Xclang -fno-cxx-modules` in its compiler sanity checks. Since -fno-cxx-modules wasn't in sccache's known flag list, the xclang argument parser in gcc.rs treated it as an UnknownFlag and bailed with CannotCache.