### PR TITLE
Update shlex dependency to version 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 2.0.1",
+ "shlex",
 ]
 
 [[package]]
@@ -3762,7 +3762,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2 0.10.8",
- "shlex 1.3.0",
+ "shlex",
  "strip-ansi-escapes",
  "syslog",
  "tar",
@@ -4001,12 +4001,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = ">=1.0, <1.0.147" # zmij (used in 1.0.147+) requires Rust 1.84+
 sha2 = { version = "0.10.8", optional = true }
-shlex = "1.3.0"
+shlex = "2.0.1"
 strip-ansi-escapes = "0.2"
 tar = "0.4.40"
 tempfile = "3"


### PR DESCRIPTION
See https://github.com/comex/rust-shlex/blob/653936e120cdd0a8d1b4f0837e2cce0f347da4c0/CHANGELOG.md. There is only one file with calls into `shlex`, and it doesn’t use any of the APIs that were removed in v2:

https://github.com/mozilla/sccache/blob/c710468cef02b86c0ad24fddd0141cda65cd7e30/src/compiler/nvcc.rs#L113

https://github.com/mozilla/sccache/blob/c710468cef02b86c0ad24fddd0141cda65cd7e30/src/compiler/nvcc.rs#L127

https://github.com/mozilla/sccache/blob/c710468cef02b86c0ad24fddd0141cda65cd7e30/src/compiler/nvcc.rs#L1125

This has the pleasant side effect of deduplicating `shlex` in `Cargo.lock`, since `cc` already updated its dependency to v2.