### PR TITLE
Bump MSRV to 1.91.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           components: ${{ matrix.component }}
           # Oldest supported version, keep in sync with README.md
-          toolchain: "1.85.0"
+          toolchain: "1.91.0"
 
       - name: clippy version
         run: cargo clippy --version
@@ -69,7 +69,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             # Oldest supported version, keep in sync with README.md
-            rustc: "1.85.0"
+            rustc: "1.91.0"
             extra_desc: dist-tests
             extra_args: --no-default-features --features=dist-tests test_dist_ -- --test-threads 1
           - os: ubuntu-22.04
@@ -94,7 +94,7 @@ jobs:
           - os: ubuntu-24.04
             cuda: "12.8"
             # Oldest supported version, keep in sync with README.md
-            rustc: "1.85.0"
+            rustc: "1.91.0"
             extra_desc: cuda12.8
           # # M1 CPU
           - os: macos-14
@@ -102,7 +102,7 @@ jobs:
           - os: windows-2022
             cuda: "12.8"
             # Oldest supported version, keep in sync with README.md
-            rustc: "1.85.0"
+            rustc: "1.91.0"
             extra_args: --no-fail-fast
             notest_cuda_compilers: clang++
             extra_desc: cuda12.8

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # Should match .rustfmt.toml
 edition = "2024"
 name = "sccache"
-rust-version = "1.85.0"
+rust-version = "1.91.0"
 version = "0.17.0"
 
 categories = ["command-line-utilities", "development-tools::build-utils"]

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ And you can build code as usual without any additional flags in the command line
 Build Requirements
 ------------------
 
-sccache is a [Rust](https://www.rust-lang.org/) program. Building it requires `cargo` (and thus`rustc`). sccache currently requires **Rust 1.85.0**. We recommend you install Rust via [Rustup](https://rustup.rs/).
+sccache is a [Rust](https://www.rust-lang.org/) program. Building it requires `cargo` (and thus`rustc`). sccache currently requires **Rust 1.91.0**. We recommend you install Rust via [Rustup](https://rustup.rs/).
 
 Build
 -----

--- a/src/cache/cache_io.rs
+++ b/src/cache/cache_io.rs
@@ -183,13 +183,13 @@ impl CacheRead {
                         let mut f = std::fs::File::create(&path)?;
                         // `optional` is false in this branch, so do not ignore errors
                         let mode = self.get_object(&key, &mut f)?;
-                        if let Some(mode) = mode {
-                            if let Err(e) = set_file_mode(path.as_path(), mode) {
-                                // Here we ignore errors from setting file mode because
-                                // if we could not create a temp file in the same directory,
-                                // we probably can't set the mode either (e.g. /dev/stuff)
-                                warn!("Failed to reset file mode: {e}");
-                            }
+                        if let Some(mode) = mode
+                            && let Err(e) = set_file_mode(path.as_path(), mode)
+                        {
+                            // Here we ignore errors from setting file mode because
+                            // if we could not create a temp file in the same directory,
+                            // we probably can't set the mode either (e.g. /dev/stuff)
+                            warn!("Failed to reset file mode: {e}");
                         }
                     }
                     // skip if no object found and it's optional

--- a/src/cache/utils.rs
+++ b/src/cache/utils.rs
@@ -18,7 +18,7 @@ use crate::errors::*;
 
 /// Normalize key `abcdef` into `a/b/c/abcdef`
 pub(in crate::cache) fn normalize_key(key: &str) -> String {
-    format!("{}/{}/{}/{}", &key[0..1], &key[1..2], &key[2..3], &key)
+    format!("{}/{}/{}/{}", &key[0..1], &key[1..2], &key[2..3], key)
 }
 
 #[cfg(unix)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -52,10 +52,10 @@ const SERVER_STARTUP_TIMEOUT: Duration = Duration::from_millis(10000);
 /// Get the port on which the server should listen.
 fn get_addr() -> crate::net::SocketAddr {
     #[cfg(unix)]
-    if let Ok(addr) = env::var("SCCACHE_SERVER_UDS") {
-        if let Ok(uds) = crate::net::SocketAddr::parse_uds(&addr) {
-            return uds;
-        }
+    if let Ok(addr) = env::var("SCCACHE_SERVER_UDS")
+        && let Ok(uds) = crate::net::SocketAddr::parse_uds(&addr)
+    {
+        return uds;
     }
     let port = env::var("SCCACHE_SERVER_PORT")
         .ok()
@@ -164,7 +164,7 @@ fn create_error_log() -> Result<File> {
     let f = match OpenOptions::new().create(true).append(true).open(&name) {
         Ok(f) => f,
         Err(_) => {
-            bail!("Cannot open/write log file '{}'", &name);
+            bail!("Cannot open/write log file '{}'", name);
         }
     };
     Ok(f)
@@ -746,7 +746,7 @@ pub fn run_command(cmd: Command) -> Result<i32> {
                     continue;
                 }
                 println!("=========================");
-                println!("Showing preprocessor entry file {}", &path.display());
+                println!("Showing preprocessor entry file {}", path.display());
                 let contents = std::fs::read(path)?;
                 let preprocessor_cache_entry =
                     crate::compiler::PreprocessorCacheEntry::read(&contents)?;

--- a/src/compiler/args.rs
+++ b/src/compiler/args.rs
@@ -184,12 +184,12 @@ impl<T: ArgumentValue> Iterator for Iter<'_, T> {
                 (0, &ArgDisposition::CanBeSeparated(d)) | (0, &ArgDisposition::Concatenated(d)) => {
                     let mut s = OsString::from(s);
                     let v = v.clone().into_arg_os_string();
-                    if let Some(d) = d {
-                        if !v.is_empty() {
-                            s.push(OsString::from(
-                                str::from_utf8(&[d]).expect("delimiter should be ascii"),
-                            ));
-                        }
+                    if let Some(d) = d
+                        && !v.is_empty()
+                    {
+                        s.push(OsString::from(
+                            str::from_utf8(&[d]).expect("delimiter should be ascii"),
+                        ));
                     }
                     s.push(v);
                     Some(s)
@@ -238,10 +238,10 @@ impl<T: ArgumentValue, F: FnMut(&Path) -> Option<String>> Iterator for IterStrin
                         Ok(s) => s,
                         Err(e) => return Some(Err(e)),
                     };
-                    if let Some(d) = d {
-                        if !v.is_empty() {
-                            s.push_str(str::from_utf8(&[d]).expect("delimiter should be ascii"));
-                        }
+                    if let Some(d) = d
+                        && !v.is_empty()
+                    {
+                        s.push_str(str::from_utf8(&[d]).expect("delimiter should be ascii"));
                     }
                     s.push_str(&v);
                     Some(Ok(s))
@@ -426,10 +426,10 @@ impl<T: ArgumentValue> ArgInfo<T> {
             ArgInfo::TakeArg(s, create, ArgDisposition::Concatenated(d)) => {
                 let mut len = s.len();
                 debug_assert_eq!(&arg[..len], s);
-                if let Some(d) = d {
-                    if arg.as_bytes().get(len) == Some(&d) {
-                        len += 1;
-                    }
+                if let Some(d) = d
+                    && arg.as_bytes().get(len) == Some(&d)
+                {
+                    len += 1;
                 }
                 Argument::WithValue(
                     s,

--- a/src/compiler/c.rs
+++ b/src/compiler/c.rs
@@ -460,71 +460,63 @@ where
         };
 
         let (preprocessor_output, include_files) = if needs_preprocessing {
-            if let Some(preprocessor_key) = &preprocessor_key {
-                if cache_control == CacheControl::Default {
-                    if let Some(mut seekable) = storage
-                        .get_preprocessor_cache_entry(preprocessor_key)
-                        .await?
+            if let Some(preprocessor_key) = &preprocessor_key
+                && cache_control == CacheControl::Default
+                && let Some(mut seekable) = storage
+                    .get_preprocessor_cache_entry(preprocessor_key)
+                    .await?
+            {
+                let mut buf = vec![];
+                seekable.read_to_end(&mut buf)?;
+                let mut preprocessor_cache_entry = PreprocessorCacheEntry::read(&buf)?;
+                let mut updated = false;
+                let hit = preprocessor_cache_entry
+                    .lookup_result_digest(preprocessor_cache_mode_config, &mut updated);
+
+                let mut update_failed = false;
+                if updated {
+                    // Time macros have been found, we need to update
+                    // the preprocessor cache entry. See [`PreprocessorCacheEntry::result_matches`].
+                    debug!("Preprocessor cache updated because of time macros: {preprocessor_key}");
+
+                    if let Err(e) = storage
+                        .put_preprocessor_cache_entry(preprocessor_key, preprocessor_cache_entry)
+                        .await
                     {
-                        let mut buf = vec![];
-                        seekable.read_to_end(&mut buf)?;
-                        let mut preprocessor_cache_entry = PreprocessorCacheEntry::read(&buf)?;
-                        let mut updated = false;
-                        let hit = preprocessor_cache_entry
-                            .lookup_result_digest(preprocessor_cache_mode_config, &mut updated);
+                        debug!("Failed to update preprocessor cache: {}", e);
+                        update_failed = true;
+                    }
+                }
 
-                        let mut update_failed = false;
-                        if updated {
-                            // Time macros have been found, we need to update
-                            // the preprocessor cache entry. See [`PreprocessorCacheEntry::result_matches`].
-                            debug!(
-                                "Preprocessor cache updated because of time macros: {preprocessor_key}"
-                            );
-
-                            if let Err(e) = storage
-                                .put_preprocessor_cache_entry(
-                                    preprocessor_key,
-                                    preprocessor_cache_entry,
-                                )
-                                .await
-                            {
-                                debug!("Failed to update preprocessor cache: {}", e);
-                                update_failed = true;
-                            }
-                        }
-
-                        if !update_failed {
-                            if let Some(key) = hit {
-                                debug!("Preprocessor cache hit: {preprocessor_key}");
-                                // A compiler binary may be a symlink to another and
-                                // so has the same digest, but that means
-                                // the toolchain will not contain the correct path
-                                // to invoke the compiler! Add the compiler
-                                // executable path to try and prevent this
-                                let weak_toolchain_key = format!(
-                                    "{}-{}",
-                                    self.executable.to_string_lossy(),
-                                    self.executable_digest
-                                );
-                                return Ok(HashResult {
-                                    key,
-                                    compilation: Box::new(CCompilation {
-                                        parsed_args: self.parsed_args.clone(),
-                                        is_locally_preprocessed: false,
-                                        #[cfg(feature = "dist-client")]
-                                        preprocessed_input: PREPROCESSING_SKIPPED_COMPILE_POISON
-                                            .to_vec(),
-                                        executable: self.executable.clone(),
-                                        compiler: self.compiler.to_owned(),
-                                        cwd: cwd.clone(),
-                                        env_vars: env_vars.clone(),
-                                    }),
-                                    weak_toolchain_key,
-                                });
-                            } else {
-                                debug!("Preprocessor cache miss: {preprocessor_key}");
-                            }
-                        }
+                if !update_failed {
+                    if let Some(key) = hit {
+                        debug!("Preprocessor cache hit: {preprocessor_key}");
+                        // A compiler binary may be a symlink to another and
+                        // so has the same digest, but that means
+                        // the toolchain will not contain the correct path
+                        // to invoke the compiler! Add the compiler
+                        // executable path to try and prevent this
+                        let weak_toolchain_key = format!(
+                            "{}-{}",
+                            self.executable.to_string_lossy(),
+                            self.executable_digest
+                        );
+                        return Ok(HashResult {
+                            key,
+                            compilation: Box::new(CCompilation {
+                                parsed_args: self.parsed_args.clone(),
+                                is_locally_preprocessed: false,
+                                #[cfg(feature = "dist-client")]
+                                preprocessed_input: PREPROCESSING_SKIPPED_COMPILE_POISON.to_vec(),
+                                executable: self.executable.clone(),
+                                compiler: self.compiler.to_owned(),
+                                cwd: cwd.clone(),
+                                env_vars: env_vars.clone(),
+                            }),
+                            weak_toolchain_key,
+                        });
+                    } else {
+                        debug!("Preprocessor cache miss: {preprocessor_key}");
                     }
                 }
             }
@@ -553,7 +545,7 @@ where
 
             let mut preprocessor_result = result.or_else(move |err| {
                 // Errors remove all traces of potential output.
-                debug!("removing files {:?}", &outputs);
+                debug!("removing files {:?}", outputs);
 
                 let v: std::result::Result<(), std::io::Error> =
                     outputs.values().try_for_each(|output| {
@@ -638,22 +630,22 @@ where
         .compute();
 
         // Cache the preprocessing step
-        if let Some(preprocessor_key) = preprocessor_key {
-            if !include_files.is_empty() {
-                let mut preprocessor_cache_entry = PreprocessorCacheEntry::new();
-                let mut files: Vec<_> = include_files
-                    .into_iter()
-                    .map(|(path, digest)| (digest, path))
-                    .collect();
-                files.sort_unstable_by(|a, b| a.1.cmp(&b.1));
-                preprocessor_cache_entry.add_result(start_of_compilation, &key, files);
+        if let Some(preprocessor_key) = preprocessor_key
+            && !include_files.is_empty()
+        {
+            let mut preprocessor_cache_entry = PreprocessorCacheEntry::new();
+            let mut files: Vec<_> = include_files
+                .into_iter()
+                .map(|(path, digest)| (digest, path))
+                .collect();
+            files.sort_unstable_by(|a, b| a.1.cmp(&b.1));
+            preprocessor_cache_entry.add_result(start_of_compilation, &key, files);
 
-                if let Err(e) = storage
-                    .put_preprocessor_cache_entry(&preprocessor_key, preprocessor_cache_entry)
-                    .await
-                {
-                    debug!("Failed to update preprocessor cache: {}", e);
-                }
+            if let Err(e) = storage
+                .put_preprocessor_cache_entry(&preprocessor_key, preprocessor_cache_entry)
+                .await
+            {
+                debug!("Failed to update preprocessor cache: {}", e);
             }
         }
 
@@ -1160,19 +1152,19 @@ fn include_is_too_new(
 ) -> bool {
     // The comparison using >= is intentional, due to a possible race between
     // starting compilation and writing the include file.
-    if let Some(mtime) = meta.modified {
-        if mtime >= time_of_compilation.into() {
-            debug!("Include file {} is too new", path.display());
-            return true;
-        }
+    if let Some(mtime) = meta.modified
+        && mtime >= time_of_compilation.into()
+    {
+        debug!("Include file {} is too new", path.display());
+        return true;
     }
 
     // The same >= logic as above applies to the change time of the file.
-    if let Some(ctime) = meta.ctime_or_creation {
-        if ctime >= time_of_compilation.into() {
-            debug!("Include file {} is too new", path.display());
-            return true;
-        }
+    if let Some(ctime) = meta.ctime_or_creation
+        && ctime >= time_of_compilation.into()
+    {
+        debug!("Include file {} is too new", path.display());
+        return true;
     }
 
     false

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1536,10 +1536,10 @@ where
     child.env_clear().envs(env.to_vec()).args(&["-vV"]);
 
     let rustc_vv = run_input_output(child, None).await.map(|output| {
-        if let Ok(stdout) = String::from_utf8(output.stdout.clone()) {
-            if stdout.starts_with("rustc ") {
-                return Ok(stdout);
-            }
+        if let Ok(stdout) = String::from_utf8(output.stdout.clone())
+            && stdout.starts_with("rustc ")
+        {
+            return Ok(stdout);
         }
         Err(ProcessError(output))
     })?;
@@ -1564,7 +1564,7 @@ where
                         // take the pathbuf for rustc as resolved by the proxy
                         match proxy.resolve_proxied_executable(creator1, cwd, env).await {
                             Ok((resolved_path, _time)) => {
-                                trace!("Resolved path with rustup proxy {:?}", &resolved_path);
+                                trace!("Resolved path with rustup proxy {:?}", resolved_path);
                                 Ok((Some(proxy), resolved_path))
                             }
                             Err(e) => {

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -811,38 +811,38 @@ pub fn parse_arguments(
             }
         }
     }
-    if language == Language::Cxx {
-        if let Some(obj) = outputs.get("obj") {
-            // MSVC can produce "type library headers"[1], with the extensions "tlh" and "tli".
-            // These files can be used in later compilation steps to interact with COM interfaces.
-            //
-            // These files are only created when the `#import` directive is used.
-            // Figuring out if an import directive is used would require parsing C++, which would be a lot of work.
-            // To avoid that problem, we just optionally cache these headers if they happen to be produced.
-            // This isn't perfect, but it is easy!
-            //
-            // [1]: https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170#_predir_the_23import_directive_header_files_created_by_import
-            let tlh = obj.path.with_extension("tlh");
-            let tli = obj.path.with_extension("tli");
+    if language == Language::Cxx
+        && let Some(obj) = outputs.get("obj")
+    {
+        // MSVC can produce "type library headers"[1], with the extensions "tlh" and "tli".
+        // These files can be used in later compilation steps to interact with COM interfaces.
+        //
+        // These files are only created when the `#import` directive is used.
+        // Figuring out if an import directive is used would require parsing C++, which would be a lot of work.
+        // To avoid that problem, we just optionally cache these headers if they happen to be produced.
+        // This isn't perfect, but it is easy!
+        //
+        // [1]: https://learn.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=msvc-170#_predir_the_23import_directive_header_files_created_by_import
+        let tlh = obj.path.with_extension("tlh");
+        let tli = obj.path.with_extension("tli");
 
-            // Primary type library header
-            outputs.insert(
-                "tlh",
-                ArtifactDescriptor {
-                    path: tlh,
-                    optional: true,
-                },
-            );
+        // Primary type library header
+        outputs.insert(
+            "tlh",
+            ArtifactDescriptor {
+                path: tlh,
+                optional: true,
+            },
+        );
 
-            // Secondary type library header
-            outputs.insert(
-                "tli",
-                ArtifactDescriptor {
-                    path: tli,
-                    optional: true,
-                },
-            );
-        }
+        // Secondary type library header
+        outputs.insert(
+            "tli",
+            ArtifactDescriptor {
+                path: tli,
+                optional: true,
+            },
+        );
     }
     // -Fd is not taken into account unless -Zi or -ZI are given
     // Clang is currently unable to generate PDB files
@@ -923,7 +923,7 @@ fn normpath(path: &str) -> String {
             let o = OsString::from_wide(&wchars[4..wchars.len() - 1]);
             o.into_string()
                 .map(|s| s.replace('\\', "/"))
-                .map_err(|_| io::Error::new(io::ErrorKind::Other, "Error converting string"))
+                .map_err(|_| io::Error::other("Error converting string"))
         })
         .unwrap_or_else(|_| path.replace('\\', "/"))
 }

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -381,10 +381,10 @@ pub fn generate_compile_commands(
             }
             if let Some(idx) = unhashed_args.iter().position(|x| x == "--threads") {
                 let arg = unhashed_args.get(idx + 1);
-                if let Some(arg) = arg.and_then(|arg| arg.to_str()) {
-                    if let Ok(arg) = arg.parse::<usize>() {
-                        num_parallel = arg;
-                    }
+                if let Some(arg) = arg.and_then(|arg| arg.to_str())
+                    && let Ok(arg) = arg.parse::<usize>()
+                {
+                    num_parallel = arg;
                 }
                 unhashed_args.splice(idx..(idx + 2), []);
                 continue;
@@ -782,13 +782,13 @@ where
             }
             Some("ptxas") => {
                 let group = device_compile_groups.values_mut().find(|cmds| {
-                    if let Some(cicc) = cmds.last() {
-                        if let Some(cicc_out) = cicc.args.last() {
-                            return args
-                                .iter()
-                                .find(|arg| cicc::is_ptxas_input(OsStr::new(arg)))
-                                .is_some_and(|input| cicc_out == input);
-                        }
+                    if let Some(cicc) = cmds.last()
+                        && let Some(cicc_out) = cicc.args.last()
+                    {
+                        return args
+                            .iter()
+                            .find(|arg| cicc::is_ptxas_input(OsStr::new(arg)))
+                            .is_some_and(|input| cicc_out == input);
                     }
                     false
                 });
@@ -798,11 +798,11 @@ where
             Some("cudafe++") => {
                 // Fix for CTK < 12.0:
                 // Add `--gen_module_id_file` if the cudafe++ args include `--module_id_file_name`
-                if !args.contains(&gen_module_id_file_flag) {
-                    if let Some(idx) = args.iter().position(|x| x == "--module_id_file_name") {
-                        // Insert `--gen_module_id_file` just before `--module_id_file_name` to match nvcc behavior
-                        args.splice(idx..idx, [gen_module_id_file_flag.clone()]);
-                    }
+                if !args.contains(&gen_module_id_file_flag)
+                    && let Some(idx) = args.iter().position(|x| x == "--module_id_file_name")
+                {
+                    // Insert `--gen_module_id_file` just before `--module_id_file_name` to match nvcc behavior
+                    args.splice(idx..idx, [gen_module_id_file_flag.clone()]);
                 }
                 (
                     env_vars.clone(),
@@ -1112,10 +1112,10 @@ fn fold_env_vars_or_split_into_exe_and_args(
     // Expand envvars in nvcc subcommands, i.e. "$CICC_PATH/cicc ..." or "%CICC_PATH%/cicc"
     if let Some(env_vars) = dist::osstring_tuples_to_strings(env_vars) {
         for (var, val) in env_vars {
-            if let Some(re) = env_var_re_map.get(&var) {
-                if re.is_match(&line) {
-                    line = line.replace(&envvar_in_shell_format(&var), &val);
-                }
+            if let Some(re) = env_var_re_map.get(&var)
+                && re.is_match(&line)
+            {
+                line = line.replace(&envvar_in_shell_format(&var), &val);
             }
         }
     }

--- a/src/compiler/rust.rs
+++ b/src/compiler/rust.rs
@@ -585,10 +585,7 @@ where
                 .context("Failed to parse output of rustup which rustc")?;
 
             let proxied_compiler = PathBuf::from(stdout.trim());
-            trace!(
-                "proxy: rustup which rustc produced: {:?}",
-                &proxied_compiler
-            );
+            trace!("proxy: rustup which rustc produced: {:?}", proxied_compiler);
             // TODO: Delegate FS access to a thread pool if possible
             let attr = fs::metadata(proxied_compiler.as_path())
                 .context("Failed to obtain metadata of the resolved, true rustc")?;
@@ -725,7 +722,7 @@ impl RustupProxy {
                 let stdout = String::from_utf8(rustup_candidate_check.stdout)
                     .map_err(|_e| anyhow!("Response of `rustup --version` is not valid UTF-8"))?;
                 Ok(if stdout.trim().starts_with("rustup ") {
-                    trace!("PROXY rustup --version produced: {}", &stdout);
+                    trace!("PROXY rustup --version produced: {}", stdout);
                     Self::new(&proxy_executable).map(Some)
                 } else {
                     Err(anyhow!("Unexpected output or `rustup --version`"))
@@ -1238,14 +1235,13 @@ fn parse_arguments(arguments: &[OsString], cwd: &Path) -> CompilerArguments<Pars
             None => {
                 match arg {
                     Argument::Raw(ref val) => {
-                        if idx == 0 {
-                            if let Some(value) = val.to_str() {
-                                if value == "rustc" {
-                                    // If the first argument is rustc, it's likely called via clippy-driver,
-                                    // so it's not actually an input file, which means we should discount it.
-                                    continue;
-                                }
-                            }
+                        if idx == 0
+                            && let Some(value) = val.to_str()
+                            && value == "rustc"
+                        {
+                            // If the first argument is rustc, it's likely called via clippy-driver,
+                            // so it's not actually an input file, which means we should discount it.
+                            continue;
                         }
                         if input.is_some() {
                             // Can't cache compilations with multiple inputs.
@@ -1873,10 +1869,10 @@ impl<T: CommandCreatorSync> Compilation<T> for RustCompilation {
             }
             // OUT_DIR was changed during transformation, check if this compilation is relying on anything
             // inside it - if so, disallow distributed compilation (there are sometimes hardcoded paths present)
-            if let Some(out_dir) = changed_out_dir {
-                if self.inputs.iter().any(|input| input.starts_with(&out_dir)) {
-                    return None;
-                }
+            if let Some(out_dir) = changed_out_dir
+                && self.inputs.iter().any(|input| input.starts_with(&out_dir))
+            {
+                return None;
             }
 
             // Add any necessary path transforms - although we haven't packaged up inputs yet, we've
@@ -1892,7 +1888,7 @@ impl<T: CommandCreatorSync> Compilation<T> for RustCompilation {
                 if remapped_disks.contains(&dist_path) {
                     continue;
                 }
-                dist_arguments.push(format!("--remap-path-prefix={}={}", &dist_path, local_path));
+                dist_arguments.push(format!("--remap-path-prefix={}={}", dist_path, local_path));
                 remapped_disks.insert(dist_path);
             }
 
@@ -2103,18 +2099,17 @@ impl pkg::InputsPackager for RustInputsPackager {
                         "Cannot distribute dylib input {} on this platform",
                         input_path.display()
                     )
-                } else if ext == RLIB_EXTENSION || ext == RMETA_EXTENSION {
-                    if let Some((ref rlib_dep_reader, ref mut dep_crate_names)) =
+                } else if (ext == RLIB_EXTENSION || ext == RMETA_EXTENSION)
+                    && let Some((ref rlib_dep_reader, ref mut dep_crate_names)) =
                         rlib_dep_reader_and_names
-                    {
-                        dep_crate_names.extend(
-                            rlib_dep_reader
-                                .discover_rlib_deps(&env_vars, &input_path)
-                                .with_context(|| {
-                                    format!("Failed to read deps of {}", input_path.display())
-                                })?,
-                        );
-                    }
+                {
+                    dep_crate_names.extend(
+                        rlib_dep_reader
+                            .discover_rlib_deps(&env_vars, &input_path)
+                            .with_context(|| {
+                                format!("Failed to read deps of {}", input_path.display())
+                            })?,
+                    );
                 }
             }
 
@@ -2137,10 +2132,10 @@ impl pkg::InputsPackager for RustInputsPackager {
             tar_inputs.push((input_path, dist_input_path));
         }
 
-        if log_enabled!(Trace) {
-            if let Some((_, ref dep_crate_names)) = rlib_dep_reader_and_names {
-                trace!("Identified dependency crate names: {:?}", dep_crate_names);
-            }
+        if log_enabled!(Trace)
+            && let Some((_, ref dep_crate_names)) = rlib_dep_reader_and_names
+        {
+            trace!("Identified dependency crate names: {:?}", dep_crate_names);
         }
 
         // Given the link paths, find the things we need to send over the wire to the remote machine. If
@@ -2409,7 +2404,7 @@ src/bin/sccache-dist/token_check.rs:
         dep_info: Some(depinfo_file.clone()),
     });
     let () = ror
-        .handle_outputs(&pt, &[depinfo_file.clone()], &[])
+        .handle_outputs(&pt, std::slice::from_ref(&depinfo_file), &[])
         .unwrap();
 
     let mut s = String::new();
@@ -2586,10 +2581,10 @@ impl RlibDepReader {
 
         {
             let mut cache = self.cache.lock().unwrap();
-            if let Some(deps_detail) = cache.get(rlib) {
-                if rlib_mtime == deps_detail.mtime {
-                    return Ok(deps_detail.deps.clone());
-                }
+            if let Some(deps_detail) = cache.get(rlib)
+                && rlib_mtime == deps_detail.mtime
+            {
+                return Ok(deps_detail.deps.clone());
             }
         }
 

--- a/src/jobserver.rs
+++ b/src/jobserver.rs
@@ -38,34 +38,32 @@ pub unsafe fn discard_inherited_jobserver() {
     if let Some(value) = ["CARGO_MAKEFLAGS", "MAKEFLAGS", "MFLAGS"]
         .into_iter()
         .find_map(|env| std::env::var(env).ok())
-    {
-        if let Some(auth) = value.rsplit(' ').find_map(|arg| {
+        && let Some(auth) = value.rsplit(' ').find_map(|arg| {
             arg.strip_prefix("--jobserver-auth=")
                 .or_else(|| arg.strip_prefix("--jobserver-fds="))
-        }) {
-            if !auth.starts_with("fifo:") {
-                let mut parts = auth.splitn(2, ',');
-                let read = parts.next().unwrap();
-                let write = match parts.next() {
-                    Some(w) => w,
-                    None => return,
-                };
-                let read = read.parse().unwrap();
-                let write = write.parse().unwrap();
-                if read < 0 || write < 0 {
-                    return;
-                }
-                unsafe {
-                    if libc::fcntl(read, libc::F_GETFD) == -1 {
-                        return;
-                    }
-                    if libc::fcntl(write, libc::F_GETFD) == -1 {
-                        return;
-                    }
-                    libc::close(read);
-                    libc::close(write);
-                }
+        })
+        && !auth.starts_with("fifo:")
+    {
+        let mut parts = auth.splitn(2, ',');
+        let read = parts.next().unwrap();
+        let write = match parts.next() {
+            Some(w) => w,
+            None => return,
+        };
+        let read = read.parse().unwrap();
+        let write = write.parse().unwrap();
+        if read < 0 || write < 0 {
+            return;
+        }
+        unsafe {
+            if libc::fcntl(read, libc::F_GETFD) == -1 {
+                return;
             }
+            if libc::fcntl(write, libc::F_GETFD) == -1 {
+                return;
+            }
+            libc::close(read);
+            libc::close(write);
         }
     }
 }

--- a/src/lru_disk_cache/mod.rs
+++ b/src/lru_disk_cache/mod.rs
@@ -263,10 +263,10 @@ impl LruDiskCache {
         size: Option<u64>,
         by: F,
     ) -> Result<()> {
-        if let Some(size) = size {
-            if !self.can_store(size) {
-                return Err(Error::FileTooLarge);
-            }
+        if let Some(size) = size
+            && !self.can_store(size)
+        {
+            return Err(Error::FileTooLarge);
         }
         let rel_path = key.as_ref();
         let path = self.rel_to_abs_path(rel_path);

--- a/src/mock_command.rs
+++ b/src/mock_command.rs
@@ -405,6 +405,10 @@ impl CommandChild for MockChild {
 
 pub enum ChildOrCall {
     Child(Result<MockChild>),
+    #[allow(
+        dead_code,
+        reason = "Read in the async_trait below, but rustc doesn't see it as used"
+    )]
     Call(Box<dyn Fn(&[OsString]) -> Result<MockChild> + Send>),
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1315,7 +1315,7 @@ where
                 let (c, proxy) = match info {
                     Ok((c, proxy)) => (c.clone(), proxy.clone()),
                     Err(err) => {
-                        trace!("Inserting PLAIN cache map info for {:?}", &path);
+                        trace!("Inserting PLAIN cache map info for {:?}", path);
                         me.compilers.write().await.insert(path, None);
 
                         return Err(err);
@@ -1328,7 +1328,7 @@ where
                 if let Some(proxy) = proxy {
                     trace!(
                         "Inserting new path proxy {:?} @ {:?} -> {:?}",
-                        &path, &cwd, resolved_compiler_path
+                        path, cwd, resolved_compiler_path
                     );
                     me.compiler_proxies
                         .write()
@@ -1342,7 +1342,7 @@ where
                 let map_info = CompilerCacheEntry::new(c.clone(), mtime, dist_info);
                 trace!(
                     "Inserting POSSIBLY PROXIED cache map info for {:?}",
-                    &resolved_compiler_path
+                    resolved_compiler_path
                 );
                 me.compilers
                     .write()

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -88,10 +88,10 @@ where
         let mut srv: SccacheServer<_, Arc<Mutex<MockCommandCreator>>> = srv;
         let addr = srv.local_addr().unwrap();
         assert!(matches!(addr, crate::net::SocketAddr::Net(a) if a.port() > 0));
-        if let Some(options) = options {
-            if let Some(timeout) = options.idle_timeout {
-                srv.set_idle_timeout(Duration::from_millis(timeout));
-            }
+        if let Some(options) = options
+            && let Some(timeout) = options.idle_timeout
+        {
+            srv.set_idle_timeout(Duration::from_millis(timeout));
         }
         let creator = srv.command_creator().clone();
         tx.send((addr, creator)).unwrap();


### PR DESCRIPTION
In preparation of the opendal bump to version 0.58.1. opendal 0.58.1 has an MSRV of 1.91.0, so sccache needs to match this in order to bump the opendal dependency.

cc #2715