### PR TITLE
tests: pin libc in the dist test crate

### DIFF
--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -77,7 +77,9 @@ fn rust_compile(tmpdir: &Path, sccache_cfg_path: &Path, sccache_cached_cfg_path:
         version = "0.1.0"
         edition = "2021"
         [dependencies]
-        libc = "0.2.169""#,
+        # Pinned: the point of this test is that distributed compilation works,
+        # not that it keeps up with whatever libc published most recently.
+        libc = "=0.2.169""#,
     );
     write_source(
         &cargo_path,


### PR DESCRIPTION
The crate generated by the dist tests depended on `libc = "0.2.169"`, a caret range, so each run compiled whatever libc was newest on crates.io. Recent libc reaches modules through `#[path]` attributes containing `..` components; those files never make it into the inputs archive sent to the build server, so rustc failed there with

    error: couldn't read `.../libc-0.2.189/src/new/glibc/sysdeps/nptl/bits/../../x86/nptl/bits/struct_mutex.rs`

No outputs came back, the client fell back to compiling locally, and test_dist_cargo_build and test_dist_cargo_makeflags failed their dist_compiles assertions.

Pin the dependency: these tests check that distributed compilation works, not that it keeps up with the latest libc release.