### PR TITLE
Don't cache ptxas PTX-verification passes

### DIFF
--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -792,7 +792,15 @@ where
                     }
                     false
                 });
-                (env_vars.clone(), Cacheable::Yes, group)
+                // For a virtual-only gencode (e.g. -gencode arch=compute_120,
+                // code=compute_120) nvcc runs ptxas with no -o just to verify the
+                // PTX. There is no artifact to cache, so run it directly.
+                let cacheable = if args.iter().any(|arg| arg == "-o") {
+                    Cacheable::Yes
+                } else {
+                    Cacheable::No
+                };
+                (env_vars.clone(), cacheable, group)
             }
             // cudafe++ _must be_ cached, because the `.module_id` file is unique to each invocation (new in CTK 12.8)
             Some("cudafe++") => {


### PR DESCRIPTION
Follow up from https://github.com/mozilla/sccache/pull/2722, we discovered issue while building torchao._C_mxfp8 extension: https://github.com/pytorch/pytorch/actions/runs/30797328141/job/91700085985

"nvcc": nvcc_args
+ [
    "-gencode=arch=compute_100,code=sm_100",
    "-gencode=arch=compute_120,code=compute_120",
],

For a virtual-only gencode such as -gencode arch=compute_120,code=compute_120 there is no SASS to emit, so output is not cacheable. nvcc runs ptxas purely to syntax-check the PTX and passes no -o at all:

  ptxas -arch=compute_120 -m64 kernel.compute_120.ptx

group_nvcc_subcommands_by_compilation_stage marks every ptxas sub-command Cacheable::Yes, and the caching path requires an "obj" output that only -o populates, so the whole compile dies in cicc::generate_compile_commands with `Missing "cubin" file output`. Any target carrying a +PTX architecture can hit this.

This fix adds a Cacheable::No clause to route the sub-command to the path nvcc.rs already uses for non-cacheable steps: build the command and run it directly. 

Test Plan:
Carried as a source patch in PyTorch CI, where it fixes the inductor build that compiles torchao against CUDA 13.2:

```
python .ci/pytorch/smoke_test/smoke_test.py --package=torchonly
```
