### PR TITLE
tests/integration: replace MinIO with Silo

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -56,7 +56,7 @@ PROFILES_zstd := zstd
 # Map backends to their services
 SERVICES_autotools :=
 SERVICES_azblob := azurite azurite-setup
-SERVICES_basedirs := redis memcached minio minio-setup azurite azurite-setup webdav
+SERVICES_basedirs := redis memcached silo silo-setup azurite azurite-setup webdav
 SERVICES_clang :=
 SERVICES_cmake :=
 SERVICES_cmake-modules :=
@@ -65,11 +65,11 @@ SERVICES_coverage :=
 SERVICES_gcc :=
 SERVICES_memcached := memcached
 SERVICES_memcached-deprecated := memcached
-SERVICES_multilevel := redis memcached minio minio-setup azurite azurite-setup webdav
-SERVICES_multilevel-chain := redis memcached minio minio-setup
+SERVICES_multilevel := redis memcached silo silo-setup azurite azurite-setup webdav
+SERVICES_multilevel-chain := redis memcached silo silo-setup
 SERVICES_redis := redis
 SERVICES_redis-deprecated := redis
-SERVICES_s3 := minio minio-setup
+SERVICES_s3 := silo silo-setup
 SERVICES_webdav := webdav
 SERVICES_zstd :=
 
@@ -84,7 +84,7 @@ help:
 	@echo "  make test-redis-deprecated   Run Redis (deprecated) test"
 	@echo "  make test-memcached          Run Memcached (new endpoint) test"
 	@echo "  make test-memcached-deprecated Run Memcached (deprecated) test"
-	@echo "  make test-s3                 Run S3/MinIO test"
+	@echo "  make test-s3                 Run S3/Silo test"
 	@echo "  make test-azblob             Run Azure Blob Storage test"
 	@echo "  make test-webdav             Run WebDAV test"
 	@echo ""

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -49,12 +49,13 @@ services:
       - test
       - memcached
 
-  minio:
-    image: minio/minio:latest
+  silo:
+    image: pgsty/silo:latest
     ports:
       - "9000:9000"
       - "9001:9001"
     environment:
+      # Silo is a MinIO fork and still reads the MINIO_* configuration.
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
     command: server /data --console-address ":9001"
@@ -65,15 +66,15 @@ services:
       - test
       - s3
 
-  minio-setup:
-    image: minio/mc:latest
+  silo-setup:
+    image: pgsty/mc:latest
     depends_on:
-      minio:
+      silo:
         condition: service_healthy
     entrypoint: >
       /bin/sh -c "
-      mc alias set myminio http://minio:9000 minioadmin minioadmin;
-      mc mb myminio/test || true;
+      mc alias set silo http://silo:9000 minioadmin minioadmin;
+      mc mb silo/test || true;
       exit 0;
       "
     profiles:
@@ -187,14 +188,14 @@ services:
     image: rust:latest
     entrypoint: /sccache/tests/integration/scripts/test-backend.sh
     depends_on:
-      minio:
+      silo:
         condition: service_healthy
-      minio-setup:
+      silo-setup:
         condition: service_completed_successfully
     environment:
       <<: *common-env
       SCCACHE_BUCKET: test
-      SCCACHE_ENDPOINT: http://minio:9000/
+      SCCACHE_ENDPOINT: http://silo:9000/
       SCCACHE_REGION: us-east-1
       AWS_ACCESS_KEY_ID: minioadmin
       AWS_SECRET_ACCESS_KEY: minioadmin
@@ -342,9 +343,9 @@ services:
         condition: service_healthy
       memcached:
         condition: service_healthy
-      minio:
+      silo:
         condition: service_healthy
-      minio-setup:
+      silo-setup:
         condition: service_completed_successfully
       azurite:
         condition: service_healthy
@@ -365,9 +366,9 @@ services:
         condition: service_healthy
       memcached:
         condition: service_healthy
-      minio:
+      silo:
         condition: service_healthy
-      minio-setup:
+      silo-setup:
         condition: service_completed_successfully
       azurite:
         condition: service_healthy
@@ -388,9 +389,9 @@ services:
         condition: service_healthy
       memcached:
         condition: service_healthy
-      minio:
+      silo:
         condition: service_healthy
-      minio-setup:
+      silo-setup:
         condition: service_completed_successfully
     profiles:
       - test

--- a/tests/integration/scripts/test-basedirs.sh
+++ b/tests/integration/scripts/test-basedirs.sh
@@ -103,7 +103,7 @@ test_backend "redis" "SCCACHE_REDIS_ENDPOINT=tcp://redis:6379"
 test_backend "memcached" "SCCACHE_MEMCACHED_ENDPOINT=tcp://memcached:11211"
 test_backend "s3" \
     "SCCACHE_BUCKET=test" \
-    "SCCACHE_ENDPOINT=http://minio:9000/" \
+    "SCCACHE_ENDPOINT=http://silo:9000/" \
     "SCCACHE_REGION=us-east-1" \
     "AWS_ACCESS_KEY_ID=minioadmin" \
     "AWS_SECRET_ACCESS_KEY=minioadmin" \

--- a/tests/integration/scripts/test-multilevel-chain.sh
+++ b/tests/integration/scripts/test-multilevel-chain.sh
@@ -66,7 +66,7 @@ export SCCACHE_MEMCACHED_KEY_PREFIX="/chain-test-l2/"
 
 # L3: S3 configuration
 export SCCACHE_BUCKET="test"
-export SCCACHE_ENDPOINT="http://minio:9000"
+export SCCACHE_ENDPOINT="http://silo:9000"
 export SCCACHE_REGION="us-east-1"
 export SCCACHE_S3_USE_SSL="false"
 export SCCACHE_S3_KEY_PREFIX="chain-test-l3/"

--- a/tests/integration/scripts/test-multilevel.sh
+++ b/tests/integration/scripts/test-multilevel.sh
@@ -223,7 +223,7 @@ test_multilevel_backend "memcached" "SCCACHE_MEMCACHED_ENDPOINT=tcp://memcached:
 
 test_multilevel_backend "s3" \
     "SCCACHE_BUCKET=test" \
-    "SCCACHE_ENDPOINT=http://minio:9000/" \
+    "SCCACHE_ENDPOINT=http://silo:9000/" \
     "SCCACHE_REGION=us-east-1" \
     "AWS_ACCESS_KEY_ID=minioadmin" \
     "AWS_SECRET_ACCESS_KEY=minioadmin" \


### PR DESCRIPTION
The minio/minio and minio/mc images are no longer available. Switch the S3 test backend to Silo (pgsty/silo and pgsty/mc), a maintained MinIO fork, renaming the compose services and endpoint host accordingly.

Silo still reads the MINIO_* environment variables and serves the /minio/health/live endpoint, so the credentials and the healthcheck are left unchanged.