### PR TITLE
multilevel: a chain with any writable level is writable

### DIFF
--- a/src/cache/multilevel.rs
+++ b/src/cache/multilevel.rs
@@ -877,14 +877,22 @@ impl Storage for MultiLevelStorage {
     }
 
     async fn check(&self) -> Result<CacheMode> {
-        let mut result = CacheMode::ReadWrite;
+        // The composite is writable when any level is writable: put()
+        // already skips read-only levels on writes, so a read-only level
+        // must not demote the whole chain (e.g. a writable local disk in
+        // front of a read-only shared remote). Only a chain in which
+        // every level is read-only is itself read-only.
+        let mut result = CacheMode::ReadOnly;
+        if self.levels.is_empty() {
+            return Ok(CacheMode::ReadWrite);
+        }
         for (idx, level) in self.levels.iter().enumerate() {
             match level.check().await {
                 Ok(CacheMode::ReadOnly) => {
-                    result = CacheMode::ReadOnly;
                     debug!("Cache level {} is read-only", idx);
                 }
                 Ok(CacheMode::ReadWrite) => {
+                    result = CacheMode::ReadWrite;
                     trace!("Cache level {} is read-write", idx);
                 }
                 Err(e) => {
@@ -893,6 +901,7 @@ impl Storage for MultiLevelStorage {
                 }
             }
         }
+        debug!("Multi-level cache mode: {:?}", result);
         Ok(result)
     }
 

--- a/src/cache/multilevel_test.rs
+++ b/src/cache/multilevel_test.rs
@@ -971,6 +971,63 @@ fn test_readonly_level_in_check() {
 }
 
 #[test]
+fn test_mixed_readonly_chain_is_readwrite_in_check() {
+    // A chain that contains a writable level must report ReadWrite even
+    // when other levels are read-only: put() skips read-only levels, so a
+    // read-only remote behind a writable local disk (the documented
+    // "read-only fallback" topology) must not demote the whole cache to
+    // read-only. Regression test for #2773.
+    let runtime = RuntimeBuilder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    // Writable L0, read-only L1
+    let rw_l0 = Arc::new(InMemoryStorage::new());
+    let ro_l1 = Arc::new(ReadOnlyStorage(Arc::new(InMemoryStorage::new())));
+    let storage =
+        MultiLevelStorage::new(vec![rw_l0 as Arc<dyn Storage>, ro_l1 as Arc<dyn Storage>]);
+    runtime.block_on(async {
+        match storage.check().await.unwrap() {
+            CacheMode::ReadWrite => {} // Expected
+            _ => panic!("Writable L0 + read-only L1 should be ReadWrite"),
+        }
+    });
+
+    // Read-only L0, writable L1: still writable (put() skips L0)
+    let ro_l0 = Arc::new(ReadOnlyStorage(Arc::new(InMemoryStorage::new())));
+    let rw_l1 = Arc::new(InMemoryStorage::new());
+    let storage =
+        MultiLevelStorage::new(vec![ro_l0 as Arc<dyn Storage>, rw_l1 as Arc<dyn Storage>]);
+    runtime.block_on(async {
+        match storage.check().await.unwrap() {
+            CacheMode::ReadWrite => {} // Expected
+            _ => panic!("Read-only L0 + writable L1 should be ReadWrite"),
+        }
+    });
+}
+
+#[test]
+fn test_all_readonly_chain_is_readonly_in_check() {
+    // Only a chain in which EVERY level is read-only is itself read-only.
+    let runtime = RuntimeBuilder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let ro_l0 = Arc::new(ReadOnlyStorage(Arc::new(InMemoryStorage::new())));
+    let ro_l1 = Arc::new(ReadOnlyStorage(Arc::new(InMemoryStorage::new())));
+    let storage =
+        MultiLevelStorage::new(vec![ro_l0 as Arc<dyn Storage>, ro_l1 as Arc<dyn Storage>]);
+    runtime.block_on(async {
+        match storage.check().await.unwrap() {
+            CacheMode::ReadOnly => {} // Expected
+            _ => panic!("All read-only levels should be ReadOnly"),
+        }
+    });
+}
+
+#[test]
 fn test_sequential_read_order() {
     // Test that reads happen sequentially (L0, L1, L2, ...), not in parallel
     // This verifies the documented behavior: "check multiple storage backends in sequence"


### PR DESCRIPTION
Fixes #2773.

`MultiLevelStorage::check()` starts from `ReadWrite` and demotes the composite to `ReadOnly` as soon as **any** level reports `ReadOnly`. The server then wraps the entire storage in `ReadOnlyStorage` ("server has setup with ReadOnly"), so every cache write is refused before any write-error policy is consulted -- including writes to writable levels, and preprocessor cache updates ("Failed to update preprocessor cache: Cannot write to read-only storage").

This inverts the documented semantics: `docs/MultiLevel.md` says read-only levels are "automatically skipped during writes, regardless of write policy", and `put()` already implements exactly that per-level skipping. The practical fallout is that the documented read-only fallback topology -- a fast writable local disk in front of a read-only shared remote (`SCCACHE_S3_RW_MODE=READ_ONLY`, or an Azure SAS token without write permission, which fails the startup write probe and is treated as read-only) -- silently stops populating the local disk cache entirely.

Reproduction (hello-world C compile, sccache 0.16.0):

| chain | server mode | local disk written |
|---|---|---|
| `disk` | ReadWrite | yes |
| `disk, s3/azure (read-only)` | ReadOnly | **no** |
| `disk, s3/azure (read-write)` | ReadWrite | yes |

The fix aggregates in the other direction: the composite is writable when any level is writable, and read-only only when every level is read-only. `put()` needs no changes -- it already routes writes only to writable levels under all three write-error policies.

Tests: the existing `test_readonly_level_in_check` (single-level, all-read-only chain) still passes; added `test_mixed_readonly_chain_is_readwrite_in_check` (writable+read-only in both orders) and `test_all_readonly_chain_is_readonly_in_check`.

Verified end to end against a real Azure container with a read-list-only SAS token: with this fix the same config that previously wrote nothing populates the local disk tier, and remote hits backfill to disk as documented.
