### PR TITLE
Don't panic in get_signal when a finished compile has neither code nor signal

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -130,13 +130,20 @@ fn notify_server_startup(name: Option<&OsString>, status: ServerStartup) -> Resu
 }
 
 #[cfg(unix)]
-fn get_signal(status: ExitStatus) -> i32 {
+fn get_signal(status: ExitStatus) -> Option<i32> {
     use std::os::unix::prelude::*;
-    status.signal().expect("must have signal")
+    // None when the process produced neither an exit code nor a terminating
+    // signal - e.g. an ExitStatus synthesized from a distributed-compile result,
+    // or an abnormal wait status. Previously this was `.expect("must have
+    // signal")`, which panicked the compile task (surfacing as a misleading
+    // "Failed to bind socket") and could be tripped repeatedly under load.
+    status.signal()
 }
 #[cfg(windows)]
-fn get_signal(_status: ExitStatus) -> i32 {
-    panic!("no signals on windows")
+fn get_signal(_status: ExitStatus) -> Option<i32> {
+    // On Windows ExitStatus::code() is always Some, so the signal branch is
+    // never reached; return None rather than panicking.
+    None
 }
 
 pub struct DistClientContainer {
@@ -1461,7 +1468,7 @@ where
 
                         match status.code() {
                             Some(code) => res.retcode = Some(code),
-                            None => res.signal = Some(get_signal(status)),
+                            None => res.signal = get_signal(status),
                         }
 
                         res.stdout = stdout;
@@ -1477,7 +1484,7 @@ where
 
                                 match output.status.code() {
                                     Some(code) => res.retcode = Some(code),
-                                    None => res.signal = Some(get_signal(output.status)),
+                                    None => res.signal = get_signal(output.status),
                                 }
                                 res.stdout = output.stdout;
                                 res.stderr = output.stderr;
@@ -2281,6 +2288,26 @@ fn waits_until_zero() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn test_get_signal_handles_signal_and_abnormal_status() {
+        use std::os::unix::process::ExitStatusExt;
+
+        // Terminated by SIGKILL: a real terminating signal is reported.
+        let killed = ExitStatus::from_raw(9);
+        assert_eq!(killed.code(), None);
+        assert_eq!(get_signal(killed), Some(9));
+
+        // A wait status that is neither a normal exit (code) nor a terminating
+        // signal - here WIFSTOPPED (low byte 0x7f). The same neither-code-nor-
+        // signal shape can arise from an ExitStatus synthesized for a
+        // distributed compile. get_signal must return None, not panic
+        // "must have signal" (which used to crash the in-flight compile task).
+        let abnormal = ExitStatus::from_raw(0x7f);
+        assert_eq!(abnormal.code(), None);
+        assert_eq!(get_signal(abnormal), None);
+    }
 
     struct StringWriter {
         buffer: String,


### PR DESCRIPTION
## Problem

`get_signal` does `status.signal().expect("must have signal")`, assuming the Unix
invariant that an `ExitStatus` with no exit code was terminated by a signal. That
does not always hold. When the server reconstructs an `ExitStatus` for a
distributed compile whose compiler died abnormally, the status can carry neither
an exit code nor a terminating signal, and the `expect()` panics the compile task.

I hit this with `sccache-dist`: when the build server's packaged toolchain fails
to start a compile (e.g. `gcc: error while loading shared libraries: libm.so.6`),
the synthesized status has neither a code nor a signal. The panic crashes the
in-flight task, which the server then surfaces as a misleading
`Failed to bind socket: ... panicked with message "must have signal"`, and under
load it recurs on every such compile.

## Fix

Return `Option<i32>` from `get_signal` and assign it straight into `res.signal`,
so a compile that reports neither a code nor a signal leaves `res.signal` unset
instead of panicking.

This matches the contract the client already implements: `handle_compile_finished`
in `commands.rs` handles the case where both `retcode` and `signal` are `None` by
printing `Missing compiler exit status!` and returning `-3`. The server simply
never reached that path because it panicked first.

The Windows arm returns `None` rather than `panic!`; `ExitStatus::code()` is always
`Some` there, so the signal branch is unreachable anyway.

## Test

Added a unit test covering a real terminating signal (SIGKILL) and the
neither-code-nor-signal case (`WIFSTOPPED` via `ExitStatusExt::from_raw`), which
previously panicked.

With the fix, the same `sccache-dist` scenario now reports `Missing compiler exit
status!` and falls back to local compilation instead of crashing the server.
