### PR TITLE
Fixed hardcoded binary path in test

### DIFF
--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -24,14 +24,8 @@ use crate::test::utils::*;
 use fs::File;
 use fs_err as fs;
 use futures::channel::oneshot::{self, Sender};
-#[cfg(not(target_os = "macos"))]
-use serial_test::serial;
 use std::io::{Cursor, Write};
-#[cfg(not(target_os = "macos"))]
-use std::net::TcpListener;
 use std::path::Path;
-#[cfg(not(target_os = "macos"))]
-use std::process::Command;
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::time::Duration;
@@ -292,33 +286,4 @@ fn test_server_compile() {
     sender.send(ServerMessage::Shutdown).ok().unwrap();
     // Ensure that it shuts down.
     child.join().unwrap();
-}
-
-#[test]
-#[serial]
-// test fails intermittently on macos:
-// https://github.com/mozilla/sccache/issues/234
-#[cfg(not(target_os = "macos"))]
-fn test_server_port_in_use() {
-    // Bind an arbitrary free port.
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let sccache = find_sccache_binary();
-    let output = Command::new(sccache)
-        .arg("--start-server")
-        .env(
-            "SCCACHE_SERVER_PORT",
-            listener.local_addr().unwrap().port().to_string(),
-        )
-        .env_remove("SCCACHE_SERVER_UDS")
-        .output()
-        .unwrap();
-    assert!(!output.status.success());
-    let s = String::from_utf8_lossy(&output.stderr);
-    const MSG: &str = "Server startup failed:";
-    assert!(
-        s.contains(MSG),
-        "Output did not contain '{}':\n========\n{}\n========",
-        MSG,
-        s
-    );
 }

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -98,25 +98,6 @@ pub fn next_command_calls<C: Fn(&[OsString]) -> Result<MockChild> + Send + 'stat
     creator.lock().unwrap().next_command_calls(call);
 }
 
-#[cfg(not(target_os = "macos"))]
-pub fn find_sccache_binary() -> PathBuf {
-    // Older versions of cargo put the test binary next to the sccache binary.
-    // Newer versions put it in the deps/ subdirectory.
-    let exe = env::current_exe().unwrap();
-    let this_dir = exe.parent().unwrap();
-    let dirs = &[&this_dir, &this_dir.parent().unwrap()];
-    dirs.iter()
-        .map(|d| d.join("sccache").with_extension(env::consts::EXE_EXTENSION))
-        .filter_map(|d| fs::metadata(&d).ok().map(|_| d))
-        .next()
-        .unwrap_or_else(|| {
-            panic!(
-            "Error: sccache binary not found, looked in `{:?}`. Do you need to run `cargo build`?",
-            dirs
-        )
-        })
-}
-
 pub struct TestFixture {
     /// Temp directory.
     pub tempdir: TempDir,

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,0 +1,34 @@
+#[cfg(not(target_os = "macos"))]
+use std::{net::TcpListener, process::Command};
+
+#[cfg(not(target_os = "macos"))]
+use serial_test::serial;
+
+#[test]
+#[serial]
+// test fails intermittently on macos:
+// https://github.com/mozilla/sccache/issues/234
+#[cfg(not(target_os = "macos"))]
+fn test_server_port_in_use() {
+    // Bind an arbitrary free port.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let sccache = env!("CARGO_BIN_EXE_sccache");
+    let output = Command::new(sccache)
+        .arg("--start-server")
+        .env(
+            "SCCACHE_SERVER_PORT",
+            listener.local_addr().unwrap().port().to_string(),
+        )
+        .env_remove("SCCACHE_SERVER_UDS")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let s = String::from_utf8_lossy(&output.stderr);
+    const MSG: &str = "Server startup failed:";
+    assert!(
+        s.contains(MSG),
+        "Output did not contain '{}':\n========\n{}\n========",
+        MSG,
+        s
+    );
+}


### PR DESCRIPTION
I noticed nightly CI failed in https://github.com/mozilla/sccache/pull/2789 due to the Cargo [`build-dir` layout changes](https://github.com/rust-lang/cargo/issues/15010) on nightly.

This PR fixes the failing test by replacing `fn find_sccache_binary` with `CARGO_BIN_EXE_sccache`.
To do this I needed to move the test from a unit test to an integration test so that Cargo would set the [`CARGO_BIN_EXE_*`](https://doc.rust-lang.org/cargo/reference/environment-variables.html) env var 