### PR TITLE
feat: support S3 SSE-KMS

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -123,7 +123,12 @@ bucket = "name"
 endpoint = "s3-us-east-1.amazonaws.com"
 use_ssl = true
 key_prefix = "s3prefix"
+# SSE-S3 with an S3-managed key (AES256).
 server_side_encryption = false
+# SSE-KMS with the AWS-managed KMS key (aws/s3).
+server_side_encryption_aws_kms = false
+# SSE-KMS with a customer-managed KMS key (takes precedence when set).
+# server_side_encryption_kms_key_id = "arn:aws:kms:us-east-1:111:key/abc"
 
 [cache.webdav]
 endpoint = "http://192.168.10.42:80/some/webdav.php"

--- a/docs/S3.md
+++ b/docs/S3.md
@@ -9,7 +9,12 @@ If you want to use S3 storage for the sccache cache, you need to set the followi
 
 If your endpoint requires HTTPS/TLS, set `SCCACHE_S3_USE_SSL=true`. If you don't need a secure network layer, HTTP (`SCCACHE_S3_USE_SSL=false`) might be better for performance.
 
-Enable server-side encryption with s3 managed key (SSE-S3), set `SCCACHE_S3_SERVER_SIDE_ENCRYPTION=true`.
+Server-side encryption can be enabled in one of three modes. They are resolved in the following order of precedence:
+
+- **SSE-KMS with a customer-managed KMS key:** set `SCCACHE_S3_SERVER_SIDE_ENCRYPTION_KMS_KEY_ID` to the KMS key ID/ARN. This implies `aws:kms` and takes precedence over the other settings.
+- **SSE-KMS with the AWS-managed KMS key (`aws/s3`):** set `SCCACHE_S3_SERVER_SIDE_ENCRYPTION_AWS_KMS=true`.
+- **SSE-S3 with an S3-managed key (AES256):** set `SCCACHE_S3_SERVER_SIDE_ENCRYPTION=true`.
+
 More details about encryption [here](https://opendal.apache.org/docs/services/s3/#server-side-encryption) and documentation [here](https://docs.rs/opendal/latest/opendal/services/struct.S3.html#method.server_side_encryption_with_s3_key).
 
 You can also define a prefix that will be prepended to the keys of all cache objects created and read within the S3 bucket, effectively creating a scope. To do that use the `SCCACHE_S3_KEY_PREFIX` environment variable. This can be useful when sharing a bucket with another application.

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -528,6 +528,8 @@ pub fn build_single_cache(
                 .with_endpoint(c.endpoint.clone())
                 .with_use_ssl(c.use_ssl)
                 .with_server_side_encryption(c.server_side_encryption)
+                .with_server_side_encryption_aws_kms(c.server_side_encryption_aws_kms)
+                .with_server_side_encryption_kms_key_id(c.server_side_encryption_kms_key_id.clone())
                 .with_enable_virtual_host_style(c.enable_virtual_host_style)
                 .build()
                 .map_err(|err| anyhow!("create s3 cache failed: {err:?}"))?;

--- a/src/cache/s3.rs
+++ b/src/cache/s3.rs
@@ -26,6 +26,8 @@ pub struct S3Cache {
     endpoint: Option<String>,
     use_ssl: Option<bool>,
     server_side_encryption: Option<bool>,
+    server_side_encryption_aws_kms: Option<bool>,
+    server_side_encryption_kms_key_id: Option<String>,
     enable_virtual_host_style: Option<bool>,
 }
 
@@ -39,6 +41,8 @@ impl S3Cache {
             endpoint: None,
             use_ssl: None,
             server_side_encryption: None,
+            server_side_encryption_aws_kms: None,
+            server_side_encryption_kms_key_id: None,
             enable_virtual_host_style: None,
         }
     }
@@ -56,6 +60,20 @@ impl S3Cache {
     }
     pub fn with_server_side_encryption(mut self, server_side_encryption: Option<bool>) -> Self {
         self.server_side_encryption = server_side_encryption;
+        self
+    }
+    pub fn with_server_side_encryption_aws_kms(
+        mut self,
+        server_side_encryption_aws_kms: Option<bool>,
+    ) -> Self {
+        self.server_side_encryption_aws_kms = server_side_encryption_aws_kms;
+        self
+    }
+    pub fn with_server_side_encryption_kms_key_id(
+        mut self,
+        server_side_encryption_kms_key_id: Option<String>,
+    ) -> Self {
+        self.server_side_encryption_kms_key_id = server_side_encryption_kms_key_id;
         self
     }
     pub fn with_enable_virtual_host_style(
@@ -93,7 +111,14 @@ impl S3Cache {
             builder = builder.endpoint(&endpoint_resolver(endpoint, self.use_ssl)?);
         }
 
-        if self.server_side_encryption.unwrap_or_default() {
+        if let Some(kms_key_id) = &self.server_side_encryption_kms_key_id {
+            // SSE-KMS with a customer-managed KMS key.
+            builder = builder.server_side_encryption_with_customer_managed_kms_key(kms_key_id);
+        } else if self.server_side_encryption_aws_kms.unwrap_or_default() {
+            // SSE-KMS with the AWS-managed KMS key (aws/s3).
+            builder = builder.server_side_encryption_with_aws_managed_kms_key();
+        } else if self.server_side_encryption.unwrap_or_default() {
+            // SSE-S3 with an S3-managed key (AES256).
             builder = builder.server_side_encryption_with_s3_key();
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -464,6 +464,8 @@ pub struct S3CacheConfig {
     pub endpoint: Option<String>,
     pub use_ssl: Option<bool>,
     pub server_side_encryption: Option<bool>,
+    pub server_side_encryption_aws_kms: Option<bool>,
+    pub server_side_encryption_kms_key_id: Option<String>,
     pub enable_virtual_host_style: Option<bool>,
     #[serde(default)]
     pub rw_mode: CacheModeConfig,
@@ -886,6 +888,10 @@ fn config_from_env() -> Result<EnvConfig> {
         let no_credentials = bool_from_env_var("SCCACHE_S3_NO_CREDENTIALS")?.unwrap_or(false);
         let use_ssl = bool_from_env_var("SCCACHE_S3_USE_SSL")?;
         let server_side_encryption = bool_from_env_var("SCCACHE_S3_SERVER_SIDE_ENCRYPTION")?;
+        let server_side_encryption_aws_kms =
+            bool_from_env_var("SCCACHE_S3_SERVER_SIDE_ENCRYPTION_AWS_KMS")?;
+        let server_side_encryption_kms_key_id =
+            string_from_env_var("SCCACHE_S3_SERVER_SIDE_ENCRYPTION_KMS_KEY_ID");
         let endpoint = string_from_env_var("SCCACHE_ENDPOINT");
         let key_prefix = key_prefix_from_env_var("SCCACHE_S3_KEY_PREFIX");
         let enable_virtual_host_style = bool_from_env_var("SCCACHE_S3_ENABLE_VIRTUAL_HOST_STYLE")?;
@@ -900,6 +906,8 @@ fn config_from_env() -> Result<EnvConfig> {
             endpoint,
             use_ssl,
             server_side_encryption,
+            server_side_encryption_aws_kms,
+            server_side_encryption_kms_key_id,
             enable_virtual_host_style,
             rw_mode,
         })
@@ -2355,6 +2363,44 @@ fn test_s3_no_credentials_valid_false() {
 
 #[test]
 #[serial(config_from_env)]
+#[cfg(feature = "s3")]
+fn test_s3_sse_kms_from_env() {
+    unsafe {
+        env::set_var("SCCACHE_BUCKET", "my-bucket");
+        env::set_var("SCCACHE_S3_SERVER_SIDE_ENCRYPTION_AWS_KMS", "true");
+        env::set_var(
+            "SCCACHE_S3_SERVER_SIDE_ENCRYPTION_KMS_KEY_ID",
+            "arn:aws:kms:us-east-1:111:key/abc",
+        );
+    }
+
+    let cfg = config_from_env();
+
+    unsafe {
+        env::remove_var("SCCACHE_BUCKET");
+        env::remove_var("SCCACHE_S3_SERVER_SIDE_ENCRYPTION_AWS_KMS");
+        env::remove_var("SCCACHE_S3_SERVER_SIDE_ENCRYPTION_KMS_KEY_ID");
+    }
+
+    let env_cfg = cfg.unwrap();
+    match env_cfg.cache.s3 {
+        Some(S3CacheConfig {
+            server_side_encryption_aws_kms,
+            ref server_side_encryption_kms_key_id,
+            ..
+        }) => {
+            assert_eq!(server_side_encryption_aws_kms, Some(true));
+            assert_eq!(
+                server_side_encryption_kms_key_id.as_deref(),
+                Some("arn:aws:kms:us-east-1:111:key/abc")
+            );
+        }
+        None => unreachable!(),
+    }
+}
+
+#[test]
+#[serial(config_from_env)]
 #[cfg(feature = "gcs")]
 fn test_gcs_service_account() {
     unsafe {
@@ -2528,6 +2574,8 @@ key_prefix = "cosprefix"
                     key_prefix: "s3prefix".into(),
                     no_credentials: true,
                     server_side_encryption: Some(false),
+                    server_side_encryption_aws_kms: None,
+                    server_side_encryption_kms_key_id: None,
                     enable_virtual_host_style: None,
                     rw_mode: CacheModeConfig::ReadWrite,
                 }),
@@ -3025,6 +3073,8 @@ fn test_get_cache_levels_single_cache() {
             endpoint: None,
             use_ssl: None,
             server_side_encryption: None,
+            server_side_encryption_aws_kms: None,
+            server_side_encryption_kms_key_id: None,
             enable_virtual_host_style: None,
             rw_mode: CacheModeConfig::ReadWrite,
         }),


### PR DESCRIPTION
Add two S3 config options alongside the existing SSE-S3 toggle:
- `server_side_encryption_aws_kms` (`SCCACHE_S3_SERVER_SIDE_ENCRYPTION_AWS_KMS`) enables SSE-KMS with the AWS-managed key (aws/s3).
- `server_side_encryption_kms_key_id` (`SCCACHE_S3_SERVER_SIDE_ENCRYPTION_KMS_KEY_ID`) enables SSE-KMS with a customer-managed KMS key.

Resolution precedence in the S3 builder: customer-managed KMS key >
AWS-managed KMS > SSE-S3. Existing `server_side_encryption` configs are unchanged.