### PR TITLE
feat: add Microsoft Entra ID (passwordless) auth for the Azure Blob backend

### DIFF
--- a/docs/Azure.md
+++ b/docs/Azure.md
@@ -1,11 +1,79 @@
 # Azure
 
-To use Azure Blob Storage, you'll need your Azure connection string and an _existing_ Blob Storage container name.  Set the `SCCACHE_AZURE_CONNECTION_STRING`
-environment variable to your connection string, and `SCCACHE_AZURE_BLOB_CONTAINER` to the name of the container to use.  Note that sccache will not create
-the container for you - you'll need to do that yourself.
+sccache can store its cache in an Azure Blob Storage container using either a
+shared-key connection string or Microsoft Entra ID (passwordless) authentication.
+In both cases set `SCCACHE_AZURE_BLOB_CONTAINER` to the name of an _existing_
+container — sccache will not create it for you.
 
-You can also define a prefix that will be prepended to the keys of all cache objects created and read within the container, effectively creating a scope. To do that use the `SCCACHE_AZURE_KEY_PREFIX` environment variable. This can be useful when sharing a bucket with another application.
+## Shared key (connection string)
 
-The `SCCACHE_AZURE_RW_MODE` environment variable can be set to `READ_ONLY` to make sccache use this backend in read-only mode. The default is `READ_WRITE`.
+Set the `SCCACHE_AZURE_CONNECTION_STRING` environment variable to your storage
+account connection string.
 
-**Important:** The environment variables are only taken into account when the server starts, i.e. only on the first run.
+## Microsoft Entra ID (passwordless)
+
+Use this when the storage account has shared-key access disabled. Instead of a
+connection string, tell sccache which account to talk to with one of the
+following (if both are set, `SCCACHE_AZURE_ENDPOINT` takes precedence):
+
+* `SCCACHE_AZURE_STORAGE_ACCOUNT` — the storage account name. sccache builds the
+  endpoint `https://{account}.blob.core.windows.net`.
+* `SCCACHE_AZURE_ENDPOINT` — a full blob endpoint, for sovereign clouds
+  (`https://{account}.blob.core.usgovcloudapi.net`,
+  `https://{account}.blob.core.chinacloudapi.cn`) or custom DNS. Takes
+  precedence over `SCCACHE_AZURE_STORAGE_ACCOUNT`. It must use `https`; plain
+  `http` is accepted only for a loopback host.
+
+`SCCACHE_AZURE_CONNECTION_STRING` and `SCCACHE_AZURE_STORAGE_ACCOUNT` /
+`SCCACHE_AZURE_ENDPOINT` are mutually exclusive.
+
+> **Azurite:** the local emulator authenticates with its well-known shared key,
+> so point sccache at it with `SCCACHE_AZURE_CONNECTION_STRING` (the shared-key
+> section above), not the passwordless path — the latter would require Azurite's
+> non-default OAuth mode plus an ambient Entra credential.
+
+Credentials are then resolved from the ambient environment, in this order:
+
+1. **Service principal** — `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`.
+2. **Workload identity** (AKS / Kubernetes / federated OIDC) — `AZURE_TENANT_ID`,
+   `AZURE_CLIENT_ID`, `AZURE_FEDERATED_TOKEN_FILE`.
+3. **Managed identity** via the instance-metadata endpoint (`169.254.169.254`) —
+   Azure **VM / VM Scale Sets** and self-hosted CI agents running on them. No
+   variables required; set `AZURE_CLIENT_ID` to select a specific user-assigned
+   identity.
+
+> **Managed-identity limitations.** App Service, Functions, Container Apps, and
+> Container Instances expose managed identity only over the `IDENTITY_ENDPOINT`
+> protocol, which this backend does not use — prefer **workload identity** or a
+> **service principal** on those hosts. In any environment with an HTTP proxy
+> configured, add `169.254.169.254` to `NO_PROXY`, or the metadata request is
+> routed to the proxy and fails. Credentials resolve lazily, so a misconfigured
+> passwordless setup builds successfully and fails only on the first cache
+> access, not at server startup.
+
+For **sovereign clouds**, `AZURE_AUTHORITY_HOST` is **required** for the service
+principal and workload identity flows (it defaults to
+`https://login.microsoftonline.com`): use `https://login.microsoftonline.us`
+(US Gov) or `https://login.partner.microsoftonline.cn` (China). Managed identity
+via IMDS does not need it. The identity needs a data-plane role on the container:
+**Storage Blob Data Contributor** for `READ_WRITE` (the default), or **Storage
+Blob Data Reader** when `SCCACHE_AZURE_RW_MODE=READ_ONLY`. sccache does not read
+or log any `AZURE_*` value — they are consumed directly by the underlying storage
+SDK when signing requests with an OAuth bearer token.
+
+> **Note:** the underlying storage SDK also honours the ambient
+> `AZBLOB_ACCOUNT_KEY` / `AZBLOB_SAS_TOKEN` variables, which take precedence over
+> Entra ID credentials. Unset them if you intend to authenticate passwordlessly.
+
+## Common options
+
+You can define a prefix that will be prepended to the keys of all cache objects
+created and read within the container, effectively creating a scope. To do that
+use the `SCCACHE_AZURE_KEY_PREFIX` environment variable. This can be useful when
+sharing a container with another application.
+
+The `SCCACHE_AZURE_RW_MODE` environment variable can be set to `READ_ONLY` to
+make sccache use this backend in read-only mode. The default is `READ_WRITE`.
+
+**Important:** The environment variables are only taken into account when the
+server starts, i.e. only on the first run.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -48,12 +48,20 @@ chain = ["disk", "redis", "s3"]
 write_error_policy = "l0"  # Optional: ignore, l0 (default), or all
 
 #[cache.azure]
-# Azure Storage connection string (see <https://docs.azure.cn/en-us/storage/common/storage-configure-connection-string>)
-connection_string = "BlobEndpoint=https://example.blob.core.windows.net/;SharedAccessSignature=..."
-# Name of container
+# Name of container (required)
 container = "my_container_name"
 # Optional string to prepend to each blob storage key
 key_prefix = ""
+# Shared-key auth: Azure Storage connection string (see
+# <https://docs.azure.cn/en-us/storage/common/storage-configure-connection-string>).
+# Mutually exclusive with the Microsoft Entra ID (passwordless) fields below.
+connection_string = "BlobEndpoint=https://example.blob.core.windows.net/;SharedAccessSignature=..."
+# Microsoft Entra ID (passwordless) auth — set ONE of these instead of a
+# connection string; credentials are read from the ambient AZURE_* environment.
+# See docs/Azure.md.
+# storage_account = "mystorageacct"                         # endpoint synthesized as https://{account}.blob.core.windows.net
+# endpoint = "https://mystorageacct.blob.core.usgovcloudapi.net"  # full endpoint (sovereign clouds / custom DNS); https only (http for loopback)
+# NOTE: an [cache.azure] block with a container but no auth source errors at startup.
 
 [cache.disk]
 dir = "/tmp/.cache/sccache"
@@ -284,10 +292,14 @@ The full url appears then as `redis://user:passwd@1.2.3.4:6379/?db=1`.
 
 #### azure
 
-* `SCCACHE_AZURE_CONNECTION_STRING`
 * `SCCACHE_AZURE_BLOB_CONTAINER`
+* `SCCACHE_AZURE_CONNECTION_STRING` shared-key connection string. Mutually exclusive with the Entra ID variables below.
+* `SCCACHE_AZURE_STORAGE_ACCOUNT` storage account name for Microsoft Entra ID (passwordless) auth; the endpoint `https://{account}.blob.core.windows.net` is synthesized.
+* `SCCACHE_AZURE_ENDPOINT` full blob endpoint override for Entra ID auth (sovereign clouds, custom DNS); must be `https` (plain `http` only for a loopback host); takes precedence over `SCCACHE_AZURE_STORAGE_ACCOUNT`.
 * `SCCACHE_AZURE_KEY_PREFIX`
 * `SCCACHE_AZURE_RW_MODE`
+
+When using Entra ID, credentials are read from the ambient `AZURE_*` environment (`AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` for a service principal, `AZURE_FEDERATED_TOKEN_FILE` for workload identity, or IMDS for a managed identity). See [Azure.md](Azure.md).
 
 #### gha
 

--- a/src/cache/azure.rs
+++ b/src/cache/azure.rs
@@ -25,15 +25,306 @@ use super::http_client::set_user_agent;
 pub struct AzureBlobCache;
 
 impl AzureBlobCache {
-    pub fn build(connection_string: &str, container: &str, key_prefix: &str) -> Result<Operator> {
-        let builder = Azblob::from_connection_string(connection_string)?
-            .container(container)
-            .root(key_prefix);
+    /// Build an Azure Blob Storage operator.
+    ///
+    /// Two authentication paths are supported, selected by the presence of a
+    /// connection string:
+    ///
+    /// * **Shared key (connection string)** — when `connection_string` is
+    ///   `Some`, the operator is built from it, unchanged from historical
+    ///   behavior.
+    /// * **Microsoft Entra ID (passwordless)** — when `connection_string` is
+    ///   `None`, the operator is built without any account key or SAS token, so
+    ///   OpenDAL (via its bundled `reqsign` dependency) resolves credentials
+    ///   from the ambient environment and signs each request with an
+    ///   `Authorization: Bearer <token>` header. Supported credential sources,
+    ///   in the order `reqsign` tries them: a **service principal**
+    ///   (`AZURE_TENANT_ID` + `AZURE_CLIENT_ID` + `AZURE_CLIENT_SECRET`),
+    ///   **workload identity** (`AZURE_TENANT_ID` + `AZURE_CLIENT_ID` +
+    ///   `AZURE_FEDERATED_TOKEN_FILE`), then a system- or user-assigned
+    ///   **managed identity** via IMDS (`AZURE_CLIENT_ID` optionally selects a
+    ///   user-assigned identity). This path needs an explicit blob endpoint,
+    ///   resolved from `endpoint` (validated and used as-is — for sovereign
+    ///   clouds or a custom endpoint) or synthesized from `storage_account` as
+    ///   `https://{account}.blob.core.windows.net`.
+    pub fn build(
+        connection_string: Option<&str>,
+        container: &str,
+        key_prefix: &str,
+        storage_account: Option<&str>,
+        endpoint: Option<&str>,
+    ) -> Result<Operator> {
+        // Normalize empty strings to absent up front so a blank value from a
+        // file config (which, unlike the env parser, does not strip empties)
+        // behaves like an unset field for BOTH the mutual-exclusivity check and
+        // the auth-path selection below.
+        let connection_string = connection_string.filter(|s| !s.is_empty());
+        let storage_account = storage_account.filter(|s| !s.is_empty());
+        let endpoint = endpoint.filter(|s| !s.is_empty());
+
+        let builder = match connection_string {
+            Some(connection_string) => {
+                // Both the env and file config surfaces flow through here. The
+                // env parser rejects this combination too, but a file config
+                // bypasses that check, so enforce mutual exclusivity centrally.
+                if storage_account.is_some() || endpoint.is_some() {
+                    bail!(
+                        "Azure cache accepts either a connection string or a storage account / endpoint (Entra ID), not both."
+                    );
+                }
+                Azblob::from_connection_string(connection_string)?
+                    .container(container)
+                    .root(key_prefix)
+            }
+            None => {
+                // Entra ID / passwordless path. Deliberately leave account_key,
+                // sas_token and connection_string unset: OpenDAL then loads
+                // Entra credentials (managed identity / workload identity /
+                // service principal) from the environment via reqsign.
+                let endpoint = resolve_blob_endpoint(endpoint, storage_account)?;
+                Azblob::default()
+                    .endpoint(&endpoint)
+                    .container(container)
+                    .root(key_prefix)
+            }
+        };
 
         let op = Operator::new(builder)?
             .layer(HttpClientLayer::new(set_user_agent()))
             .layer(LoggingLayer::default())
             .finish();
         Ok(op)
+    }
+}
+
+/// Resolve the Azure Blob endpoint for the Entra ID (passwordless) path.
+///
+/// OpenDAL's Azblob backend requires an explicit endpoint and does not derive
+/// one from the account name, so callers must supply either a full `endpoint`
+/// (for sovereign clouds or a custom endpoint) or a `storage_account` name from
+/// which the public-cloud endpoint is synthesized. An explicit endpoint takes
+/// precedence.
+fn resolve_blob_endpoint(endpoint: Option<&str>, storage_account: Option<&str>) -> Result<String> {
+    // Callers normalize empty strings to absent, but do so here too so this
+    // function is correct in isolation (and unit-testable with blank inputs).
+    let endpoint = endpoint.filter(|s| !s.is_empty());
+    let storage_account = storage_account.filter(|s| !s.is_empty());
+    match (endpoint, storage_account) {
+        (Some(endpoint), _) => {
+            let endpoint = endpoint.trim_end_matches('/');
+            // The endpoint is a trust boundary: the OAuth bearer token is sent to
+            // whatever host it resolves to. Validate up front so a malformed or
+            // token-redirecting endpoint fails at startup with an actionable
+            // message rather than at first cache access, and so the token is never
+            // sent in cleartext or to an unintended host. Mirrors the S3 backend's
+            // `http::Uri` endpoint validation.
+            let uri: http::Uri = endpoint
+                .parse()
+                .map_err(|err| anyhow!("Azure endpoint `{endpoint}` is not a valid URI: {err}"))?;
+            let authority = uri
+                .authority()
+                .ok_or_else(|| anyhow!("Azure endpoint `{endpoint}` must include a host."))?;
+            // Reject `user@host` — the userinfo, not the real host, is what a
+            // reader would trust, while the bearer token goes to `host`.
+            if authority.as_str().contains('@') {
+                bail!("Azure endpoint `{endpoint}` must not contain userinfo (`user@host`).");
+            }
+            let host = uri.host().unwrap_or_default();
+            if host.is_empty() {
+                bail!("Azure endpoint `{endpoint}` must include a host.");
+            }
+            // `http::Uri::host()` returns an IPv6 authority in bracketed form;
+            // strip the brackets before parsing so `[::1]` (and expanded forms)
+            // are recognised as loopback.
+            let host_ip = host
+                .strip_prefix('[')
+                .and_then(|h| h.strip_suffix(']'))
+                .unwrap_or(host);
+            let is_loopback = host.eq_ignore_ascii_case("localhost")
+                || host_ip
+                    .parse::<std::net::IpAddr>()
+                    .map(|ip| ip.is_loopback())
+                    .unwrap_or(false);
+            match uri.scheme_str() {
+                Some("https") => {}
+                Some("http") if is_loopback => {}
+                _ => bail!(
+                    "Azure endpoint `{endpoint}` must use https (http is allowed only for a loopback host)."
+                ),
+            }
+            Ok(endpoint.to_string())
+        }
+        (None, Some(storage_account)) => {
+            // The account name is interpolated into the endpoint host, so reject
+            // anything that is not a bare account name to keep it from altering
+            // the host the OAuth bearer token is sent to.
+            if !storage_account.chars().all(|c| c.is_ascii_alphanumeric()) {
+                bail!(
+                    "Azure storage account `{storage_account}` is invalid: expected only ASCII alphanumeric characters."
+                );
+            }
+            Ok(format!("https://{storage_account}.blob.core.windows.net"))
+        }
+        (None, None) => bail!(
+            "Azure Entra ID authentication requires a storage account or blob endpoint \
+             (env `SCCACHE_AZURE_STORAGE_ACCOUNT` / `SCCACHE_AZURE_ENDPOINT`, or the \
+             `storage_account` / `endpoint` config fields)."
+        ),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_resolve_blob_endpoint_from_account() -> Result<()> {
+        assert_eq!(
+            resolve_blob_endpoint(None, Some("mystorageacct"))?,
+            "https://mystorageacct.blob.core.windows.net"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_blob_endpoint_explicit_wins_and_trims() -> Result<()> {
+        // An explicit endpoint takes precedence over the account name, and any
+        // trailing slash is trimmed (OpenDAL stores the endpoint without one).
+        assert_eq!(
+            resolve_blob_endpoint(
+                Some("https://acct.blob.core.usgovcloudapi.net/"),
+                Some("ignored")
+            )?,
+            "https://acct.blob.core.usgovcloudapi.net"
+        );
+        assert_eq!(
+            resolve_blob_endpoint(Some("http://127.0.0.1:10000/devstoreaccount1"), None)?,
+            "http://127.0.0.1:10000/devstoreaccount1"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_blob_endpoint_requires_a_source() {
+        assert!(resolve_blob_endpoint(None, None).is_err());
+    }
+
+    #[test]
+    fn test_resolve_blob_endpoint_rejects_insecure_and_malformed() {
+        // http against a non-loopback host would leak the OAuth bearer token in
+        // cleartext, and a scheme-less value is not a usable endpoint.
+        assert!(resolve_blob_endpoint(Some("http://storage.example.com"), None).is_err());
+        assert!(resolve_blob_endpoint(Some("storage.example.com"), None).is_err());
+        // Userinfo would send the token to `host`, not the trusted-looking prefix.
+        assert!(
+            resolve_blob_endpoint(
+                Some("https://acct.blob.core.windows.net@evil.example"),
+                None
+            )
+            .is_err()
+        );
+        // An authority with no host is not a usable endpoint.
+        assert!(resolve_blob_endpoint(Some("https://:443"), None).is_err());
+    }
+
+    #[test]
+    fn test_resolve_blob_endpoint_accepts_loopback_variants() {
+        // Azurite / local proxies: http is allowed for every loopback spelling,
+        // case-insensitively, including bracketed and expanded IPv6.
+        for ep in [
+            "http://127.0.0.1:10000/devstoreaccount1",
+            "http://localhost:10000/devstoreaccount1",
+            "http://LOCALHOST:10000/devstoreaccount1",
+            "http://[::1]:10000/devstoreaccount1",
+        ] {
+            assert!(resolve_blob_endpoint(Some(ep), None).is_ok(), "{ep}");
+        }
+    }
+
+    #[test]
+    fn test_resolve_blob_endpoint_rejects_account_that_alters_host() {
+        // A "storage account" carrying path/scheme separators must not be able
+        // to redirect where the bearer token is sent.
+        assert!(resolve_blob_endpoint(None, Some("acct/../evil")).is_err());
+        assert!(resolve_blob_endpoint(None, Some("acct.evil.com")).is_err());
+    }
+
+    #[test]
+    fn test_resolve_blob_endpoint_ignores_empty_strings() {
+        // An empty endpoint must not shadow a valid storage account.
+        assert_eq!(
+            resolve_blob_endpoint(Some(""), Some("acct")).unwrap(),
+            "https://acct.blob.core.windows.net"
+        );
+        assert!(resolve_blob_endpoint(Some(""), Some("")).is_err());
+    }
+
+    #[test]
+    fn test_build_entra_path_builds_operator() {
+        // No connection string + a storage account selects the Entra path. The
+        // operator is constructed lazily (no network), so build() succeeds; assert
+        // the wiring (scheme + container) rather than just that it did not panic.
+        let op = AzureBlobCache::build(None, "container", "prefix", Some("mystorageacct"), None)
+            .unwrap();
+        assert_eq!(op.info().scheme(), "azblob");
+        assert_eq!(op.info().name(), "container");
+    }
+
+    #[test]
+    fn test_build_connection_string_path_builds_operator() {
+        // AccountKey must be valid base64 (opendal validates it at build time).
+        let conn = "DefaultEndpointsProtocol=https;AccountName=acct;AccountKey=dGVzdGtleQ==;EndpointSuffix=core.windows.net";
+        let op = AzureBlobCache::build(Some(conn), "container", "prefix", None, None).unwrap();
+        assert_eq!(op.info().scheme(), "azblob");
+        assert_eq!(op.info().name(), "container");
+    }
+
+    #[test]
+    fn test_build_rejects_conflicting_auth_sources() {
+        // Both operands of the mutual-exclusivity guard are exercised: a
+        // connection string paired with a storage account, and with an endpoint.
+        let err = AzureBlobCache::build(Some("conn"), "container", "prefix", Some("acct"), None)
+            .unwrap_err();
+        assert!(err.to_string().contains("not both"));
+
+        let err = AzureBlobCache::build(
+            Some("conn"),
+            "container",
+            "prefix",
+            None,
+            Some("https://acct.blob.core.windows.net"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("not both"));
+    }
+
+    #[test]
+    fn test_build_requires_an_auth_source() {
+        // A container with no connection string and no Entra source: the error
+        // names both the env vars and the config fields, since this branch is
+        // reachable from a file config too.
+        let err = AzureBlobCache::build(None, "container", "prefix", None, None).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("storage account or blob endpoint"), "{msg}");
+    }
+
+    #[test]
+    fn test_build_blank_connection_string_falls_through_to_entra() {
+        // A blank connection_string from a file config must behave as absent and
+        // NOT be mistaken for a shared-key source that conflicts with the account.
+        assert!(
+            AzureBlobCache::build(Some(""), "container", "prefix", Some("mystorageacct"), None)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_build_blank_entra_fields_do_not_conflict_with_connection_string() {
+        // Blank storage_account/endpoint from a file config must not trip the
+        // mutual-exclusivity guard when a real connection string is set.
+        let conn = "DefaultEndpointsProtocol=https;AccountName=acct;AccountKey=dGVzdGtleQ==;EndpointSuffix=core.windows.net";
+        assert!(
+            AzureBlobCache::build(Some(conn), "container", "prefix", Some(""), Some("")).is_ok()
+        );
     }
 }

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -402,11 +402,19 @@ pub fn build_single_cache(
             connection_string,
             container,
             key_prefix,
+            storage_account,
+            endpoint,
             rw_mode,
         }) => {
             debug!("Init azure cache with container {container}, key_prefix {key_prefix}");
-            let operator = AzureBlobCache::build(connection_string, container, key_prefix)
-                .map_err(|err| anyhow!("create azure cache failed: {err:?}"))?;
+            let operator = AzureBlobCache::build(
+                connection_string.as_deref(),
+                container,
+                key_prefix,
+                storage_account.as_deref(),
+                endpoint.as_deref(),
+            )
+            .map_err(|err| anyhow!("create azure cache failed: {err:?}"))?;
             let storage = RemoteStorage::new(operator, basedirs.to_vec(), (*rw_mode).into());
             Ok(Arc::new(storage))
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -233,9 +233,18 @@ impl HTTPUrl {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AzureCacheConfig {
-    pub connection_string: String,
+    /// Shared-key connection string. When set, the shared-key path is used.
+    /// When absent, the Microsoft Entra ID (passwordless) path is used and
+    /// `storage_account`/`endpoint` supply the blob endpoint.
+    pub connection_string: Option<String>,
     pub container: String,
     pub key_prefix: String,
+    /// Storage account name for the Entra ID path. The blob endpoint is
+    /// synthesized as `https://{storage_account}.blob.core.windows.net`.
+    pub storage_account: Option<String>,
+    /// Full blob endpoint override for the Entra ID path (sovereign clouds,
+    /// custom DNS). Takes precedence over `storage_account`.
+    pub endpoint: Option<String>,
     #[serde(default)]
     pub rw_mode: CacheModeConfig,
 }
@@ -1066,20 +1075,51 @@ fn config_from_env() -> Result<EnvConfig> {
     };
 
     // ======= Azure =======
-    let azure = if let (Some(connection_string), Some(container)) = (
-        string_from_env_var("SCCACHE_AZURE_CONNECTION_STRING"),
-        string_from_env_var("SCCACHE_AZURE_BLOB_CONTAINER"),
-    ) {
+    // Azure is enabled whenever a container is configured. Authentication is
+    // then selected by presence:
+    //   * SCCACHE_AZURE_CONNECTION_STRING                     -> shared-key (legacy) path
+    //   * SCCACHE_AZURE_STORAGE_ACCOUNT / SCCACHE_AZURE_ENDPOINT -> Entra ID (passwordless)
+    let azure = if let Some(container) = string_from_env_var("SCCACHE_AZURE_BLOB_CONTAINER") {
+        let connection_string = string_from_env_var("SCCACHE_AZURE_CONNECTION_STRING");
+        let storage_account = string_from_env_var("SCCACHE_AZURE_STORAGE_ACCOUNT");
+        let endpoint = string_from_env_var("SCCACHE_AZURE_ENDPOINT");
         let key_prefix = key_prefix_from_env_var("SCCACHE_AZURE_KEY_PREFIX");
         let rw_mode =
             cache_mode_from_env_var("SCCACHE_AZURE_RW_MODE").unwrap_or(CacheModeConfig::ReadWrite);
 
-        Some(AzureCacheConfig {
-            connection_string,
-            container,
-            key_prefix,
-            rw_mode,
-        })
+        let has_entra_source = storage_account.is_some() || endpoint.is_some();
+        if connection_string.is_some() && has_entra_source {
+            bail!(
+                "Set either SCCACHE_AZURE_CONNECTION_STRING (shared key) or SCCACHE_AZURE_STORAGE_ACCOUNT / SCCACHE_AZURE_ENDPOINT (Entra ID), not both."
+            );
+        }
+        if connection_string.is_none() && !has_entra_source {
+            // Backwards compatible with the historical behavior where a
+            // container without any auth source left the Azure backend disabled
+            // (previously the destructure required both the connection string
+            // and the container). Warn rather than fail so a stray container
+            // variable cannot take down an unrelated cache backend, while still
+            // surfacing the misconfiguration. This is deliberately more lenient
+            // than a file config: an explicit `[cache.azure]` block with no auth
+            // source is a real misconfiguration and errors at operator build
+            // (AzureBlobCache::build -> resolve_blob_endpoint), because a config
+            // file — unlike an ambient env var — is an unambiguous opt-in.
+            warn!(
+                "SCCACHE_AZURE_BLOB_CONTAINER is set but no Azure auth source was provided \
+                 (SCCACHE_AZURE_CONNECTION_STRING, SCCACHE_AZURE_STORAGE_ACCOUNT or \
+                 SCCACHE_AZURE_ENDPOINT); the Azure cache backend is disabled."
+            );
+            None
+        } else {
+            Some(AzureCacheConfig {
+                connection_string,
+                container,
+                key_prefix,
+                storage_account,
+                endpoint,
+                rw_mode,
+            })
+        }
     } else {
         None
     };
@@ -1657,9 +1697,11 @@ fn config_overrides() {
     let env_conf = EnvConfig {
         cache: CacheConfigs {
             azure: Some(AzureCacheConfig {
-                connection_string: String::new(),
+                connection_string: None,
                 container: String::new(),
                 key_prefix: String::new(),
+                storage_account: None,
+                endpoint: None,
                 rw_mode: CacheModeConfig::ReadWrite,
             }),
             disk: Some(DiskCacheConfig {
@@ -1725,9 +1767,11 @@ fn config_overrides() {
             })),
             cache_configs: CacheConfigs {
                 azure: Some(AzureCacheConfig {
-                    connection_string: String::new(),
+                    connection_string: None,
                     container: String::new(),
                     key_prefix: String::new(),
+                    storage_account: None,
+                    endpoint: None,
                     rw_mode: CacheModeConfig::ReadWrite,
                 }),
                 disk: Some(DiskCacheConfig {
@@ -2401,6 +2445,254 @@ fn test_s3_sse_kms_from_env() {
 
 #[test]
 #[serial(config_from_env)]
+#[cfg(feature = "azure")]
+fn test_azure_entra_storage_account_enables() {
+    unsafe {
+        env::set_var("SCCACHE_AZURE_BLOB_CONTAINER", "my-container");
+        env::set_var("SCCACHE_AZURE_STORAGE_ACCOUNT", "mystorageacct");
+    }
+
+    let cfg = config_from_env();
+
+    unsafe {
+        env::remove_var("SCCACHE_AZURE_BLOB_CONTAINER");
+        env::remove_var("SCCACHE_AZURE_STORAGE_ACCOUNT");
+    }
+
+    let env_cfg = cfg.unwrap();
+    match env_cfg.cache.azure {
+        Some(AzureCacheConfig {
+            ref connection_string,
+            ref container,
+            ref storage_account,
+            ref endpoint,
+            ..
+        }) => {
+            assert_eq!(container, "my-container");
+            assert!(connection_string.is_none());
+            assert_eq!(storage_account.as_deref(), Some("mystorageacct"));
+            assert!(endpoint.is_none());
+        }
+        None => unreachable!(),
+    }
+}
+
+#[test]
+#[serial(config_from_env)]
+#[cfg(feature = "azure")]
+fn test_azure_entra_endpoint_enables() {
+    unsafe {
+        env::set_var("SCCACHE_AZURE_BLOB_CONTAINER", "my-container");
+        env::set_var(
+            "SCCACHE_AZURE_ENDPOINT",
+            "https://acct.blob.core.usgovcloudapi.net",
+        );
+    }
+
+    let cfg = config_from_env();
+
+    unsafe {
+        env::remove_var("SCCACHE_AZURE_BLOB_CONTAINER");
+        env::remove_var("SCCACHE_AZURE_ENDPOINT");
+    }
+
+    let env_cfg = cfg.unwrap();
+    match env_cfg.cache.azure {
+        Some(AzureCacheConfig {
+            ref connection_string,
+            ref storage_account,
+            ref endpoint,
+            ..
+        }) => {
+            assert!(connection_string.is_none());
+            assert!(storage_account.is_none());
+            assert_eq!(
+                endpoint.as_deref(),
+                Some("https://acct.blob.core.usgovcloudapi.net")
+            );
+        }
+        None => unreachable!(),
+    }
+}
+
+#[test]
+#[serial(config_from_env)]
+#[cfg(feature = "azure")]
+fn test_azure_connection_string_still_works() {
+    unsafe {
+        env::set_var("SCCACHE_AZURE_BLOB_CONTAINER", "my-container");
+        env::set_var("SCCACHE_AZURE_CONNECTION_STRING", "some-connection-string");
+    }
+
+    let cfg = config_from_env();
+
+    unsafe {
+        env::remove_var("SCCACHE_AZURE_BLOB_CONTAINER");
+        env::remove_var("SCCACHE_AZURE_CONNECTION_STRING");
+    }
+
+    let env_cfg = cfg.unwrap();
+    match env_cfg.cache.azure {
+        Some(AzureCacheConfig {
+            ref connection_string,
+            ref storage_account,
+            ref endpoint,
+            ..
+        }) => {
+            assert_eq!(connection_string.as_deref(), Some("some-connection-string"));
+            assert!(storage_account.is_none());
+            assert!(endpoint.is_none());
+        }
+        None => unreachable!(),
+    }
+}
+
+#[test]
+#[serial(config_from_env)]
+#[cfg(feature = "azure")]
+fn test_azure_conflicting_auth_sources() {
+    unsafe {
+        env::set_var("SCCACHE_AZURE_BLOB_CONTAINER", "my-container");
+        env::set_var("SCCACHE_AZURE_CONNECTION_STRING", "some-connection-string");
+        env::set_var("SCCACHE_AZURE_STORAGE_ACCOUNT", "mystorageacct");
+    }
+
+    let cfg = config_from_env();
+
+    unsafe {
+        env::remove_var("SCCACHE_AZURE_BLOB_CONTAINER");
+        env::remove_var("SCCACHE_AZURE_CONNECTION_STRING");
+        env::remove_var("SCCACHE_AZURE_STORAGE_ACCOUNT");
+    }
+
+    let error = cfg.unwrap_err();
+    assert_eq!(
+        "Set either SCCACHE_AZURE_CONNECTION_STRING (shared key) or SCCACHE_AZURE_STORAGE_ACCOUNT / SCCACHE_AZURE_ENDPOINT (Entra ID), not both.",
+        error.to_string()
+    );
+}
+
+#[test]
+#[serial(config_from_env)]
+#[cfg(feature = "azure")]
+fn test_azure_conflicting_connection_string_and_endpoint() {
+    // The other operand of the mutual-exclusivity check: connection string paired
+    // with an endpoint (rather than a storage account) must also be rejected.
+    unsafe {
+        env::set_var("SCCACHE_AZURE_BLOB_CONTAINER", "my-container");
+        env::set_var("SCCACHE_AZURE_CONNECTION_STRING", "some-connection-string");
+        env::set_var(
+            "SCCACHE_AZURE_ENDPOINT",
+            "https://acct.blob.core.windows.net",
+        );
+    }
+
+    let cfg = config_from_env();
+
+    unsafe {
+        env::remove_var("SCCACHE_AZURE_BLOB_CONTAINER");
+        env::remove_var("SCCACHE_AZURE_CONNECTION_STRING");
+        env::remove_var("SCCACHE_AZURE_ENDPOINT");
+    }
+
+    let error = cfg.unwrap_err();
+    assert_eq!(
+        "Set either SCCACHE_AZURE_CONNECTION_STRING (shared key) or SCCACHE_AZURE_STORAGE_ACCOUNT / SCCACHE_AZURE_ENDPOINT (Entra ID), not both.",
+        error.to_string()
+    );
+}
+
+#[test]
+#[serial(config_from_env)]
+#[cfg(feature = "azure")]
+fn test_azure_no_auth_source_disables_backend() {
+    unsafe {
+        env::set_var("SCCACHE_AZURE_BLOB_CONTAINER", "my-container");
+    }
+
+    let cfg = config_from_env();
+
+    unsafe {
+        env::remove_var("SCCACHE_AZURE_BLOB_CONTAINER");
+    }
+
+    // A container with no auth source disables Azure (backwards compatible)
+    // rather than failing the whole config load.
+    let env_cfg = cfg.unwrap();
+    assert!(env_cfg.cache.azure.is_none());
+}
+
+#[test]
+#[cfg(feature = "azure")]
+fn test_azure_toml_endpoint_field() {
+    let toml = r#"
+[cache.azure]
+container = "c"
+key_prefix = "p"
+endpoint = "https://acct.blob.core.usgovcloudapi.net"
+"#;
+    let file_config: FileConfig = toml::from_str(toml).expect("Is valid toml.");
+    assert_eq!(
+        file_config.cache.azure,
+        Some(AzureCacheConfig {
+            connection_string: None,
+            container: "c".to_owned(),
+            key_prefix: "p".to_owned(),
+            storage_account: None,
+            endpoint: Some("https://acct.blob.core.usgovcloudapi.net".to_owned()),
+            rw_mode: CacheModeConfig::ReadWrite,
+        })
+    );
+}
+
+#[test]
+#[cfg(feature = "azure")]
+fn test_azure_toml_connection_string_field() {
+    let toml = r#"
+[cache.azure]
+container = "c"
+key_prefix = "p"
+connection_string = "conn"
+"#;
+    let file_config: FileConfig = toml::from_str(toml).expect("Is valid toml.");
+    assert_eq!(
+        file_config
+            .cache
+            .azure
+            .and_then(|a| a.connection_string)
+            .as_deref(),
+        Some("conn")
+    );
+}
+
+#[test]
+#[cfg(feature = "azure")]
+fn test_azure_toml_container_only_deserializes_with_no_auth() {
+    // A container-only block is valid TOML and leaves every auth source None
+    // (the file surface, unlike the env parser, does not warn-and-disable — the
+    // missing-auth error is raised later at operator build, see
+    // AzureBlobCache::build's test_build_requires_an_auth_source).
+    let toml = r#"
+[cache.azure]
+container = "c"
+key_prefix = "p"
+"#;
+    let file_config: FileConfig = toml::from_str(toml).expect("Is valid toml.");
+    assert_eq!(
+        file_config.cache.azure,
+        Some(AzureCacheConfig {
+            connection_string: None,
+            container: "c".to_owned(),
+            key_prefix: "p".to_owned(),
+            storage_account: None,
+            endpoint: None,
+            rw_mode: CacheModeConfig::ReadWrite,
+        })
+    );
+}
+
+#[test]
+#[serial(config_from_env)]
 #[cfg(feature = "gcs")]
 fn test_gcs_service_account() {
     unsafe {
@@ -2452,8 +2744,10 @@ type = "token"
 token = "secrettoken"
 
 
-#[cache.azure]
-# does not work as it appears
+[cache.azure]
+container = "azurecontainer"
+key_prefix = "azureprefix"
+storage_account = "azureaccount"
 
 [cache.disk]
 dir = "/tmp/.cache/sccache"
@@ -2526,7 +2820,14 @@ key_prefix = "cosprefix"
         file_config,
         FileConfig {
             cache: CacheConfigs {
-                azure: None, // TODO not sure how to represent a unit struct in TOML Some(AzureCacheConfig),
+                azure: Some(AzureCacheConfig {
+                    connection_string: None,
+                    container: "azurecontainer".to_owned(),
+                    key_prefix: "azureprefix".to_owned(),
+                    storage_account: Some("azureaccount".to_owned()),
+                    endpoint: None,
+                    rw_mode: CacheModeConfig::ReadWrite,
+                }),
                 disk: Some(DiskCacheConfig {
                     dir: PathBuf::from("/tmp/.cache/sccache"),
                     size: 7 * 1024 * 1024 * 1024,


### PR DESCRIPTION
Closes #1118.

## Summary

sccache's Azure Blob backend currently supports only connection-string
(shared-key) authentication, which fails against storage accounts that have
shared-key access disabled — an increasingly common security baseline (and one
some Azure Policy configurations mandate).

This adds a **Microsoft Entra ID (passwordless)** path: when no connection
string is configured, the Azblob operator is built without an account key or
SAS token, so OpenDAL (via its `reqsign` dependency) resolves an Entra
credential from the ambient environment and signs each request with an OAuth
bearer token.

## Behavior

- **Shared key (unchanged):** `SCCACHE_AZURE_CONNECTION_STRING` keeps its
  existing behavior, byte-for-byte.
- **Entra ID (new):** with no connection string, select the account via either
  - `SCCACHE_AZURE_STORAGE_ACCOUNT` — endpoint synthesized as
    `https://{account}.blob.core.windows.net`, or
  - `SCCACHE_AZURE_ENDPOINT` — a full endpoint for sovereign clouds / custom
    DNS, validated as an `https` URI (plain `http` accepted only for a loopback
    host).

  Credentials then resolve from the environment: a service principal
  (`AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET`), workload
  identity (`AZURE_FEDERATED_TOKEN_FILE`), or a managed identity via IMDS.
- The two modes are **mutually exclusive**, enforced on both the env and
  file-config surfaces; blank values from a file config are treated as absent.
- A container configured with no auth source: an ambient env var only warns and
  disables the backend (so a stray variable can't take down an unrelated cache),
  whereas an explicit `[cache.azure]` block errors clearly at startup.

No new dependencies — `opendal/services-azblob` and `reqsign` are already pulled
in by the existing `azure` feature.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
  `cargo check --no-default-features` (with and without `--features azure`), and
  `cargo test --features azure` all pass.
- Unit tests cover endpoint synthesis / precedence / trailing-slash handling,
  `https` + host-injection validation, empty-string normalization, auth-mode
  selection, mutual exclusivity (both operands), the no-auth error, and config
  parsing across the env and TOML surfaces.
- The passwordless *request* path (IMDS / token exchange) cannot run in CI
  without a live account; a key-less `Azblob` build is confirmed to engage
  reqsign's OAuth loader chain rather than going anonymous. In practice this
  path has been running as the compilation-cache backend for a CI fleet,
  authenticating to Azure Blob Storage via workload identity
  (`AZURE_FEDERATED_TOKEN_FILE`).

## Docs

`docs/Azure.md` and `docs/Configuration.md` are updated with the new variables,
precedence, mutual exclusivity, the `https`/loopback rule, and an Azurite note.
