### PR TITLE
fix(dist): close piped stdin before waiting on the child

### DIFF
--- a/src/bin/sccache-dist/build.rs
+++ b/src/bin/sccache-dist/build.rs
@@ -55,6 +55,11 @@ impl CommandExt for Command {
             .take()
             .expect("Requested piped stdin but not present");
         pipe(&mut stdin).context("Failed to pipe input to process")?;
+        // `process.stdin` was moved out by the `.take()` above, so
+        // `wait_with_output()` has no stdin left to close. Without this the write
+        // end stays open for the rest of the function and a child that reads to
+        // EOF never returns.
+        drop(stdin);
         let output = process
             .wait_with_output()
             .context("Failed to wait for process to return")?;


### PR DESCRIPTION
Fixes #2805

## What

`CommandExt::check_piped` drops the `ChildStdin` it took from the `Child` before
calling `wait_with_output()`, so the child sees EOF on stdin.

```diff
     pipe(&mut stdin).context("Failed to pipe input to process")?;
+    // `process.stdin` was moved out by the `.take()` above, so
+    // `wait_with_output()` has no stdin left to close. Without this the write
+    // end stays open for the rest of the function and a child that reads to EOF
+    // never returns.
+    drop(stdin);
     let output = process
         .wait_with_output()
         .context("Failed to wait for process to return")?;
```

## Why

`check_piped` takes stdin out of the `Child`:

```rust
let mut stdin = process.stdin.take().expect("Requested piped stdin but not present");
```

`stdin` is owned and lives until the end of the function, so it is still open
while `wait_with_output()` blocks. `Child::wait_with_output` closes only the
stdin still held by the `Child` (`drop(self.stdin.take())`), which is `None`
here, making that a no-op.

The closure cannot close it either — its parameter is `&mut ChildStdin`, so the
callee cannot drop the value. Only `check_piped` can.

The two callers are `DockerBuilder::make_image` (`build.rs:720`) and
`DockerBuilder::perform_build` (`build.rs:771`), both of which pipe a tar into
`docker cp - <container>:/`. `docker cp -` reads until EOF, so with the write end
held open it never exits, and every job on a `type = "docker"` build server
blocks indefinitely with its container left in `Created`.

Both call sites already `drop()` the corresponding reader right after the call
(`drop(toolchain_rdr)`, `drop(inputs_rdr)`); this makes the writer symmetric.

## Reproducing the underlying behaviour

That `docker cp -` requires EOF rather than merely a complete archive can be
shown without sccache:

```sh
docker run --rm alpine sh -c 'mkdir -p /s && echo hi > /s/f && tar -cf - -C /s f' > /tmp/t.tar
docker create --name cptest alpine true

time ( cat /tmp/t.tar ) | docker cp - cptest:/            # docker cp:  0.019s
time ( cat /tmp/t.tar; sleep 20 ) | docker cp - cptest:/  # docker cp: 20.013s
```

The archive is complete and valid in both cases; only the writer's behaviour
differs. Measured on Docker 29.7.2, and reproduced on an earlier client, so this
is not specific to a particular release.

## Testing

- Before: a single `sccache gcc -c hello.c` against a `type = "docker"` build
  server made no progress; the container stayed in `Created` and the client fell
  back to local compilation.
- After: the same compile completes and is reported as a distributed compile.
- Larger workload: a Linux 6.12 `defconfig` build distributed 2,867 compilations
  across 11 build servers with no scheduler allocation failures.

## Scope

One statement, in a helper used only by the Docker builder. The `overlay` and
`pot` builders do not call `check_piped`. No public API or configuration change.