### PR TITLE
fix: strip SCCACHE_BASEDIRS from escaped-backslash paths on Windows

### DIFF
--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -1761,6 +1761,42 @@ mod test {
         assert_eq!(h1, hash_with_basedirs(preprocessed1, &multi_basedirs));
     }
 
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_hash_key_basedirs_windows_escaped_backslashes() {
+        // On Windows, paths in preprocessor output are C string literals with
+        // escaped backslashes (e.g. MSVC: #line 1 "D:\\dir\\file.c", clang:
+        // # 1 "D:\\dir\\file.c"). The same source compiled from two different
+        // directories must produce the same hash when both are basedirs.
+        let args = ovec!["a", "b", "c"];
+        let preprocessed1 =
+            b"#line 1 \"D:\\\\dev\\\\user1\\\\project\\\\src\\\\main.c\"\nint main() { return 0; }";
+        let preprocessed2 =
+            b"#line 1 \"E:\\\\work\\\\user2\\\\checkout\\\\src\\\\main.c\"\nint main() { return 0; }";
+        // As normalized by Config: lowercase, forward slashes, trailing slash
+        let basedirs = [
+            b"d:/dev/user1/project/".to_vec(),
+            b"e:/work/user2/checkout/".to_vec(),
+        ];
+
+        let hash_with_basedirs = |output: &[u8], dirs: &[Vec<u8>]| {
+            HashKeyParams::new("abcd", Language::C, &args, output)
+                .with_basedirs(dirs)
+                .compute()
+        };
+
+        // Same hash with different absolute (escaped backslash) paths
+        let h1 = hash_with_basedirs(preprocessed1, &basedirs);
+        let h2 = hash_with_basedirs(preprocessed2, &basedirs);
+        assert_eq!(h1, h2);
+
+        // Different hashes without basedirs
+        assert_neq!(
+            HashKeyParams::new("abcd", Language::C, &args, preprocessed1).compute(),
+            HashKeyParams::new("abcd", Language::C, &args, preprocessed2).compute()
+        );
+    }
+
     #[test]
     fn test_language_from_file_name() {
         fn t(extension: &str, expected: Language) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1754,32 +1754,20 @@ mod tests {
         let input = b"#line 1 \"C:\\\\Users\\\\test\\\\project\\\\src\\\\main.c\"";
         let output = super::strip_basedirs(input, std::slice::from_ref(&basedir));
         let expected = b"#line 1 \"src\\\\main.c\"";
-        assert_eq!(
-            &*output,
-            &expected[..],
-            "Failed to strip basedir from path with escaped backslashes"
-        );
+        assert_eq!(&*output, &expected[..]);
 
         // GNU-style linemarker as emitted by clang on Windows
         let input = b"# 1 \"C:\\\\Users\\\\test\\\\project\\\\include\\\\header.h\" 1\nint x;";
         let output = super::strip_basedirs(input, std::slice::from_ref(&basedir));
         let expected = b"# 1 \"include\\\\header.h\" 1\nint x;";
-        assert_eq!(
-            &*output,
-            &expected[..],
-            "Failed to strip basedir from GNU linemarker with escaped backslashes"
-        );
+        assert_eq!(&*output, &expected[..]);
 
         // Multiple occurrences, plain and escaped forms mixed in one output
         let input =
             b"# 1 \"C:\\\\Users\\\\test\\\\project\\\\a.c\"\n# 2 \"C:/Users/test/project/b.h\"";
         let output = super::strip_basedirs(input, std::slice::from_ref(&basedir));
         let expected = b"# 1 \"a.c\"\n# 2 \"b.h\"";
-        assert_eq!(
-            &*output,
-            &expected[..],
-            "Failed to strip both escaped and plain forms of the basedir"
-        );
+        assert_eq!(&*output, &expected[..]);
     }
 
     #[cfg(target_os = "windows")]
@@ -1791,11 +1779,7 @@ mod tests {
         let input = b"#line 1 \"\\\\\\\\server\\\\share\\\\project\\\\src\\\\main.c\"";
         let output = super::strip_basedirs(input, std::slice::from_ref(&basedir));
         let expected = b"#line 1 \"src\\\\main.c\"";
-        assert_eq!(
-            &*output,
-            &expected[..],
-            "Failed to strip escaped UNC basedir"
-        );
+        assert_eq!(&*output, &expected[..]);
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1096,18 +1096,35 @@ pub fn strip_basedirs<'a>(preprocessor_output: &'a [u8], basedirs: &[Vec<u8>]) -
 
     for (idx, basedir_bytes) in basedirs.iter().enumerate() {
         let basedir = basedir_bytes.as_slice();
-        // Use memchr's fast substring search
-        let finder = memchr::memmem::find_iter(normalized_output, &basedir);
 
-        for pos in finder {
-            // Check if this is a valid boundary (start, whitespace, quote, or '<')
-            let is_boundary = pos == 0
-                || normalized_output[pos - 1].is_ascii_whitespace()
-                || normalized_output[pos - 1] == b'"'
-                || normalized_output[pos - 1] == b'<';
+        // On Windows, preprocessor output quotes paths as C string literals
+        // (#line directives and GNU linemarkers), so backslash separators
+        // appear escaped: `#line 1 "C:\\dir\\file.h"`. normalize_win_path
+        // converts each backslash to a forward slash, which turns every
+        // escaped separator into a DOUBLE forward slash ("c://dir//file.h").
+        // Search for that doubled variant of the basedir as well, otherwise
+        // such paths are never stripped.
+        #[cfg(target_os = "windows")]
+        let doubled_basedir = double_path_separators(basedir);
+        #[cfg(target_os = "windows")]
+        let needles: [&[u8]; 2] = [basedir, &doubled_basedir];
+        #[cfg(not(target_os = "windows"))]
+        let needles: [&[u8]; 1] = [basedir];
 
-            if is_boundary {
-                matches.push((pos, basedir.len(), idx));
+        for needle in needles {
+            // Use memchr's fast substring search
+            let finder = memchr::memmem::find_iter(normalized_output, needle);
+
+            for pos in finder {
+                // Check if this is a valid boundary (start, whitespace, quote, or '<')
+                let is_boundary = pos == 0
+                    || normalized_output[pos - 1].is_ascii_whitespace()
+                    || normalized_output[pos - 1] == b'"'
+                    || normalized_output[pos - 1] == b'<';
+
+                if is_boundary {
+                    matches.push((pos, needle.len(), idx));
+                }
             }
         }
     }
@@ -1152,6 +1169,24 @@ pub fn strip_basedirs<'a>(preprocessor_output: &'a [u8], basedirs: &[Vec<u8>]) -
     result.extend_from_slice(&preprocessor_output[current_pos..]);
 
     Cow::Owned(result)
+}
+
+/// Double every `/` in a normalized path.
+///
+/// Paths inside preprocessor output are C string literals, so on Windows
+/// their backslash separators are escaped (`\\`). After normalize_win_path
+/// each backslash becomes a `/`, i.e. every escaped separator ends up as
+/// `//`. This produces the matching variant of a basedir for such paths.
+#[cfg(target_os = "windows")]
+fn double_path_separators(path: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(path.len() * 2);
+    for &b in path {
+        out.push(b);
+        if b == b'/' {
+            out.push(b'/');
+        }
+    }
+    out
 }
 
 /// Normalize path for case-insensitive comparison.
@@ -1703,6 +1738,63 @@ mod tests {
         assert_eq!(
             &*output, expected,
             "Failed to strip reverse mixed slash path"
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_strip_basedir_windows_escaped_backslashes() {
+        // MSVC (cl -E) and clang on Windows quote paths in #line directives /
+        // GNU linemarkers as C string literals, escaping every backslash:
+        //     #line 1 "C:\\Users\\test\\project\\src\\main.c"
+        // normalize_win_path converts each '\' to '/', so each escaped
+        // separator becomes a DOUBLE forward slash ("c://users//...") and must
+        // still match the basedir (normalized with single slashes).
+        let basedir = b"c:/users/test/project/".to_vec();
+        let input = b"#line 1 \"C:\\\\Users\\\\test\\\\project\\\\src\\\\main.c\"";
+        let output = super::strip_basedirs(input, std::slice::from_ref(&basedir));
+        let expected = b"#line 1 \"src\\\\main.c\"";
+        assert_eq!(
+            &*output,
+            &expected[..],
+            "Failed to strip basedir from path with escaped backslashes"
+        );
+
+        // GNU-style linemarker as emitted by clang on Windows
+        let input = b"# 1 \"C:\\\\Users\\\\test\\\\project\\\\include\\\\header.h\" 1\nint x;";
+        let output = super::strip_basedirs(input, std::slice::from_ref(&basedir));
+        let expected = b"# 1 \"include\\\\header.h\" 1\nint x;";
+        assert_eq!(
+            &*output,
+            &expected[..],
+            "Failed to strip basedir from GNU linemarker with escaped backslashes"
+        );
+
+        // Multiple occurrences, plain and escaped forms mixed in one output
+        let input =
+            b"# 1 \"C:\\\\Users\\\\test\\\\project\\\\a.c\"\n# 2 \"C:/Users/test/project/b.h\"";
+        let output = super::strip_basedirs(input, std::slice::from_ref(&basedir));
+        let expected = b"# 1 \"a.c\"\n# 2 \"b.h\"";
+        assert_eq!(
+            &*output,
+            &expected[..],
+            "Failed to strip both escaped and plain forms of the basedir"
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_strip_basedir_windows_escaped_unc() {
+        // UNC basedir: //server/share/dir/ appears as \\\\server\\share\\dir\\
+        // in escaped form
+        let basedir = b"//server/share/project/".to_vec();
+        let input = b"#line 1 \"\\\\\\\\server\\\\share\\\\project\\\\src\\\\main.c\"";
+        let output = super::strip_basedirs(input, std::slice::from_ref(&basedir));
+        let expected = b"#line 1 \"src\\\\main.c\"";
+        assert_eq!(
+            &*output,
+            &expected[..],
+            "Failed to strip escaped UNC basedir"
         );
     }
 


### PR DESCRIPTION
# fix: strip `SCCACHE_BASEDIRS` from escaped-backslash paths on Windows

Fixes #2737.

## Problem

`SCCACHE_BASEDIRS` has no effect on Windows. The same source compiled
from two different checkout directories produces different cache keys, so
nothing is shared across roots — the feature silently does nothing.

### Root cause

On Windows, paths inside preprocessor output are emitted as **C string
literals**. MSVC `#line` directives and clang GNU linemarkers quote them
with escaped backslash separators:

```
#line 1 "C:\\Users\\me\\project\\src\\main.c"
```

`normalize_win_path` converts every backslash to a forward slash, so each
escaped separator `\\` becomes a **double** forward slash:

```
c://users//me//project//src//main.c
```

But the normalized basedir uses single slashes (`c:/users/me/project/`),
so `strip_basedirs` never finds a boundary match, and the absolute path is
left in the preprocessed output that feeds the hash.

## Fix

In `strip_basedirs`, also search for a doubled-separator variant of each
basedir, produced by a new `double_path_separators` helper. Escaped paths
are now stripped in addition to the existing plain form; mixed
escaped/plain occurrences and UNC basedirs are handled too.

The extra needle and the helper are gated behind
`cfg(target_os = "windows")`, so non-Windows builds and behavior are
unchanged.

## Tests

New unit tests (Windows-only):

- `util::tests::test_strip_basedir_windows_escaped_backslashes` — MSVC
  `#line`, clang linemarker, and mixed escaped/plain occurrences.
- `util::tests::test_strip_basedir_windows_escaped_unc` — escaped UNC
  basedir.
- `compiler::c::test::test_hash_key_basedirs_windows_escaped_backslashes`
  — the same source under two different basedir roots hashes equally, and
  differs without basedirs.

All three fail before the change and pass after. `cargo test --lib`,
`cargo fmt --check`, and `cargo clippy --lib` are clean on the changed
code (the single pre-existing clippy warning in `msvc.rs` is untouched).

### Manual end-to-end verification

Reproduced with real toolchains on Windows: building the same source from
two distinct absolute directories with `SCCACHE_BASEDIRS` set goes from
**0/2** cache hits (unpatched) to **1/2** (patched) for both clang and
MSVC.
