### PR TITLE
Switch to etecetra & support XDG on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,27 +741,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.61.1",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +829,16 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1607,16 +1596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
-dependencies = [
- "bitflags 2.9.4",
- "libc",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,12 +1964,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-multimap"
@@ -2453,17 +2426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.11",
- "libredox",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2902,9 +2864,9 @@ dependencies = [
  "clap",
  "codspeed-divan-compat",
  "daemonix",
- "directories",
  "encoding_rs",
  "env_logger",
+ "etcetera",
  "filetime",
  "flate2",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,9 +52,9 @@ byteorder = "1.5"
 bytes = "1"
 chrono = "0.4"
 clap = { version = "4.5.13", features = ["derive", "env", "wrap_help"] }
-directories = "6.0"
 encoding_rs = "0.8"
 env_logger = "0.11"
+etcetera = "0.11"
 filetime = "0.2"
 flate2 = { version = "1.0", optional = true, default-features = false, features = [
   "rust_backend",

--- a/docs/Local.md
+++ b/docs/Local.md
@@ -1,6 +1,6 @@
 # Local
 
-sccache defaults to using local disk storage. You can set the `SCCACHE_DIR` environment variable to change the disk cache location. By default it will use a sensible location for the current platform: `~/.cache/sccache` on Linux, `%LOCALAPPDATA%\Mozilla\sccache` on Windows, and `~/Library/Caches/Mozilla.sccache` on MacOS.
+sccache defaults to using local disk storage. You can set the `SCCACHE_DIR` environment variable to change the disk cache location. By default it will use a sensible location for the current platform: `~/.cache/sccache` on Linux, `%LOCALAPPDATA%\Mozilla\sccache\cache` on Windows, and `~/.cache/sccache` on MacOS.
 
 The default cache size is 10 gigabytes. To change this, set `SCCACHE_CACHE_SIZE`, for example `SCCACHE_CACHE_SIZE="1G"`.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,9 @@
 use crate::cache::CacheMode;
 #[cfg(target_os = "windows")]
 use crate::util::normalize_win_path;
-use directories::ProjectDirs;
+#[cfg(target_os = "macos")]
+use etcetera::app_strategy::Apple;
+use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, choose_app_strategy};
 use fs::File;
 use fs_err as fs;
 #[cfg(any(feature = "dist-client", feature = "dist-server"))]
@@ -97,20 +99,46 @@ const TEN_GIGS: u64 = 10 * 1024 * 1024 * 1024;
 
 pub const INSECURE_DIST_CLIENT_TOKEN: &str = "dangerously_insecure_client";
 
+fn app_strategy_args(app_name: &str) -> AppStrategyArgs {
+    AppStrategyArgs {
+        top_level_domain: String::new(),
+        author: ORGANIZATION.to_owned(),
+        app_name: app_name.to_owned(),
+    }
+}
+
+// Windows known-folder conventions on Windows, XDG everywhere else.
+fn app_strategy(app_name: &str) -> impl AppStrategy {
+    choose_app_strategy(app_strategy_args(app_name))
+        .expect("Unable to determine application directories")
+}
+
+// Legacy `~/Library` locations used by the old `directories` crate on macOS.
+#[cfg(target_os = "macos")]
+fn legacy_macos_strategy(app_name: &str) -> Apple {
+    Apple::new(app_strategy_args(app_name)).expect("Unable to determine application directories")
+}
+
+// Prefer the legacy macOS cache dir if it already exists, else the new one.
+fn default_cache_dir(app_name: &str) -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        let legacy_path = legacy_macos_strategy(app_name).cache_dir();
+        if legacy_path.exists() {
+            return legacy_path;
+        }
+    }
+    app_strategy(app_name).cache_dir()
+}
+
 // Unfortunately this means that nothing else can use the sccache cache dir as
 // this top level directory is used directly to store sccache cached objects...
 pub fn default_disk_cache_dir() -> PathBuf {
-    ProjectDirs::from("", ORGANIZATION, APP_NAME)
-        .expect("Unable to retrieve disk cache directory")
-        .cache_dir()
-        .to_owned()
+    default_cache_dir(APP_NAME)
 }
 // ...whereas subdirectories are used of this one
 pub fn default_dist_cache_dir() -> PathBuf {
-    ProjectDirs::from("", ORGANIZATION, DIST_APP_NAME)
-        .expect("Unable to retrieve dist cache directory")
-        .cache_dir()
-        .to_owned()
+    default_cache_dir(DIST_APP_NAME)
 }
 
 fn default_disk_cache_size() -> u64 {
@@ -1233,27 +1261,23 @@ fn config_from_env() -> Result<EnvConfig> {
     })
 }
 
-// The directories crate changed the location of `config_dir` on macos in version 3,
-// so we also check the config in `preference_dir` (new in that version), which
-// corresponds to the old location, for compatibility with older setups.
 fn config_file(env_var: &str, leaf: &str) -> PathBuf {
     if let Some(env_value) = env::var_os(env_var) {
         return env_value.into();
     }
-    let dirs =
-        ProjectDirs::from("", ORGANIZATION, APP_NAME).expect("Unable to get config directory");
-    // If the new location exists, use that.
-    let path = dirs.config_dir().join(leaf);
-    if path.exists() {
-        return path;
+    // Prefer the legacy macOS config dirs if they already exist. The old
+    // `directories` crate used Application Support (Apple's `data_dir`) and,
+    // for older versions, Preferences (Apple's `config_dir`).
+    #[cfg(target_os = "macos")]
+    {
+        let legacy = legacy_macos_strategy(APP_NAME);
+        for legacy_path in [legacy.in_data_dir(leaf), legacy.in_config_dir(leaf)] {
+            if legacy_path.exists() {
+                return legacy_path;
+            }
+        }
     }
-    // If the old location exists, use that.
-    let path = dirs.preference_dir().join(leaf);
-    if path.exists() {
-        return path;
-    }
-    // Otherwise, use the new location.
-    dirs.config_dir().join(leaf)
+    app_strategy(APP_NAME).in_config_dir(leaf)
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]


### PR DESCRIPTION
The directories crate is unmaintained, so switching to etcetera which also provides an easy way to support XDG paths on macOS which are usually preferred for CLI applications (while maintaining backwards compatibility).