### PR TITLE
msvc: treat /d2<name> codegen switches as flags, not input files

### DIFF
--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -438,6 +438,12 @@ msvc_args!(static ARGS: [ArgInfo<ArgData>; _] = [
     msvc_take_arg!("clr:", OsString, Concatenated, PassThroughWithSuffix),
     msvc_take_arg!("constexpr:", OsString, Concatenated, PassThroughWithSuffix),
     msvc_flag!("d1nodatetime", PassThrough),
+    // /d2<name> - undocumented back-end codegen switches (e.g. /d2archSSE42,
+    // which Godot uses to enable SSE4.2 autovectorization). Unrecognized args
+    // are classified as Raw, i.e. as input files, so without this entry any
+    // command line carrying one is rejected as "multiple input files" and
+    // silently never cached. They affect codegen, so hash them via the suffix.
+    msvc_take_arg!("d2", OsString, Concatenated, PassThroughWithSuffix),
     msvc_take_arg!("deps", PathBuf, Concatenated, DepFile),
     msvc_take_arg!("diagnostics:", OsString, Concatenated, PassThroughWithSuffix),
     msvc_take_arg!("doc", PathBuf, Concatenated, TooHardPath), // Creates an .xdc file.
@@ -1863,6 +1869,41 @@ mod test {
         assert!(preprocessor_args.is_empty());
         assert_eq!(common_args, ovec!["-foo", "-bar"]);
         assert!(!msvc_show_includes);
+    }
+
+    #[test]
+    fn test_parse_arguments_d2_codegen_flag() {
+        // /d2<name> back-end codegen switches must parse as flags. Before they
+        // were in the table they fell through to Argument::Raw, i.e. were taken
+        // for a second input file, and the whole command line was rejected as
+        // "multiple input files" - so a build using one (Godot passes
+        // /d2archSSE42 on every x86_64 MSVC compile) cached nothing at all.
+        let args = ovec!["/c", "foo.c", "/d2archSSE42", "/Fofoo.obj"];
+        let ParsedArguments {
+            input,
+            language,
+            outputs,
+            common_args,
+            ..
+        } = match parse_arguments(args) {
+            CompilerArguments::Ok(args) => args,
+            o => panic!("Got unexpected parse result: {:?}", o),
+        };
+        assert_eq!(Some("foo.c"), input.to_str());
+        assert_eq!(Language::C, language);
+        assert_map_contains!(
+            outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: PathBuf::from("foo.obj"),
+                    optional: false
+                }
+            )
+        );
+        // Kept in common_args so the switch is part of the cache key - two
+        // objects built with different /d2 switches must not collide.
+        assert_eq!(common_args, ovec!["/d2archSSE42"]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

MSVC's undocumented back-end switches (`/d2archSSE42`, `/d2ssa-cfg-jt-`, …) have no entry in the MSVC argument table, so they fall through to `Argument::Raw` — i.e. they are taken for an input file. A command line carrying one therefore trips

```rust
if input_arg.is_some() {
    // Can't cache compilations with multiple inputs.
    multiple_input = true;
```

and is rejected with `CannotCache("multiple input files")`.

This is not a corner case. Godot passes `/d2archSSE42` on **every** x86_64 MSVC compile to enable SSE4.2 autovectorization, so an entire engine build caches nothing:

```
Compile requests                    5116
Compile requests executed              1
Cache hits                             1
Cache hits rate                   100.00 %
Non-cacheable calls                 5115
Non-cacheable reasons:
  multiple input files              5115
```

The failure is quiet and the statistics actively mislead: the reported hit rate is 100%, because the only cacheable call in the build is the one translation unit that happens to omit the flag. Nothing errors, the build simply never caches.

## Change

One entry in the table:

```rust
msvc_take_arg!("d2", OsString, Concatenated, PassThroughWithSuffix),
```

`PassThroughWithSuffix` keeps the switch in `common_args`, so it stays part of the cache key — objects built with different `/d2` switches must not collide.

Scoped to `/d2` deliberately: a generic `/d1` entry would sit in front of the existing `/d1nodatetime` entry in this sorted, binary-searched array. `/d1nodatetime` is left as-is.

## Verification

- New regression test `test_parse_arguments_d2_codegen_flag` asserting `/d2archSSE42` parses as a flag, the single input is still detected, and the switch lands in `common_args`.
- `compiler::msvc` — 45 passed, 0 failed. `compiler::args` — 7 passed, 0 failed (incl. `test_bsearch` / `test_multi_search`, which cover the sorted-array lookup this entry is inserted into).
- End-to-end against a real build: compiling a Godot translation unit with a patched sccache, flag present and the build system untouched, goes miss → **hit**, `Non-cacheable calls 0`. With the stock binary the identical command reports `multiple input files`.