### PR TITLE
Fix description of Unix socket-based Redis connection

### DIFF
--- a/docs/Redis.md
+++ b/docs/Redis.md
@@ -6,7 +6,7 @@ If you want to use a Redis cluster, set `SCCACHE_REDIS_CLUSTER_ENDPOINTS` instea
 Redis endpoint URL format can be found in the [OpenDAL source code](https://github.com/apache/opendal/blob/5f1d5d1d61ed28f63d4955538b33a4d582feebef/core/src/services/redis/backend.rs#L268-L307). Some valid examples:
 * `redis://127.0.0.1:6379` or `tcp://127.0.0.1:6379` or `127.0.0.1:6379` - TCP-based Redis connection (non-secure)
 * `rediss://@1.2.3.4:6379` - TLS-based Redis connection over TCP (secure)
-* `unix:///tmp/redis.sock` or `redis+unix:///tmp/redis.sock` - Unix socket-based Redis connection
+* `unix://localhost/tmp/redis.sock` or `redis+unix://localhost/tmp/redis.sock` - Unix socket-based Redis connection
 
 Redis can be configured as a LRU (least recently used) cache with a fixed maximum cache size. Set `maxmemory` and `maxmemory-policy` according to the [Redis documentation](https://redis.io/topics/lru-cache). The `allkeys-lru` policy which discards the *least recently accessed or modified* key fits well for the sccache use case.
 


### PR DESCRIPTION
OpenDAL parses the URI with http::Uri which _expects_ a host. If no host is specified parsing is going to fail.