### PR TITLE
[ci] enforce 'zizmor' checks for GitHub Actions configurations

### DIFF
--- a/.github/actions/artifact_failure/action.yml
+++ b/.github/actions/artifact_failure/action.yml
@@ -9,6 +9,8 @@ runs:
   steps:
     - name: pack failure artifacts
       shell: bash
+      env:
+        INPUTS_NAME: ${{ inputs.name }}
       run: |
         echo "Current running processes"
         ps uax
@@ -23,8 +25,8 @@ runs:
             --exclude='docs' \
             --exclude='bins' \
             --exclude='.git' \
-            -zcf target/failure-${{ inputs.name }}.tar.gz .
-    - uses: actions/upload-artifact@v4
+            -zcf target/failure-${INPUTS_NAME}.tar.gz .
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.name }}
         path: target/failure-${{ inputs.name }}.tar.gz

--- a/.github/actions/nvcc-toolchain/action.yml
+++ b/.github/actions/nvcc-toolchain/action.yml
@@ -9,8 +9,12 @@ runs:
   steps:
     - if: runner.os == 'Linux'
       shell: bash
-      run: .github/actions/nvcc-toolchain/install-cuda.sh ${{ inputs.cuda-version }}
+      env:
+        INPUTS_NAME: ${{ inputs.name }}
+      run: .github/actions/nvcc-toolchain/install-cuda.sh ${INPUTS_NAME}
 
     - if: runner.os == 'Windows'
       shell: powershell
-      run: .\.github\actions\nvcc-toolchain\install-cuda.ps1 -cudaVersion ${{ inputs.cuda-version }}
+      env:
+        INPUTS_CUDA_VERSION: ${{ inputs.cuda-version }}
+      run: .\.github\actions\nvcc-toolchain\install-cuda.ps1 -cudaVersion ${INPUTS_CUDA_VERSION}

--- a/.github/actions/rust-toolchain/action.yml
+++ b/.github/actions/rust-toolchain/action.yml
@@ -16,10 +16,18 @@ runs:
   using: composite
   steps:
     - shell: bash
+      env:
+        INPUTS_COMPONENTS: ${{ inputs.components }}
+        INPUTS_TARGET: ${{ inputs.target }}
+        INPUTS_TOOLCHAIN: ${{ inputs.toolchain }}
       run: |
         set -x
-        rustup override set ${{ inputs.toolchain || 'stable' }}
-        ${{ inputs.target && format('rustup target add {0}', inputs.target) }}
-        ${{ inputs.components && format('rustup component add {0}', inputs.components) }}
+        rustup override set "${INPUTS_TOOLCHAIN:-stable}"
+        if [[ -n "${INPUTS_TARGET}" ]]; then
+          rustup target add ${INPUTS_TARGET}
+        fi
+        if [[ -n "${INPUTS_COMPONENTS}" ]]; then
+          rustup component add ${INPUTS_COMPONENTS}
+        fi
         cargo --version
         rustc --version

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
     schedule:
       interval: weekly 
     open-pull-requests-limit: 8
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,13 +26,13 @@ jobs:
           - simulation
           - memory
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable # zizmor: ignore[unpinned-uses]
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-codspeed
         shell: bash
@@ -43,7 +43,7 @@ jobs:
         run: cargo codspeed build
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
         env:
           CODSPEED_LOG: debug
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: ci
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: ${{ matrix.component }} ${{ matrix.os }}
@@ -19,7 +22,9 @@ jobs:
             cargo_cmd: clippy --locked --all-targets -- -D warnings -A unknown-lints -A clippy::type_complexity -A clippy::new-without-default
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Install rust
         uses: ./.github/actions/rust-toolchain
@@ -42,7 +47,9 @@ jobs:
         feature: [ azure, gcs, gha, memcached, redis, s3, webdav ]
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Check feature ${{ matrix.feature }}
         run: cargo check --no-default-features --features ${{ matrix.feature }}
@@ -51,7 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Check
         run: npx --yes @taplo/cli fmt --check
@@ -130,10 +139,12 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: '0' # save disk space
     steps:
       - if: ${{ contains(matrix.os, 'windows') }}
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Install rust
         uses: ./.github/actions/rust-toolchain
@@ -234,7 +245,7 @@ jobs:
 
       - name: Upload coverage results (to Codecov.io)
         if: ${{ ! matrix.no_coverage }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           files: ${{ steps.coverage.outputs.report }}
           ## flags: IntegrationTests, UnitTests, ${{ steps.vars.outputs.CODECOV_FLAGS }}
@@ -306,7 +317,9 @@ jobs:
             rustflags: -Ctarget-feature=+crt-static
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Install rust
         uses: ./.github/actions/rust-toolchain
@@ -374,7 +387,7 @@ jobs:
           ID: ${{ startsWith(github.ref, 'refs/tags/') && github.ref || github.sha }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.binary || 'sccache' }}-${{ steps.id.outputs.id }}-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/${{ matrix.binary || 'sccache' }}${{ endsWith(matrix.target, '-msvc') && '.exe' || '' }}
@@ -391,9 +404,11 @@ jobs:
         job:
           - { os: ubuntu-22.04 }
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
       - name: Prepare, build and test
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@5a72679103d223925653750faa878a143340fbd0 # v1.5.0
         with:
           mem: 8192
           usesh: true
@@ -450,7 +465,9 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Check versions
         run: |
@@ -463,7 +480,7 @@ jobs:
           fi
 
       - name: Get artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Create release assets
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,6 +463,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build, lint, test ]
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    permissions:
+      contents: write
     steps:
       - name: Clone repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/.github/workflows/close-snap.yml
+++ b/.github/workflows/close-snap.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   close:
     runs-on: ubuntu-latest
@@ -12,7 +15,7 @@ jobs:
 
     steps:
     - name: Close obsolete channels
-      uses: canonical/actions/close-snap@release
+      uses: canonical/actions/close-snap@release # zizmor: ignore[unpinned-uses]
       continue-on-error: true
       with:
         channel: edge/pr${{ github.event.number }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,12 +12,17 @@ env:
   SCCACHE_PATH: /home/runner/.cargo/bin/sccache
   ACTIONS_CACHE_SERVICE_V2: on
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Install rust
         uses: ./.github/actions/rust-toolchain
@@ -28,7 +33,7 @@ jobs:
         run: |
           cargo build --all-features
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: integration-tests
           path: ./target/debug/sccache
@@ -41,7 +46,9 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Test
         run: cd tests/integration && WITH_COVERAGE=1 make test-${{ matrix.type }}
@@ -56,7 +63,7 @@ jobs:
           ls ../../target/integration-coverage/reports/lcov.info -l
 
       - name: Upload coverage results (to Codecov.io)
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           files: target/integration-coverage/reports/lcov.info
           name: codecov-umbrella-integration-${{ matrix.type }}
@@ -75,10 +82,12 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Configure Cache Env
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
@@ -89,7 +98,7 @@ jobs:
         with:
           toolchain: "stable"
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: integration-tests
           path: /home/runner/.cargo/bin/
@@ -123,10 +132,12 @@ jobs:
       SCCACHE_ERROR_LOG: "${{ github.workspace }}\\server_log.txt"
 
     steps:
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Install rust
         uses: ./.github/actions/rust-toolchain
@@ -215,20 +226,22 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       # I don't want to break the cache during testing. Will turn on after I
       # make sure it's working.
       #
       # - name: Configure Cache Env
-      #   uses: actions/github-script@v8
+      #   uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       #   with:
       #     script: |
       #       core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
       #       core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
 
       # - name: Configure ROCm Env
-      #   uses: actions/github-script@v8
+      #   uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       #   with:
       #     script: |
       #       core.exportVariable('ROCM_PATH', process.env.ROCM_PATH || '');
@@ -251,7 +264,7 @@ jobs:
         run: |
           cargo build -p randomize_readdir
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: integration-tests
           path: /home/runner/.cargo/bin/
@@ -304,7 +317,9 @@ jobs:
       SCCACHE_PATH: target/debug/sccache
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Install rust
         uses: ./.github/actions/rust-toolchain

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   Snap:
     runs-on: ubuntu-latest
@@ -12,12 +15,13 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       with:
         fetch-depth: 0  # needed for version determination
+        persist-credentials: false
 
     - name: Build and publish the snap
-      uses: canonical/actions/build-snap@release
+      uses: canonical/actions/build-snap@release # zizmor: ignore[unpinned-uses]
       with:
         snapcraft-channel: edge
         review-opts: --allow-classic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,4 @@
+rules:
+  unpinned-images:
+    ignore:
+      - ci.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,7 @@ repos:
         pass_filenames: false
         types: [file, rust]
         language: system
+-   repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.26.1
+    hooks:
+    -   id: zizmor

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         pass_filenames: false
         types: [file, rust]
         language: system
--   repo: https://github.com/woodruffw/zizmor-pre-commit
+-   repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.26.1
     hooks:
     -   id: zizmor

--- a/docs/GHA.md
+++ b/docs/GHA.md
@@ -8,7 +8,7 @@ This cache type will need tokens like `ACTIONS_RESULTS_URL` and `ACTIONS_RUNTIME
 
 ```yaml
 - name: Configure sccache
-  uses: actions/github-script@v7
+  uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
   with:
     script: |
       core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');


### PR DESCRIPTION
👋🏻 hi, `sccache` user for a few years, first-time contributor.

This PR proposes introducing `zizmor`, a static analyzer that enforces stricter security rules for GitHub Actions (https://github.com/zizmorcore/zizmor). I don't have any affiliation with that project, just genuinely think its suggestions are very useful.

## Changes

* adds `zizmor` pre-commit hook, pinned to its latest release
* pins most third-party GitHub Actions uses to commit SHAs instead of mutable tags
  - *kept the same versions you were already getting, any upgrades/downgrades in this PR are mistakes*
* passes inputs through `env:` to avoid script injection (https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable)
* adds a "dependency cooldown" for dependabot (a minimum age that releases must reach before dependabot recommends updating to them)
* adds explicit permissions to workflows that were missing it (ref: https://docs.github.com/en/actions/reference/security/secure-use#restricting-permissions-for-tokens)

## Notes for Reviewers

### How I tested this

Ran `pre-commit` and `actionlint` locally

```shell
pre-commit run --all-files
actionlint .github/workflows/*
```

The only other way I know to test changes like this is to actually run CI.

### Related work

This would help with @sylvestre 's draft PR here: #2636

And would avoid findings like https://github.com/mozilla/sccache/pull/2729#discussion_r3375056305 that GitHub Advanced Security is adding to PRs here.

### Handling this PR

I know this is a sensitive and large-ish changeset and I'm a random person from the internet. I'm happy to break this into smaller PRs if you like, or for maintainers to close this and make these changes themselves.

Thanks for your time and consideration.