### PR TITLE
fall back locally on server connection/startup failures

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -568,7 +568,7 @@ where
 /// or produced by a local `SccacheService` in client-side mode.
 #[allow(clippy::too_many_arguments)]
 fn handle_compile_result<T>(
-    mut creator: T,
+    creator: T,
     runtime: &mut Runtime,
     response: CompileResponse,
     finished: Option<CompileFinished>,
@@ -597,6 +597,19 @@ where
         }
     }
 
+    run_compiler_locally(creator, runtime, exe, cmdline, cwd)
+}
+
+fn run_compiler_locally<T>(
+    mut creator: T,
+    runtime: &mut Runtime,
+    exe: &Path,
+    cmdline: Vec<OsString>,
+    cwd: &Path,
+) -> Result<i32>
+where
+    T: CommandCreatorSync,
+{
     let mut cmd = creator.new_command_sync(exe);
     cmd.args(&cmdline).current_dir(cwd);
     if log_enabled!(Trace) {
@@ -906,7 +919,26 @@ pub fn run_command(cmd: Command) -> Result<i32> {
                 });
 
             let jobserver = Client::new();
-            let conn = connect_or_start_server(&get_addr(), startup_timeout)?;
+            let conn = match connect_or_start_server(&get_addr(), startup_timeout) {
+                Ok(conn) => conn,
+                Err(error) if ignore_all_server_io_errors() => {
+                    eprintln!(
+                        "sccache: warning: failed to connect to or start server, \
+                         compiling locally instead: {error:#}"
+                    );
+                    let mut runtime = new_client_runtime()?;
+                    let exe = which_in(Path::new(&exe), env::var_os("PATH"), &cwd)?;
+                    return run_compiler_locally(
+                        ProcessCommandCreator::new(&jobserver),
+                        &mut runtime,
+                        &exe,
+                        cmdline,
+                        &cwd,
+                    )
+                    .context("failed to execute compiler locally");
+                }
+                Err(error) => return Err(error),
+            };
             if config.client_side_mode {
                 // Under make -jN each CLI process gets only 2 worker threads;
                 // one for preprocessing/compilation and one for IPC.  The

--- a/tests/sccache_args.rs
+++ b/tests/sccache_args.rs
@@ -14,6 +14,55 @@ use std::process::Command;
 #[macro_use]
 extern crate log;
 
+#[cfg(unix)]
+fn command_with_server_start_failure() -> Result<(tempfile::TempDir, Command)> {
+    let tempdir = tempfile::tempdir()?;
+    let config = tempdir.path().join("config");
+    std::fs::write(&config, "")?;
+
+    let mut command = Command::new(SCCACHE_BIN.as_os_str());
+    command
+        .args(["rustc", "--version"])
+        .current_dir(tempdir.path())
+        .env("SCCACHE_CONF", config)
+        .env("SCCACHE_DIR", tempdir.path().join("cache"))
+        .env_remove("SCCACHE_IGNORE_SERVER_IO_ERROR")
+        // Force server start to fail with an overlong unix domain socket.
+        .env("SCCACHE_SERVER_UDS", "x".repeat(4096));
+
+    Ok((tempdir, command))
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn test_server_start_failure_falls_back() -> Result<()> {
+    let (_tempdir, mut command) = command_with_server_start_failure()?;
+
+    command
+        .env("SCCACHE_IGNORE_SERVER_IO_ERROR", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with("rustc "))
+        .stderr(predicate::str::contains("compiling locally instead"));
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn test_server_start_failure_errors() -> Result<()> {
+    let (_tempdir, mut command) = command_with_server_start_failure()?;
+
+    command
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("sccache: error"));
+
+    Ok(())
+}
+
 #[test]
 #[serial]
 #[cfg(feature = "gcs")]


### PR DESCRIPTION
README.md states:

> To have sccache instead gracefully failover to the local compiler without stopping, set the environment variable `SCCACHE_IGNORE_SERVER_IO_ERROR=1`.

This patch extends this behavior to failures that happen during connect_or_start_server.