### PR TITLE
nvcc (Windows): protect escaped quotes in dryrun lines before flattening backslashes

### DIFF
--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -1096,14 +1096,6 @@ fn fold_env_vars_or_split_into_exe_and_args(
     // The rest of the lines are subcommands, so parse into a vec of [cmd, args..]
 
     let mut line = if cfg!(target_os = "windows") {
-        // Protect escaped quotes (\") before flattening path separators:
-        // nvcc --dryrun prints string-valued defines as -D "FILE_NAME=\"x.dll\"",
-        // and replacing '\' with '/' first turns \" into /", collapsing the
-        // line's quote structure. shlex then mis-groups everything after the
-        // first such define into one giant token, so the host preprocess runs
-        // WITHOUT those -D's and #ifdef-guarded instantiations silently
-        // disappear from the final object (dropped-instantiation miscompile;
-        // observed as lld-link undefined symbols on ONNX Runtime).
         let line = line
             .replace("\\\"", "\u{1}")
             .replace("\"\"", "\"")
@@ -1575,13 +1567,6 @@ mod test {
     #[test]
     #[cfg(windows)]
     fn test_group_nvcc_subcommands_preserves_escaped_quotes_in_defines() {
-        // nvcc --dryrun on Windows prints string-valued defines with escaped
-        // quotes (-D "FILE_NAME=\"x.dll\""). The line mangling used to flatten
-        // '\' to '/' before tokenization, collapsing the quote structure:
-        // shlex then packed every argument after the first such define into
-        // one giant token, the preprocess ran without those -D's, and
-        // #ifdef-guarded instantiations silently vanished from the final
-        // object (observed as lld-link undefined symbols on ONNX Runtime).
         let bin_dir = tempfile::tempdir().unwrap();
 
         for exe in ["nvcc", "cl", "cudafe++", "cicc", "ptxas", "fatbinary"] {

--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -1096,11 +1096,21 @@ fn fold_env_vars_or_split_into_exe_and_args(
     // The rest of the lines are subcommands, so parse into a vec of [cmd, args..]
 
     let mut line = if cfg!(target_os = "windows") {
+        // Protect escaped quotes (\") before flattening path separators:
+        // nvcc --dryrun prints string-valued defines as -D "FILE_NAME=\"x.dll\"",
+        // and replacing '\' with '/' first turns \" into /", collapsing the
+        // line's quote structure. shlex then mis-groups everything after the
+        // first such define into one giant token, so the host preprocess runs
+        // WITHOUT those -D's and #ifdef-guarded instantiations silently
+        // disappear from the final object (dropped-instantiation miscompile;
+        // observed as lld-link undefined symbols on ONNX Runtime).
         let line = line
+            .replace("\\\"", "\u{1}")
             .replace("\"\"", "\"")
             .replace(r"\\?\", "")
             .replace('\\', "/")
-            .replace(r"//?/", "");
+            .replace(r"//?/", "")
+            .replace('\u{1}', "\\\"");
         match host_compiler {
             NvccHostCompiler::Msvc => line.replace(" -E ", " -P ").replace(" > ", " -Fi"),
             _ => line,
@@ -1559,6 +1569,105 @@ mod test {
             let mut permissions = fs::metadata(&path).unwrap().permissions();
             permissions.set_mode(0o755);
             fs::set_permissions(&path, permissions).unwrap();
+        }
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_group_nvcc_subcommands_preserves_escaped_quotes_in_defines() {
+        // nvcc --dryrun on Windows prints string-valued defines with escaped
+        // quotes (-D "FILE_NAME=\"x.dll\""). The line mangling used to flatten
+        // '\' to '/' before tokenization, collapsing the quote structure:
+        // shlex then packed every argument after the first such define into
+        // one giant token, the preprocess ran without those -D's, and
+        // #ifdef-guarded instantiations silently vanished from the final
+        // object (observed as lld-link undefined symbols on ONNX Runtime).
+        let bin_dir = tempfile::tempdir().unwrap();
+
+        for exe in ["nvcc", "cl", "cudafe++", "cicc", "ptxas", "fatbinary"] {
+            fake_executable(bin_dir.path(), exe);
+        }
+
+        let path = bin_dir.path().to_string_lossy();
+        let dryrun = format!(
+            r#"#$ PATH={path}
+#$ cl -D__CUDACC__ -D "FILE_NAME=\"kernel.dll\"" -D "USE_CUDA=1" -DGUARDED_AFTER=1 -E -x c++ "kernel.cu" > "kernel.cpp4.ii"
+#$ cudafe++ --gen_c_file_name "kernel.cudafe1.cpp" --stub_file_name "kernel.cudafe1.stub.c" --module_id_file_name "kernel.module_id" --simt-only "kernel.cpp4.ii"
+#$ cl -D__CUDA_ARCH__=800 -D__CUDACC__ -D "FILE_NAME=\"kernel.dll\"" -D "USE_CUDA=1" -DGUARDED_AFTER=1 -E -x c++ "kernel.cu" > "kernel.cpp1.ii"
+#$ cicc --device-c -arch compute_80 --module_id_file_name "kernel.module_id" --gen_c_file_name "kernel.cudafe1.c" --stub_file_name "kernel.cudafe1.stub.c" --gen_device_file_name "kernel.cudafe1.gpu" "kernel.cpp1.ii" --simt-only -o "kernel.ptx"
+#$ ptxas -arch=sm_80 --compile-only "kernel.ptx" -o "kernel.cubin"
+#$ fatbinary --create="kernel.fatbin" "--image3=kind=elf,sm=80,file=kernel.cubin" --embedded-fatbin="kernel.fatbin.c" --device-c
+#$ cl -D__CUDA_ARCH__=800 -D__CUDACC__ -c -x c++ "kernel.cudafe1.cpp" -Fo"kernel.o"
+"#
+        );
+
+        let creator = new_creator();
+        next_command(
+            &creator,
+            Ok(MockChild::new(
+                exit_status(0),
+                dryrun.as_bytes(),
+                dryrun.as_bytes(),
+            )),
+        );
+        next_command(
+            &creator,
+            Ok(MockChild::new(
+                exit_status(0),
+                dryrun.as_bytes(),
+                dryrun.as_bytes(),
+            )),
+        );
+
+        let groups = group_nvcc_subcommands_by_compilation_stage(
+            &creator,
+            &bin_dir.path().join("nvcc"),
+            &["-c", "kernel.cu", "-o", "kernel.o"].map(OsString::from),
+            OsStr::new("-c"),
+            bin_dir.path(),
+            bin_dir.path(),
+            None,
+            &[],
+            &NvccHostCompiler::Msvc,
+            OsStr::new("kernel.o"),
+        )
+        .wait()
+        .unwrap();
+
+        let all_cmds = groups.iter().flatten().collect::<Vec<_>>();
+        let preprocess_cmds = all_cmds
+            .iter()
+            .filter(|cmd| {
+                cmd.exe.file_stem().and_then(|s| s.to_str()) == Some("cl")
+                    && cmd.args.iter().any(|a| a.starts_with("-Fi"))
+            })
+            .collect::<Vec<_>>();
+        assert!(!preprocess_cmds.is_empty(), "no preprocess steps found");
+
+        for cmd in preprocess_cmds {
+            // The giant-token fingerprint of the collapse: several " -D "
+            // pairs packed into a single argument.
+            assert!(
+                cmd.args.iter().all(|a| !a.contains(" -D ")),
+                "quote collapse: multiple -D pairs packed into one token: {:?}",
+                cmd.args
+            );
+            // Every define survives as its own token, escaped quotes intact.
+            assert!(
+                cmd.args.iter().any(|a| a == "USE_CUDA=1"),
+                "USE_CUDA=1 lost: {:?}",
+                cmd.args
+            );
+            assert!(
+                cmd.args.iter().any(|a| a == "-DGUARDED_AFTER=1"),
+                "-DGUARDED_AFTER=1 lost: {:?}",
+                cmd.args
+            );
+            assert!(
+                cmd.args.iter().any(|a| a == "FILE_NAME=\"kernel.dll\""),
+                "string-valued define mangled: {:?}",
+                cmd.args
+            );
         }
     }
 


### PR DESCRIPTION
## Problem

On Windows, `nvcc --dryrun` prints string-valued defines with escaped quotes:

```
-D "FILE_NAME=\"onnxruntime_providers_cuda.dll\""
```

`fold_env_vars_or_split_into_exe_and_args` flattens `\` to `/` *before*
tokenizing the line (to normalize paths), which turns every `\"` into `/"`
and collapses the line's quote structure at the first such define.
`shlex::split` then packs everything after it into one giant token — on a
real ONNX Runtime v1.28.0 compile we measured a **493-character token
containing ~30 `-D` pairs** (`USE_CUDA=1`, `USE_FLASH_ATTENTION=1`,
`USE_MEMORY_EFFICIENT_ATTENTION=1`, `USE_FP8_KV_CACHE=1`, ...).

The host preprocess that produces `cpp4.ii` therefore runs **without** those
defines, `cudafe++` generates no stubs for the `#ifdef`-guarded explicit
instantiations, and the loss propagates silently through ptx/cubin into the
final object. It surfaces hours later as `lld-link: undefined symbol`
(`BiasSoftmaxImpl<double>`, `QkvToContext<*, __nv_fp8_e4m3>`,
`run_memory_efficient_attention`) — a silent miscompile, not a build error.
onnxruntime-genai's CUDA TUs fail hard (nvcc exit -2) through the same path.

Likely the mechanism behind long-standing Windows reports such as #1077, and
the remaining actionable half of #2808 (whose deadlock we could no longer
reproduce once our storage backend was healthy — see the issue addendum).

## Reproduction (single command)

ONNX Runtime v1.28.0, `onnxruntime/contrib_ops/cuda/math/bias_softmax_impl.cu`,
compiled with the exact command from ORT's build.ninja (extract via
`ninja -t commands`), CUDA 13.3.1, four `-gencode` archs, cl.exe host:

* bare nvcc: 3,189 defined symbols
* `sccache nvcc` (cold cache): 2,628 — every `double` instantiation's
  `__device_stub__` missing, float/half intact
* intermediates: `cudafe1.stub.c` ddd-marker counts 88 (bare) vs 0 (wrapped);
  the wrapped `cpp4.ii` lacks exactly the `#ifdef USE_CUDA` instantiation

## Fix

Protect the `\"` escapes with a sentinel (`\u{1}`) around the backslash
flatten and restore them afterwards, so `shlex` sees the original quoting.
One hunk in `fold_env_vars_or_split_into_exe_and_args`, plus a regression
test (`test_group_nvcc_subcommands_preserves_escaped_quotes_in_defines`)
that feeds an escaped-quote dryrun line through the grouping and asserts
every define survives as its own token (the giant-token fingerprint —
`" -D "` inside a single argument — is asserted absent).

With the patch, the reproducer's object matches bare nvcc symbol-for-symbol
(3,189 == 3,189; only 1:1-substituted `??_C@` string literals differ, the
expected module-id naming divergence).


---
\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)
