### PR TITLE
nvcc: accept the --diag-error/--diag-suppress/--diag-warn family

### DIFF
--- a/src/compiler/nvcc.rs
+++ b/src/compiler/nvcc.rs
@@ -1419,6 +1419,9 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     take_arg!("--dependency-output", PathBuf, Separated, DepArgumentPath),
     flag!("--device-c", DoCompilation),
     flag!("--device-w", DoCompilation),
+    take_arg!("--diag-error", OsString, CanBeSeparated(b'='), PassThrough),
+    take_arg!("--diag-suppress", OsString, CanBeSeparated(b'='), PassThrough),
+    take_arg!("--diag-warn", OsString, CanBeSeparated(b'='), PassThrough),
     flag!("--expt-extended-lambda", PreprocessorArgumentFlag),
     flag!("--expt-relaxed-constexpr", PreprocessorArgumentFlag),
     flag!("--extended-lambda", PreprocessorArgumentFlag),
@@ -1461,6 +1464,9 @@ counted_array!(pub static ARGS: [ArgInfo<gcc::ArgData>; _] = [
     flag!("-cubin", DoCompilation),
     flag!("-dc", DoCompilation),
     take_arg!("-default-stream", OsString, CanBeSeparated(b'='), PassThrough),
+    take_arg!("-diag-error", OsString, CanBeSeparated(b'='), PassThrough),
+    take_arg!("-diag-suppress", OsString, CanBeSeparated(b'='), PassThrough),
+    take_arg!("-diag-warn", OsString, CanBeSeparated(b'='), PassThrough),
     flag!("-dw", DoCompilation),
     flag!("-expt-extended-lambda", PreprocessorArgumentFlag),
     flag!("-expt-relaxed-constexpr", PreprocessorArgumentFlag),
@@ -2149,6 +2155,38 @@ mod test {
                 "--suppress-stack-size-warning",
                 "-Xcudafe",
                 "--display_error_number",
+                "-c"
+            ],
+            a.common_args
+        );
+    }
+
+    #[test]
+    fn test_parse_diag_suppress_separated() {
+        // The separated form (`--diag-suppress 1394,1388`, as OpenCV emits
+        // it) must not be mistaken for a second input file.
+        let a = parses!(
+            "-x=cu",
+            "-Xcudafe",
+            "--display_error_number",
+            "--diag-suppress",
+            "1394,1388",
+            "-diag-warn=68",
+            "-c",
+            "foo.c",
+            "-o",
+            "foo.o"
+        );
+        assert_eq!(Some("foo.c"), a.input.to_str());
+        assert_eq!(Language::Cuda, a.language);
+        assert_eq!(
+            ovec![
+                "-Xcudafe",
+                "--display_error_number",
+                "--diag-suppress",
+                "1394,1388",
+                "-diag-warn",
+                "68",
                 "-c"
             ],
             a.common_args


### PR DESCRIPTION
While trying to get OpenCV's CUDA build cached on Windows I noticed that none of its .cu files ever got cache hits. The server log shows every single compile being rejected with:

```
CannotCache(multiple input files)
```

OpenCV passes `-Xcudafe --display_error_number --diag-suppress 1394,1388` on every CUDA file. The problem: `--diag-suppress` (and its siblings `--diag-error` / `--diag-warn`) are missing from the nvcc argument table. nvcc accepts the value either attached (`--diag-suppress=1394,1388`) or as a separate argument, and CMake/OpenCV happen to emit the separated form - so sccache parses `1394,1388` as a bare token, takes it for a second input file and refuses the compile.

Easy to reproduce with any single nvcc compile: add `--diag-suppress 1394,1388` and the request is forwarded uncached (`requests executed 0` in the stats), switch to `--diag-suppress=1394,1388` and the same compile caches fine.

This adds the three flags in both their single- and double-dash forms (`CanBeSeparated`, `PassThrough`) plus a regression test for the separated form. With the patch applied, OpenCV's CUDA compiles (155 files in our build) all cache. Same kind of table gap #2708 filled for `--dependency-output`.

Possibly related: #2726 hits the same `multiple input files` rejection, but from the MSVC-side parsing of nvcc's host sub-compile - I reproduced it on current main and verified this PR does not change it.
