### PR TITLE
cmdline: warn instead of recursing when invoked as a non-sccache name that is sccache itself

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -231,7 +231,21 @@ pub fn try_parse() -> Result<Command> {
                             Ok(full_path) => args[0] = full_path.into(),
                             Err(_) => {}
                         }
-                        args.insert(0, env!("CARGO_PKG_NAME").into());
+
+                        // If $name resolves back to sccache itself, masquerading would
+                        // make it wrap itself and recurse forever (`<compiler> -vV`). Warn
+                        // and run as plain sccache instead of prepending the name.
+                        if PathBuf::from(&args[0]).canonicalize().ok()
+                            == env::current_exe().ok().and_then(|p| p.canonicalize().ok())
+                        {
+                            warn!(
+                                "sccache invoked as `{}`, which resolves to sccache itself; running as sccache (put a real `{}` on PATH to wrap it)",
+                                exe.display(),
+                                exe_filename.to_string_lossy()
+                            );
+                        } else {
+                            args.insert(0, env!("CARGO_PKG_NAME").into());
+                        }
                     }
                 }
             }

--- a/tests/sccache_args.rs
+++ b/tests/sccache_args.rs
@@ -57,6 +57,33 @@ fn test_gcp_arg_check() -> Result<()> {
     Ok(())
 }
 
+/// Running the sccache binary under a name that is not `sccache` and is not a
+/// real compiler on PATH must NOT make sccache wrap itself (which used to recurse
+/// forever via the `<compiler> -vV` detection probe). It should warn and behave
+/// as a normal sccache invocation instead. The test timeout guards the old hang.
+#[cfg(unix)]
+#[test]
+fn test_masquerade_as_self_warns_instead_of_recursing() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir()?;
+    // A name that is not `sccache` and (almost certainly) not on PATH.
+    let masquerade = tmp.path().join("notacompiler");
+    std::fs::copy(SCCACHE_BIN.as_os_str(), &masquerade)?;
+    std::fs::set_permissions(&masquerade, std::fs::Permissions::from_mode(0o755))?;
+
+    let mut cmd = Command::new(&masquerade);
+    cmd.arg("--version").env("SCCACHE_LOG", "warn");
+    cmd.assert()
+        .success()
+        // It ran as sccache (printed the version) ...
+        .stdout(predicate::str::contains("sccache"))
+        // ... after warning that the name resolved back to sccache itself.
+        .stderr(predicate::str::contains("resolves to sccache itself"));
+
+    Ok(())
+}
+
 #[test]
 #[serial]
 #[cfg(feature = "s3")]


### PR DESCRIPTION


When sccache is run under a name other than `sccache`, it acts as a compiler masquerade and prepends `sccache` to argv. If that name resolves back to the sccache binary itself (no real compiler of that name on PATH), the prepend made sccache wrap itself, and the `<compiler> -vV` rustc-detection probe re-entered the same path under the same name -- recursing forever and spawning a server-side process per core (a fork bomb that just hangs). Seen when an sccache binary was installed at a path whose filename was not `sccache`.

Detect that case and warn, running as a normal sccache invocation instead of prepending the name. Add an integration test that runs the binary under a non-sccache, non-PATH name and asserts it warns and behaves as sccache rather than hanging.