### PR TITLE
Make gcc diagnostics color output work the same as for rustc

### DIFF
--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -545,7 +545,11 @@ where
             Some(s) if s.len() == 2 => NormalizedDisposition::Concatenated,
             _ => NormalizedDisposition::Separated,
         };
-        args.extend(arg.normalize(norm).iter_os_strings());
+
+        match arg.get_data() {
+            Some(DiagnosticsColor(_)) | Some(DiagnosticsColorFlag) => {}
+            _ => args.extend(arg.normalize(norm).iter_os_strings()),
+        }
     }
 
     let xclang_it = ExpandIncludeFile::new(cwd, &xclangs);
@@ -971,6 +975,10 @@ where
     arguments.extend_from_slice(&parsed_args.unhashed_args);
     arguments.extend_from_slice(&parsed_args.common_args);
     arguments.extend_from_slice(&parsed_args.arch_args);
+
+    if matches!(parsed_args.color_mode, ColorMode::On | ColorMode::Auto) {
+        arguments.push("-fdiagnostics-color=always".into());
+    }
     if parsed_args.double_dash_input {
         arguments.push("--".into());
     }
@@ -1919,7 +1927,7 @@ mod test {
             o => panic!("Got unexpected parse result: {:?}", o),
         };
 
-        assert!(args.common_args.contains(&"-fdiagnostics-color".into()));
+        assert!(!args.common_args.contains(&"-fdiagnostics-color".into()));
     }
 
     #[test]
@@ -2617,7 +2625,16 @@ mod test {
             language_to_gcc_arg,
         )
         .unwrap();
-        let expected_args = ovec!["-x", "c", "-c", "-o", "foo.o", "--", "foo.c"];
+        let expected_args = ovec![
+            "-x",
+            "c",
+            "-c",
+            "-o",
+            "foo.o",
+            "-fdiagnostics-color=always",
+            "--",
+            "foo.c"
+        ];
         assert_eq!(command.get_arguments(), expected_args);
     }
 


### PR DESCRIPTION
When using `sccache` with gcc using the `-fdiagnostics-color=auto` flag, there is currently no color output being shown.
This is due to gcc not outputting colors, when standard error is not a terminal, which is the case when using sccache.

This PR addresses this behavior, by making sccache behave similarly for gcc as for rustc. When the `-fdiagnostics-color` flag is specified, it will remove this flag from the arguments and add it back as `-fdiagnostics-color=always`, if the `color_mode` is set to `On` or `Auto`.

Please let me know if there is anything I should change or might not have considered!