### PR TITLE
Fix ToolchainPackager cfg gate to build on ppc64le/s390x

### DIFF
--- a/src/dist/cache.rs
+++ b/src/dist/cache.rs
@@ -302,7 +302,10 @@ mod client {
                 Box::new(PanicToolchainPackager)
             }
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(all(
+            target_os = "linux",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        ))]
         impl crate::dist::pkg::ToolchainPackager for PanicToolchainPackager {
             fn write_pkg(self: Box<Self>, _f: super::fs::File) -> crate::errors::Result<()> {
                 panic!("should not have called packager")


### PR DESCRIPTION
On Linux ppc64le/s390x, the blanket `impl<T: Send> ToolchainPackager for T` in pkg.rs is active (non-x86_64/aarch64 path), but the test-only PanicToolchainPackager impl in cache.rs was gated on only `target_os = "linux"`, causing a conflicting-impl error on those architectures.