### PR TITLE
gcc: mark flags as TooHard if need to cache something else

### DIFF
--- a/src/compiler/gcc.rs
+++ b/src/compiler/gcc.rs
@@ -216,6 +216,7 @@ counted_array!(pub static ARGS: [ArgInfo<ArgData>; _] = [
     take_arg!("-aux-info", OsString, Separated, PassThrough),
     take_arg!("-b", OsString, Separated, PassThrough),
     flag!("-c", DoCompilation),
+    take_arg!("-fcallgraph-info", OsString, Concatenated(b'='), TooHard),
     take_arg!("-fdiagnostics-color", OsString, Concatenated(b'='), DiagnosticsColor),
     // Old: gcc/clang header module flag.
     flag!("-fmodules", TooHardFlag),
@@ -227,11 +228,12 @@ counted_array!(pub static ARGS: [ArgInfo<ArgData>; _] = [
     flag!("-fno-profile-generate", TooHardFlag),
     flag!("-fno-profile-use", TooHardFlag),
     flag!("-fno-working-directory", PreprocessorArgumentFlag),
-    flag!("-fplugin=libcc1plugin", TooHardFlag),
+    take_arg!("-fplugin", OsString, Concatenated(b'='), TooHard),
     flag!("-fprofile-arcs", ProfileGenerate),
     flag!("-fprofile-generate", ProfileGenerate),
     take_arg!("-fprofile-use", OsString, Concatenated, TooHard),
     flag!("-frepo", TooHardFlag),
+    flag!("-fstack-usage", TooHardFlag),
     flag!("-fsyntax-only", TooHardFlag),
     flag!("-ftest-coverage", TestCoverage),
     flag!("-fworking-directory", PreprocessorArgumentFlag),
@@ -1812,6 +1814,8 @@ mod test {
     #[test]
     fn test_parse_arguments_too_hard() {
         let too_hard_flags = stringvec![
+            "-fstack-usage",
+            "-fcallgraph-info",
             "-save-temps",
             "-save-temps=cwd",
             "-save-temps=obj",
@@ -2294,6 +2298,35 @@ mod test {
             CompilerArguments::NotCompilation,
             parse_arguments_(
                 stringvec!["-shared", "foo.o", "-o", "foo.so", "bar.o"],
+                false
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_arguments_fplugin() {
+        assert_eq!(
+            CompilerArguments::CannotCache("-fplugin", None),
+            parse_arguments_(
+                stringvec!["-c", "foo.c", "-fplugin=plugin.so", "-o", "foo.o"],
+                false
+            )
+        );
+        assert_eq!(
+            CompilerArguments::CannotCache("-fplugin", None),
+            parse_arguments_(
+                stringvec!["-c", "foo.c", "-fplugin=libcc1plugin", "-o", "foo.o"],
+                false
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_arguments_fcallgraph_info_with_markers() {
+        assert_eq!(
+            CompilerArguments::CannotCache("-fcallgraph-info", None),
+            parse_arguments_(
+                stringvec!["-c", "foo.c", "-fcallgraph-info=su,da", "-o", "foo.o"],
                 false
             )
         );


### PR DESCRIPTION
This PR is partially done with AI.

AI search to flags we're not listed and I select what should we do with them.