### PR TITLE
msvc: backport flags support

### DIFF
--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -509,7 +509,7 @@ msvc_args!(static ARGS: [ArgInfo<ArgData>; _] = [
     msvc_take_arg!("o", PathBuf, Separated, Output), // Deprecated but valid
     msvc_flag!("openmp", PassThrough),
     msvc_flag!("openmp-", PassThrough),
-    msvc_flag!("openmp:experimental", PassThrough),
+    msvc_take_arg!("openmp:", OsString, Concatenated, PassThroughWithSuffix),
     msvc_flag!("options:strict", PassThrough),
     msvc_flag!("permissive", PassThrough),
     msvc_flag!("permissive-", PassThrough),
@@ -2336,6 +2336,37 @@ mod test {
         assert_eq!(1, outputs.len());
         assert!(preprocessor_args.is_empty());
         assert_eq!(common_args, ovec!["/feature:rcpc"]);
+    }
+
+    #[test]
+    fn test_parse_arguments_openmp() {
+        let args = ovec!["/openmp:llvm", "-c", "foo.c", "/Fofoo.obj"];
+        let ParsedArguments {
+            input,
+            language,
+            outputs,
+            preprocessor_args,
+            common_args,
+            ..
+        } = match parse_arguments(args) {
+            CompilerArguments::Ok(args) => args,
+            o => panic!("Got unexpected parse result: {o:?}"),
+        };
+        assert_eq!(Some("foo.c"), input.to_str());
+        assert_eq!(Language::C, language);
+        assert_map_contains!(
+            outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: PathBuf::from("foo.obj"),
+                    optional: false,
+                }
+            )
+        );
+        assert_eq!(1, outputs.len());
+        assert!(preprocessor_args.is_empty());
+        assert_eq!(common_args, ovec!["/openmp:llvm"]);
     }
 
     #[test]

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -474,6 +474,7 @@ msvc_args!(static ARGS: [ArgInfo<ArgData>; _] = [
     msvc_flag!("external:templates-", PassThrough),
     msvc_flag!("fastfail", PassThrough),
     msvc_take_arg!("favor:", OsString, Concatenated, PassThroughWithSuffix),
+    msvc_take_arg!("feature:", OsString, Concatenated, PassThroughWithSuffix),
     msvc_flag!("forceInterlockedFunctions", PassThrough),
     msvc_flag!("forceInterlockedFunctions-", PassThrough),
     msvc_take_arg!("fp:", OsString, Concatenated, PassThroughWithSuffix),
@@ -2298,6 +2299,37 @@ mod test {
             );
             assert!(!msvc_show_includes);
         }
+    }
+
+    #[test]
+    fn test_parse_arguments_feature() {
+        let args = ovec!["/feature:rcpc", "-c", "foo.c", "/Fofoo.obj"];
+        let ParsedArguments {
+            input,
+            language,
+            outputs,
+            preprocessor_args,
+            common_args,
+            ..
+        } = match parse_arguments(args) {
+            CompilerArguments::Ok(args) => args,
+            o => panic!("Got unexpected parse result: {o:?}"),
+        };
+        assert_eq!(Some("foo.c"), input.to_str());
+        assert_eq!(Language::C, language);
+        assert_map_contains!(
+            outputs,
+            (
+                "obj",
+                ArtifactDescriptor {
+                    path: PathBuf::from("foo.obj"),
+                    optional: false,
+                }
+            )
+        );
+        assert_eq!(1, outputs.len());
+        assert!(preprocessor_args.is_empty());
+        assert_eq!(common_args, ovec!["/feature:rcpc"]);
     }
 
     #[test]

--- a/src/compiler/msvc.rs
+++ b/src/compiler/msvc.rs
@@ -475,12 +475,18 @@ msvc_args!(static ARGS: [ArgInfo<ArgData>; _] = [
     msvc_flag!("fastfail", PassThrough),
     msvc_take_arg!("favor:", OsString, Concatenated, PassThroughWithSuffix),
     msvc_take_arg!("feature:", OsString, Concatenated, PassThroughWithSuffix),
+    msvc_flag!("fno-sanitize-address-asan-compat-lib", PassThrough),
+    msvc_flag!("fno-sanitize-address-vcasan-lib", PassThrough),
+    msvc_take_arg!("fno-sanitize-coverage", OsString, Concatenated(b'='), PassThroughWithSuffix),
     msvc_flag!("forceInterlockedFunctions", PassThrough),
     msvc_flag!("forceInterlockedFunctions-", PassThrough),
     msvc_take_arg!("fp:", OsString, Concatenated, PassThroughWithSuffix),
     msvc_take_arg!("fpcvt:", OsString, Concatenated, PassThroughWithSuffix),
+    msvc_flag!("fsanitize-address-asan-compat-lib", PassThrough),
+    msvc_flag!("fsanitize-address-use-after-return", PassThrough),
     msvc_take_arg!("fsanitize-blacklist", PathBuf, Concatenated(b'='), ExtraHashFile),
-    msvc_flag!("fsanitize=address", PassThrough),
+    msvc_take_arg!("fsanitize-coverage", OsString, Concatenated(b'='), PassThroughWithSuffix),
+    msvc_take_arg!("fsanitize=", OsString, Concatenated, PassThroughWithSuffix),
     msvc_flag!("fsyntax-only", SuppressCompilation),
     msvc_take_arg!("guard:cf", OsString, Concatenated, PassThroughWithSuffix),
     msvc_take_arg!("guard:ehcont", OsString, Concatenated, PassThroughWithSuffix),
@@ -3171,6 +3177,35 @@ mod test {
         assert_eq!(Cacheable::No, cacheable);
         // Ensure that we ran all processes.
         assert_eq!(0, creator.lock().unwrap().children.len());
+    }
+
+    #[test]
+    fn test_parse_fsanitize() {
+        let args = ovec![
+            "-c",
+            "foo.c",
+            "-o",
+            "foo.o",
+            "-fsanitize=address",
+            "-fsanitize=kernel-address",
+            "/fsanitize=fuzzer",
+            "/fsanitize-coverage=edge",
+            "/fno-sanitize-coverage=inline-8bit-counters"
+        ];
+        let ParsedArguments { common_args, .. } = match parse_arguments(args) {
+            CompilerArguments::Ok(args) => args,
+            o => panic!("Got unexpected parse result: {o:?}"),
+        };
+        assert_eq!(
+            ovec![
+                "-fsanitize=address",
+                "-fsanitize=kernel-address",
+                "/fsanitize=fuzzer",
+                "/fsanitize-coverage=edge",
+                "/fno-sanitize-coverage=inline-8bit-counters"
+            ],
+            common_args
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR is a backport of commits from https://github.com/rapidsai/sccache.

Nothing was changed in commit payload: only conflicts resolution.

Closes #2726 